### PR TITLE
Implement missing stop_ringing method to fix build

### DIFF
--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -94,4 +94,8 @@ impl<R: Runtime> AlarmManager<R> {
       alarm_id: None,
     })
   }
+  pub fn stop_ringing(&self) -> crate::Result<()> {
+    println!("Desktop: Stop ringing request received");
+    Ok(())
+  }
 }


### PR DESCRIPTION
This PR fixes a compilation error on desktop builds where the `AlarmManager` trait implementation in `desktop.rs` was missing the `stop_ringing` method, which is required by the shared `commands.rs`.

## Changes
- **plugins/alarm-manager/src/desktop.rs**: Added a stub implementation of `stop_ringing`.
  - Currently logs the request and returns `Ok(())`.
  - This effectively treats `stop_ringing` as a no-op on desktop, which is appropriate as desktop alarm sound management is handled differently (typically frontend-side) compared to the native Android AlarmManager.

## Verification
- Verified that `pnpm dev:desktop` now compiles successfully without the previous `E0599` error.
- Verified that the application launches (noting an expected environment-specific panic unrelated to this change).