### PR TITLE
Establish development standards and agent guides

### DIFF
--- a/docs/guides/AI_AGENT_USAGE_GUIDE.md
+++ b/docs/guides/AI_AGENT_USAGE_GUIDE.md
@@ -1,0 +1,580 @@
+# Using Threshold Pattern Docs with AI Coding Agents
+
+**Purpose:** Guide for leveraging the Threshold plugin documentation with AI coding agents (Claude, GPT-4, Cursor, Copilot, etc.)
+
+---
+
+## Overview
+
+The Threshold plugin pattern documentation is specifically designed to work well with AI coding agents. The documents are:
+- ✅ Comprehensive and self-contained
+- ✅ Include code templates and examples
+- ✅ Provide verification steps
+- ✅ Written in clear, structured markdown
+- ✅ Cover common pitfalls and edge cases
+
+---
+
+## Recommended Storage Location
+
+Store the pattern documents in your repository where AI agents can reference them:
+
+```
+threshold/
+├── docs/
+│   ├── guides/
+│   │   └── AI_AGENT_USAGE_GUIDE.md
+│   ├── patterns/
+│   │   ├── THRESHOLD_PLUGIN_MANIFEST_PATTERN.md
+│   │   ├── PLUGIN_MANIFEST_QUICKSTART.md
+│   │   └── PLUGIN_MANIFEST_PR_CHECKLIST.md
+│   ├── ALARM_MANAGER.md
+│   ├── ANDROID_INTENTS.md
+│   ├── DESKTOP_DEEPLINKS.md
+│   └── UI_TASK.md
+└── plugins/
+    ├── alarm-manager/
+    └── predictive-back/
+```
+
+**Why this works:**
+- Agents can access local files via file paths
+- Documentation is version-controlled with code
+- Updates to patterns propagate to all future agent tasks
+- Team members can also read the docs
+
+---
+
+## Usage Patterns
+
+### Pattern 1: Create New Plugin with Android Support
+
+**Scenario:** You're creating a new plugin called `notification-manager`.
+
+**Agent Prompt:**
+```markdown
+I need to create a new Tauri plugin called `notification-manager` with Android support.
+
+Please follow the Threshold Android Manifest Injection Pattern documented in:
+- `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md` (for quick reference)
+- `/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md` (for comprehensive details)
+
+Requirements:
+1. Plugin needs these Android permissions:
+   - POST_NOTIFICATIONS
+   - VIBRATE
+   - WAKE_LOCK
+
+2. Implement manifest injection in build.rs following the pattern
+
+3. Plugin commands are:
+   - notify
+   - cancel
+   - list_active
+
+Please implement the complete plugin structure with proper manifest injection.
+```
+
+**What the Agent Will Do:**
+1. Read both pattern documents
+2. Extract templates and conventions
+3. Generate `build.rs` with correct injection
+4. Create proper `Cargo.toml` with build feature
+5. Set up library manifest correctly
+6. Follow naming conventions (block identifiers, etc.)
+
+---
+
+### Pattern 2: Update Existing Plugin
+
+**Scenario:** Migrating an existing plugin to the pattern.
+
+**Agent Prompt:**
+```markdown
+Please update the alarm-manager plugin to follow the Android Manifest Injection Pattern.
+
+Use the specific implementation prompt at:
+`/docs/prompts/LLM_AGENT_PROMPT_ALARM_MANAGER_UPDATE.md`
+
+This prompt contains:
+- Step-by-step instructions
+- Current state analysis
+- Expected changes
+- Verification procedures
+
+Follow all phases and provide verification results when complete.
+```
+
+**What the Agent Will Do:**
+1. Read the task-specific prompt
+2. Reference the main pattern docs as needed
+3. Analyze current implementation
+4. Make required changes
+5. Run verification steps
+6. Report results
+
+---
+
+### Pattern 3: Review Plugin PR
+
+**Scenario:** An AI agent reviews a PR that adds Android support.
+
+**Agent Prompt:**
+```markdown
+Please review this PR that adds Android manifest injection to the barcode-scanner plugin.
+
+Use the review checklist at:
+`/docs/patterns/PLUGIN_MANIFEST_PR_CHECKLIST.md`
+
+Files changed in this PR:
+- plugins/barcode-scanner/build.rs
+- plugins/barcode-scanner/Cargo.toml
+- plugins/barcode-scanner/android/src/main/AndroidManifest.xml
+
+Provide:
+1. Checklist completion results
+2. Any issues found
+3. Approval or requested changes
+```
+
+**What the Agent Will Do:**
+1. Read the PR checklist
+2. Examine each changed file
+3. Verify against checklist items
+4. Identify issues or approve
+5. Generate review comment
+
+---
+
+### Pattern 4: Troubleshoot Implementation
+
+**Scenario:** The pattern isn't working as expected.
+
+**Agent Prompt:**
+```markdown
+I'm implementing Android manifest injection in my plugin but getting this error:
+```
+[error message here]
+```
+
+Please help troubleshoot using:
+`/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`
+
+Specifically, check the troubleshooting section and compare my implementation to the examples.
+
+My current build.rs:
+```rust
+[paste your build.rs]
+```
+```
+
+**What the Agent Will Do:**
+1. Read troubleshooting section
+2. Compare your code to templates
+3. Identify the issue
+4. Provide corrected code
+5. Explain what was wrong
+
+---
+
+## Best Practices for Agent Prompts
+
+### 1. Always Reference Documentation Paths
+
+**❌ Bad:**
+```
+Implement Android manifest injection for my plugin.
+```
+
+**✅ Good:**
+```
+Implement Android manifest injection following the pattern in `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md`.
+```
+
+**Why:** Explicit paths ensure the agent reads your specific documentation, not its general knowledge.
+
+---
+
+### 2. Be Specific About Requirements
+
+**❌ Bad:**
+```
+Add permissions to my plugin.
+```
+
+**✅ Good:**
+```
+Add these Android permissions using the manifest injection pattern:
+- CAMERA
+- VIBRATE
+
+Follow the template in section 4 of PLUGIN_MANIFEST_QUICKSTART.md.
+```
+
+**Why:** Specific requirements + doc reference = better results.
+
+---
+
+### 3. Request Verification
+
+**❌ Bad:**
+```
+Update the plugin to use manifest injection.
+```
+
+**✅ Good:**
+```
+Update the plugin to use manifest injection and verify using the steps in Phase 5 of the implementation guide.
+
+Provide:
+1. Build output
+2. Generated manifest snippet
+3. Confirmation that runtime behaviour works
+```
+
+**Why:** Verification ensures the agent tests its work.
+
+---
+
+### 4. Reference Specific Sections
+
+**❌ Bad:**
+```
+Fix my build.rs using the pattern doc.
+```
+
+**✅ Good:**
+```
+Fix my build.rs by comparing it to the "Template Code" section in THRESHOLD_PLUGIN_MANIFEST_PATTERN.md (line ~450).
+
+Focus on:
+- COMMANDS array definition
+- Injection function signature
+- Block identifier format
+```
+
+**Why:** Specific sections guide the agent to the most relevant information.
+
+---
+
+## Multi-Document Reference Strategy
+
+For complex tasks, give agents a reading order:
+
+```markdown
+Please implement Android manifest injection for the location-tracker plugin.
+
+Read documents in this order:
+1. `/docs/patterns/DOCUMENTATION_OVERVIEW.md` - understand the doc structure
+2. `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md` - get quick template
+3. `/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md` section 7 - review "Feature-Gated Permissions" pattern (location is sensitive)
+
+Requirements:
+- Base permissions: ACCESS_FINE_LOCATION
+- Feature-gated: ACCESS_BACKGROUND_LOCATION (opt-in only)
+
+Follow the feature-gated pattern from section 7.
+```
+
+---
+
+## Verification Integration
+
+Always include verification in your prompts:
+
+```markdown
+After implementing manifest injection:
+
+1. Run verification commands from the implementation prompt
+2. Provide output of:
+   ```bash
+   cat apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml | grep -A 20 "tauri-plugin-your-plugin"
+   ```
+3. Confirm no build errors
+4. Confirm runtime behaviour is correct
+
+Do not consider the task complete until all verification passes.
+```
+
+---
+
+## Agent-Specific Tips
+
+### Claude (Anthropic)
+- ✅ Excels at reading long documents
+- ✅ Good at following structured checklists
+- ✅ Can process multiple doc references simultaneously
+- **Tip:** Give it the full pattern doc, it will handle it well
+
+### GPT-4 (OpenAI)
+- ✅ Good with templates and examples
+- ⚠️ May need more explicit step-by-step instructions
+- **Tip:** Reference specific code examples rather than sections
+
+### Cursor / Copilot
+- ✅ Best with inline code suggestions
+- ⚠️ May not read full documents automatically
+- **Tip:** Paste relevant template sections into the prompt
+
+### Open-Source Models
+- ⚠️ May struggle with very long documents
+- **Tip:** Use QUICKSTART.md instead of full pattern doc
+- **Tip:** Provide explicit code templates
+
+---
+
+## Template Prompts for Common Tasks
+
+### Create Plugin from Scratch
+```markdown
+Create a new Tauri plugin called `{plugin-name}` with Android support.
+
+Follow: `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md`
+
+Android permissions needed:
+- {PERMISSION_1}
+- {PERMISSION_2}
+
+Tauri commands:
+- {command_1}
+- {command_2}
+
+Include:
+1. Proper manifest injection in build.rs
+2. Correct Cargo.toml with build feature
+3. Library manifest with components only
+
+Verify using steps from the quickstart doc.
+```
+
+---
+
+### Add Android Support to Existing Plugin
+```markdown
+Add Android support to the existing `{plugin-name}` plugin.
+
+Current state:
+- Has desktop implementation
+- No Android code yet
+- Commands: {list commands}
+
+Required Android permissions:
+- {PERMISSION_1}
+- {PERMISSION_2}
+
+Follow the pattern in `/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md` sections 4-6.
+
+Create:
+1. build.rs with manifest injection
+2. android/ directory with proper structure
+3. Native Kotlin/Java code (basic structure)
+
+Provide verification that manifest injection works.
+```
+
+---
+
+### Migrate Library Manifest to Injection
+```markdown
+Migrate `{plugin-name}` from library manifest approach to build-time injection.
+
+Current manifest is at: `plugins/{plugin-name}/android/src/main/AndroidManifest.xml`
+
+Steps:
+1. Extract all `<uses-permission>` from library manifest
+2. Implement injection in build.rs following `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md`
+3. Remove permissions from library manifest (keep components)
+4. Verify with multiple builds (test idempotency)
+
+Ensure no duplicate permissions in final generated manifest.
+```
+
+---
+
+## Integration with CI/CD
+
+You can use AI agents in automated workflows:
+
+```yaml
+# .github/workflows/plugin-validation.yml
+name: Validate Plugin Pattern
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/*/build.rs'
+      - 'plugins/*/Cargo.toml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      # Use AI agent to validate
+      - name: AI Pattern Validation
+        run: |
+          ai-agent run --prompt "
+          Review the changed plugin files against the checklist in:
+          /docs/patterns/PLUGIN_MANIFEST_PR_CHECKLIST.md
+          
+          Report any violations of the pattern.
+          " --files plugins/**
+```
+
+---
+
+## Maintaining Documentation for AI Agents
+
+### Keep Docs Up-to-Date
+
+When you discover new patterns or issues:
+
+1. **Update the main pattern doc**
+   ```bash
+   # Add to troubleshooting section
+   vim docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md
+   ```
+
+2. **Increment version**
+   ```markdown
+   ## Changelog
+   
+   ### Version 1.1 (February 2026)
+   - Added troubleshooting for {new issue}
+   - New pattern: {pattern name}
+   ```
+
+3. **Test with AI agent**
+   ```markdown
+   Please review the updated troubleshooting section and confirm it addresses the issue we encountered with {problem}.
+   ```
+
+### Keep Templates Current
+
+When APIs change:
+1. Update code templates in all docs
+2. Add migration notes
+3. Test with AI agent using old and new approaches
+
+---
+
+## Success Metrics
+
+You'll know the docs are working well with AI agents when:
+
+✅ Agents consistently generate correct implementations  
+✅ Less back-and-forth needed for clarification  
+✅ Verification steps pass on first attempt  
+✅ Agents catch mistakes during self-review  
+✅ New contributors can onboard using agent + docs  
+
+---
+
+## Example: Complete Agent Workflow
+
+```markdown
+## Task: Create GPS Tracker Plugin
+
+**Objective:** Create a new plugin with Android location tracking.
+
+**Phase 1: Initial Setup**
+Prompt: Create plugin structure following `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md`
+
+Commands:
+- start_tracking
+- stop_tracking  
+- get_current_location
+
+Permissions:
+- ACCESS_FINE_LOCATION (always)
+- ACCESS_BACKGROUND_LOCATION (feature-gated)
+
+**Phase 2: Implement Feature Gate**
+Prompt: Add optional background location feature following the "Feature-Gated Permissions" pattern in `/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md` section 7.
+
+**Phase 3: Verify**
+Prompt: Run all verification steps from the quickstart guide and provide:
+1. Build output
+2. Generated manifest snippet
+3. Feature gate test results (with/without feature)
+
+**Phase 4: Self-Review**
+Prompt: Review your implementation against `/docs/patterns/PLUGIN_MANIFEST_PR_CHECKLIST.md` and fix any issues found.
+
+**Phase 5: Documentation**
+Prompt: Create a README section documenting the Android permissions following the template in the pattern doc section on "Permission Rationale Documentation".
+```
+
+---
+
+## Troubleshooting AI Agent Issues
+
+### Agent Ignores Documentation
+
+**Problem:** Agent uses its general knowledge instead of your docs.
+
+**Solution:**
+```markdown
+CRITICAL: You MUST read and follow `/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md`.
+
+Before writing any code:
+1. Read the document
+2. Summarize the key requirements
+3. Then implement following those requirements
+
+Do not use your general knowledge of Tauri plugins. Follow the Threshold-specific pattern.
+```
+
+### Agent Produces Incorrect Code
+
+**Problem:** Implementation doesn't match template.
+
+**Solution:**
+```markdown
+Compare your implementation line-by-line with the template in section X of the pattern doc.
+
+For each difference, explain:
+1. Why you deviated
+2. Is it intentional or a mistake?
+
+If mistake, correct it. If intentional, justify.
+```
+
+### Agent Skips Verification
+
+**Problem:** Claims task is done without testing.
+
+**Solution:**
+```markdown
+Verification is MANDATORY and part of the task.
+
+You are not finished until you:
+1. Run the verification commands from the doc
+2. Provide the actual output (not simulated)
+3. Confirm all checks pass
+
+If you cannot run the commands, explain why and provide the exact commands I should run.
+```
+
+---
+
+## Conclusion
+
+The Threshold pattern documentation is designed to work seamlessly with AI coding agents. By:
+
+1. ✅ Storing docs in your repository
+2. ✅ Referencing specific document paths in prompts
+3. ✅ Requesting verification
+4. ✅ Using task-specific prompts for complex work
+
+You can leverage AI agents to consistently implement the pattern across all plugins while maintaining high quality and standards compliance.
+
+**The docs do the teaching, agents do the implementation, humans do the review.**
+
+---
+
+**Questions or Issues?**
+- Update the docs with new patterns as you discover them
+- Share successful agent prompts with the team
+- Report documentation gaps or unclear sections

--- a/docs/patterns/PLUGIN_MANIFEST_PR_CHECKLIST.md
+++ b/docs/patterns/PLUGIN_MANIFEST_PR_CHECKLIST.md
@@ -1,0 +1,456 @@
+# Plugin Manifest Injection - PR Review Checklist
+
+**Purpose:** Ensure plugin PRs correctly implement the Android manifest injection pattern  
+**For:** Threshold maintainers reviewing plugin contributions
+
+---
+
+## Quick Verification (2 minutes)
+
+Run this script to verify basic implementation:
+
+```bash
+#!/bin/bash
+# verify-manifest-injection.sh
+
+PLUGIN_NAME=$1
+PLUGIN_PATH="plugins/${PLUGIN_NAME}"
+
+echo "🔍 Checking ${PLUGIN_NAME}..."
+
+# Check 1: build feature enabled
+if ! grep -q 'features = \["build"\]' "${PLUGIN_PATH}/Cargo.toml"; then
+    echo "❌ Missing build feature in Cargo.toml"
+    exit 1
+fi
+
+# Check 2: build.rs exists
+if [ ! -f "${PLUGIN_PATH}/build.rs" ]; then
+    echo "❌ Missing build.rs"
+    exit 1
+fi
+
+# Check 3: injection call present
+if ! grep -q "update_android_manifest" "${PLUGIN_PATH}/build.rs"; then
+    echo "❌ No manifest injection in build.rs"
+    exit 1
+fi
+
+# Check 4: uses correct block identifier format
+if ! grep -q "tauri-plugin-${PLUGIN_NAME}" "${PLUGIN_PATH}/build.rs"; then
+    echo "⚠️  Block identifier might not follow convention"
+fi
+
+echo "✅ Basic checks passed"
+```
+
+Usage:
+```bash
+chmod +x verify-manifest-injection.sh
+./verify-manifest-injection.sh alarm-manager
+```
+
+---
+
+## Detailed Review Checklist
+
+### 1. Cargo.toml Configuration
+
+- [ ] `[build-dependencies]` section exists
+- [ ] `tauri-plugin` is listed with version `2.0.0` or higher
+- [ ] `features = ["build"]` is specified
+- [ ] If using feature gates, features are defined in `[features]` section
+
+**Example:**
+```toml
+[build-dependencies]
+tauri-plugin = { version = "2.0.0", features = ["build"] }
+
+[features]
+default = []
+some-optional-feature = []
+```
+
+---
+
+### 2. build.rs Implementation
+
+#### Basic Structure
+- [ ] `COMMANDS` constant defined with actual command names
+- [ ] `main()` function calls `tauri_plugin::Builder::new(COMMANDS).build()`
+- [ ] Injection function is called from `main()`
+- [ ] Error handling uses `.expect()` with descriptive message
+
+#### Injection Function
+- [ ] Function returns `std::io::Result<()>`
+- [ ] Uses `tauri_plugin::mobile::update_android_manifest(...)`
+- [ ] Block identifier follows convention: `tauri-plugin-{plugin-name}.{category}`
+- [ ] Parent tag is correct (`manifest` for permissions)
+- [ ] Permissions use raw string literals (`r#"..."#`)
+- [ ] No escaped quotes in raw strings (❌ `\"` inside `r#"..."#`)
+
+**Red Flags:**
+```rust
+// ❌ Wrong - no error handling
+tauri_plugin::mobile::update_android_manifest(...);
+
+// ❌ Wrong - escaped quotes in raw string
+r#"<uses-permission android:name=\"android.permission.CAMERA\" />"#
+
+// ❌ Wrong - uses "android" instead of commands
+tauri_plugin::Builder::new(&["android"]).build();
+
+// ❌ Wrong - generic block identifier
+"MY PLUGIN"  // Should be "tauri-plugin-my-plugin.permissions"
+
+// ❌ Wrong - unstable block identifier
+format!("plugin-{}", timestamp)  // Must be stable!
+```
+
+**Good Examples:**
+```rust
+// ✅ Correct
+const COMMANDS: &[&str] = &["scan", "cancel"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+    inject_android_permissions()
+        .expect("Failed to inject barcode-scanner permissions");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions = vec![
+        r#"<uses-permission android:name="android.permission.CAMERA" />"#,
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-barcode-scanner.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+---
+
+### 3. Library Manifest (android/src/main/AndroidManifest.xml)
+
+- [ ] File exists at `plugins/{name}/android/src/main/AndroidManifest.xml`
+- [ ] Permissions being injected are **removed** from this file
+- [ ] Components (services, receivers, activities) are **kept** in this file
+- [ ] No duplicate permission declarations
+
+**Before (❌ Wrong - has both):**
+```xml
+<manifest>
+    <!-- ❌ This will be injected via build.rs, should remove -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    
+    <application>
+        <!-- ✅ Keep this -->
+        <service android:name=".MyService" />
+    </application>
+</manifest>
+```
+
+**After (✅ Correct):**
+```xml
+<manifest>
+    <!-- Permissions are now injected via build.rs -->
+    
+    <application>
+        <!-- Components stay here -->
+        <service android:name=".MyService" />
+    </application>
+</manifest>
+```
+
+---
+
+### 4. Documentation
+
+- [ ] Plugin README lists all required permissions
+- [ ] Each permission has a "why needed" explanation
+- [ ] Privacy implications documented for sensitive permissions
+- [ ] Feature gates documented (if any)
+- [ ] Installation instructions are correct
+
+**Example README section:**
+```markdown
+## Android Permissions
+
+This plugin requires the following permissions:
+
+### `CAMERA` (Required)
+- **Purpose:** Scan barcodes using device camera
+- **When:** Only during active scanning
+- **Privacy:** Processed locally, not transmitted
+
+### Optional Features
+
+Enable camera access:
+```toml
+tauri-plugin-barcode = { version = "1.0", features = ["camera"] }
+```
+```
+
+---
+
+### 5. Testing Evidence
+
+Request the author provide:
+
+- [ ] Screenshot/paste of generated manifest showing comment markers
+- [ ] Confirmation that app builds without errors
+- [ ] Verification that runtime behaviour works (no SecurityException)
+- [ ] Test on physical device or emulator
+
+**What to ask for:**
+```
+Please provide:
+1. Output of: cat apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+2. Confirmation that `pnpm tauri android build` succeeds
+3. Screenshot of app working on device/emulator
+```
+
+---
+
+### 6. Common Mistakes to Catch
+
+#### Mistake 1: Duplicate Permissions
+```xml
+<!-- Generated manifest - ❌ BAD -->
+<uses-permission android:name="android.permission.CAMERA" />  <!-- From library manifest -->
+<!-- tauri-plugin-scanner.permissions -->
+<uses-permission android:name="android.permission.CAMERA" />  <!-- From injection -->
+<!-- tauri-plugin-scanner.permissions -->
+```
+
+**Fix:** Remove from library manifest.
+
+#### Mistake 2: Wrong Block Identifier
+```rust
+// ❌ Wrong - too generic
+tauri_plugin::mobile::update_android_manifest(
+    "PERMISSIONS",  // Not unique!
+    "manifest",
+    permissions.join("\n"),
+)
+
+// ✅ Correct - follows convention
+tauri_plugin::mobile::update_android_manifest(
+    "tauri-plugin-barcode-scanner.permissions",
+    "manifest",
+    permissions.join("\n"),
+)
+```
+
+#### Mistake 3: Injecting Components Unnecessarily
+```rust
+// ❌ Don't do this unless you have a good reason
+let components = vec![
+    r#"<service android:name=".MyService" />"#,
+];
+tauri_plugin::mobile::update_android_manifest(
+    "tauri-plugin-my-plugin.application",
+    "application",
+    components.join("\n"),
+)?;
+```
+
+**Guideline:** Only inject components if they're conditionally required. Otherwise use library manifest.
+
+#### Mistake 4: Feature Gate Syntax Error
+```rust
+// ❌ Wrong - uses underscore
+#[cfg(feature = "camera_access")]
+
+// ✅ Correct - uses hyphen (matches Cargo.toml)
+#[cfg(feature = "camera-access")]
+```
+
+#### Mistake 5: Hardcoded Commands
+```rust
+// ❌ Wrong - outdated command list
+const COMMANDS: &[&str] = &["old_command"];
+
+// Make sure to update when adding new commands!
+```
+
+**Check:** Verify COMMANDS list matches actual `#[tauri::command]` functions in the plugin.
+
+---
+
+## Build Verification
+
+### Manual Test Procedure
+
+1. **Checkout the PR branch**
+   ```bash
+   gh pr checkout <pr-number>
+   ```
+
+2. **Clean build**
+   ```bash
+   cd apps/threshold
+   rm -rf src-tauri/gen
+   pnpm tauri android build
+   ```
+
+3. **Inspect generated manifest**
+   ```bash
+   cat src-tauri/gen/android/app/src/main/AndroidManifest.xml | grep -A 20 "tauri-plugin"
+   ```
+
+4. **Verify idempotency**
+   ```bash
+   pnpm tauri android build  # Build again
+   # Check manifest - should be identical, no duplicates
+   ```
+
+5. **Test on device**
+   ```bash
+   pnpm tauri android dev
+   # Verify plugin functionality works
+   ```
+
+---
+
+## Approval Criteria
+
+✅ **Approve if:**
+- All checklist items pass
+- Build succeeds
+- Generated manifest has correct injection markers
+- No duplicate permissions
+- Documentation is clear
+- Feature gates work (if applicable)
+- Runtime behaviour is correct
+
+❌ **Request changes if:**
+- Build feature not enabled
+- Block identifier doesn't follow convention
+- Permissions duplicated in library manifest
+- Missing documentation
+- Test evidence not provided
+- Syntax errors in injection code
+
+⚠️ **Request discussion if:**
+- Plugin injects components (discuss if necessary)
+- Uses configuration-driven injection (verify implementation)
+- Has many feature gates (verify they're all useful)
+- Permissions seem excessive (ask for justification)
+
+---
+
+## Response Templates
+
+### Approval Comment
+```markdown
+✅ Manifest injection implementation looks good!
+
+Verified:
+- Build feature enabled
+- Injection code follows pattern
+- Generated manifest correct
+- Documentation complete
+
+Merging!
+```
+
+### Request Changes Comment
+```markdown
+Thanks for the PR! The manifest injection implementation needs a few adjustments:
+
+**Issues:**
+- [ ] Missing `features = ["build"]` in `Cargo.toml`
+- [ ] Block identifier should be `tauri-plugin-{name}.permissions` not `{name}`
+- [ ] Remove injected permissions from library manifest
+
+**Example:**
+```rust
+// In build.rs
+tauri_plugin::mobile::update_android_manifest(
+    "tauri-plugin-your-plugin.permissions",  // ⚠️ Update this
+    "manifest",
+    permissions.join("\n"),
+)
+```
+
+See `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md` for complete guide.
+```
+
+### Architecture Discussion Comment
+```markdown
+I see you're injecting components via `build.rs`. Can you explain why this is needed versus keeping them in the library manifest?
+
+Generally we prefer library manifest for components and only inject permissions. The exception is if components need to be conditionally included based on features.
+
+If this is just for convenience, please move components back to the library manifest.
+```
+
+---
+
+## Automated Checks (Future)
+
+Consider adding these as CI checks:
+
+```yaml
+# .github/workflows/plugin-manifest-check.yml
+name: Plugin Manifest Check
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/*/build.rs'
+      - 'plugins/*/Cargo.toml'
+
+jobs:
+  verify-injection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Check build feature
+        run: |
+          for plugin in plugins/*/Cargo.toml; do
+            if ! grep -q 'features = \["build"\]' "$plugin"; then
+              echo "::error file=$plugin::Missing build feature"
+              exit 1
+            fi
+          done
+      
+      - name: Check block identifiers
+        run: |
+          for build_rs in plugins/*/build.rs; do
+            plugin_name=$(dirname "$build_rs" | xargs basename)
+            if ! grep -q "tauri-plugin-${plugin_name}" "$build_rs"; then
+              echo "::warning file=$build_rs::Block identifier might not follow convention"
+            fi
+          done
+      
+      - name: Check for escaped quotes in raw strings
+        run: |
+          if grep -r 'r#".*\\".*"#' plugins/*/build.rs; then
+            echo "::error::Found escaped quotes in raw string literals"
+            exit 1
+          fi
+```
+
+---
+
+## Contact
+
+**Questions about reviewing manifest injection PRs?**
+- Refer to `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`
+- Check alarm-manager implementation as reference
+- Ask in Threshold maintainer discussions
+
+**Found an issue with this checklist?**
+- Submit a PR to update this document
+- Help improve the review process
+
+---
+
+**Last Updated:** January 2026  
+**Document Version:** 1.0

--- a/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md
+++ b/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md
@@ -1,0 +1,173 @@
+# Quick Start: Android Manifest Injection
+
+**For:** Plugin authors adding Android support  
+**Time:** 15 minutes  
+**Difficulty:** Easy
+
+---
+
+## TL;DR
+
+Make your plugin automatically handle its Android permissions. Users won't need to edit manifests manually.
+
+---
+
+## Step-by-Step
+
+### 1. Add Build Dependency
+
+```toml
+# plugins/your-plugin/Cargo.toml
+
+[build-dependencies]
+tauri-plugin = { version = "2.0.0", features = ["build"] }
+#                                              ^^^^^^^ Must include
+```
+
+### 2. Create build.rs
+
+```rust
+// plugins/your-plugin/build.rs
+
+const COMMANDS: &[&str] = &[
+    "your_command_1",
+    "your_command_2",
+    // List all your Tauri commands
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+
+    inject_android_permissions()
+        .expect("Failed to inject Android permissions");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions = vec![
+        // Add your required permissions
+        r#"<uses-permission android:name="android.permission.YOUR_PERMISSION" />"#,
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-YOUR-PLUGIN-NAME.permissions",  // ⚠️ Change this
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+### 3. Update Library Manifest
+
+```xml
+<!-- plugins/your-plugin/android/src/main/AndroidManifest.xml -->
+
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Remove <uses-permission> tags you're now injecting -->
+    
+    <application>
+        <!-- Keep services, receivers, activities here -->
+    </application>
+</manifest>
+```
+
+### 4. Test It
+
+```bash
+cd apps/threshold
+pnpm tauri android build
+
+# Check generated manifest
+cat src-tauri/gen/android/app/src/main/AndroidManifest.xml
+```
+
+Look for:
+```xml
+<!-- tauri-plugin-YOUR-PLUGIN-NAME.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+<uses-permission android:name="..." />
+<!-- tauri-plugin-YOUR-PLUGIN-NAME.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+```
+
+✅ **You're done!** Your plugin now manages its own permissions.
+
+---
+
+## Common Permissions
+
+```rust
+// Camera
+r#"<uses-permission android:name="android.permission.CAMERA" />"#
+
+// Location
+r#"<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />"#
+
+// Notifications (Android 13+)
+r#"<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />"#
+
+// Vibration
+r#"<uses-permission android:name="android.permission.VIBRATE" />"#
+
+// Internet
+r#"<uses-permission android:name="android.permission.INTERNET" />"#
+
+// Wake Lock
+r#"<uses-permission android:name="android.permission.WAKE_LOCK" />"#
+```
+
+---
+
+## Optional: Feature Gates
+
+Make sensitive permissions opt-in:
+
+```toml
+# Cargo.toml
+[features]
+default = []
+camera-access = []  # Opt-in feature
+```
+
+```rust
+// build.rs
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![];
+
+    // Always included
+    permissions.push(r#"<uses-permission android:name="android.permission.VIBRATE" />"#);
+
+    // Only if feature enabled
+    #[cfg(feature = "camera-access")]
+    permissions.push(r#"<uses-permission android:name="android.permission.CAMERA" />"#);
+
+    // ... rest of function
+}
+```
+
+Users enable with:
+```toml
+tauri-plugin-your-plugin = { version = "1.0", features = ["camera-access"] }
+```
+
+---
+
+## Reference Example
+
+See the full implementation in `plugins/alarm-manager/build.rs`.
+
+For complete documentation, read `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`.
+
+---
+
+## Need Help?
+
+**Problem:** Permissions not appearing  
+**Fix:** Ensure you run `pnpm tauri android build`, not `cargo build`
+
+**Problem:** Build fails  
+**Fix:** Check XML syntax, verify block identifier is unique
+
+**Problem:** Runtime SecurityException  
+**Fix:** Some permissions need runtime requests (add permission request code)
+
+**Full troubleshooting:** See main pattern document.

--- a/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md
+++ b/docs/patterns/THRESHOLD_PLUGIN_MANIFEST_PATTERN.md
@@ -1,0 +1,1045 @@
+# Threshold Plugin Android Manifest Injection Pattern
+
+**Version:** 1.0  
+**Date:** January 2026  
+**Status:** Approved Standard  
+**Audience:** Threshold Plugin Authors
+
+---
+
+## Executive Summary
+
+This document defines the **standard pattern** for Android manifest management in Threshold plugins. Following this pattern ensures users never need to manually edit Android manifests—your plugin handles all its own requirements automatically.
+
+**Pattern Status:** ✅ Validated against Tauri official plugins  
+**Complexity:** Low (15 minutes to implement)  
+**Benefit:** Eliminates manual permission configuration for all Threshold users
+
+---
+
+## Table of Contents
+
+1. [Why This Pattern Matters](#why-this-pattern-matters)
+2. [How Tauri's Manifest Injection Works](#how-tauris-manifest-injection-works)
+3. [Threshold Plugin Conventions](#threshold-plugin-conventions)
+4. [Implementation Guide](#implementation-guide)
+5. [Template Code](#template-code)
+6. [Testing Procedures](#testing-procedures)
+7. [Common Patterns](#common-patterns)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## Why This Pattern Matters
+
+### The Problem
+
+Without this pattern:
+```rust
+// ❌ User must manually edit their AndroidManifest.xml
+// ❌ Easy to forget permissions
+// ❌ Hard to feature-gate sensitive permissions
+// ❌ Plugin updates might need manifest changes
+```
+
+### The Solution
+
+With this pattern:
+```rust
+// ✅ Permissions injected automatically at build time
+// ✅ Plugin owns its requirements
+// ✅ Feature flags control sensitive permissions
+// ✅ Plugin updates "just work"
+```
+
+### Real-World Impact
+
+**Before:** User installs your alarm-manager plugin, builds, and gets cryptic "SecurityException: Permission denied" errors at runtime. They search docs, find they need 10+ permissions, manually add them.
+
+**After:** User installs your plugin, builds, everything works. The build system handles permissions automatically.
+
+---
+
+## How Tauri's Manifest Injection Works
+
+Tauri v2 provides a build-time helper that modifies the **generated** Android project:
+
+```rust
+tauri_plugin::mobile::update_android_manifest(
+    block_identifier: &str,  // Unique ID for your injection block
+    parent_tag: &str,        // Where to inject (manifest/application/activity)
+    content: String,         // XML to inject
+) -> std::io::Result<()>
+```
+
+### The Magic
+
+1. During `tauri android build` or `tauri android dev`, Tauri sets `TAURI_ANDROID_PROJECT_PATH`
+2. Your plugin's `build.rs` calls `update_android_manifest()`
+3. The helper reads `${TAURI_ANDROID_PROJECT_PATH}/app/src/main/AndroidManifest.xml`
+4. It inserts (or replaces) your XML block **right before** `</{parent_tag}>`
+5. It wraps your block in comment markers for idempotency:
+   ```xml
+   <!-- block_identifier. AUTO-GENERATED. DO NOT REMOVE. -->
+   <your-xml-here />
+   <!-- block_identifier. AUTO-GENERATED. DO NOT REMOVE. -->
+   ```
+
+### Idempotency
+
+Running the build multiple times won't duplicate your block—it will replace the existing one. This is safe and correct.
+
+### Validation
+
+This pattern is used by official Tauri plugins:
+- ✅ `tauri-plugin-deep-link` (injects intent-filters)
+- ✅ `tauri-plugin-nfc` (injects NFC intent-filters)
+- ✅ Validated against `tauri-apps/plugins-workspace@v2` branch
+
+---
+
+## Threshold Plugin Conventions
+
+To maintain consistency across all Threshold plugins, we follow these naming conventions:
+
+### Block Identifiers
+
+Format: `tauri-plugin-{plugin-name}.{category}`
+
+Examples:
+- `tauri-plugin-alarm-manager.permissions`
+- `tauri-plugin-alarm-manager.application`
+- `tauri-plugin-notification-manager.permissions`
+
+**Rule:** Use your plugin's crate name (without `tauri-plugin-` prefix) + category.
+
+### Parent Tags
+
+| Parent Tag | Use For | Example |
+|------------|---------|---------|
+| `manifest` | `<uses-permission>`, `<uses-feature>`, `<queries>` | Permission declarations |
+| `application` | `<service>`, `<receiver>`, `<provider>`, `<activity>` (secondary) | App components |
+| `activity` | `<intent-filter>`, `<meta-data>` | Main activity configuration |
+
+**Rule:** Don't inject components unless you have a specific reason. Use the library manifest for components.
+
+### What Goes Where
+
+| Item | Location | Reason |
+|------|----------|--------|
+| Permissions | Inject via `build.rs` | Allows feature-gating, explicit documentation |
+| Services | Library manifest | Gradle merger handles them correctly |
+| Receivers | Library manifest | Gradle merger handles them correctly |
+| Activities | Library manifest | Gradle merger handles them correctly |
+| Intent filters (main activity) | Inject via `build.rs` | Only if configuration-driven |
+
+**Recommended Split for Most Plugins:**
+- ✅ **Inject:** Permissions
+- ✅ **Library manifest:** Everything else
+
+---
+
+## Implementation Guide
+
+### Step 1: Verify Prerequisites
+
+Check your `Cargo.toml`:
+
+```toml
+[build-dependencies]
+tauri-plugin = { version = "2.0.0", features = ["build"] }
+#                                              ^^^^^^^ Required!
+```
+
+If the `build` feature is missing, add it.
+
+### Step 2: Identify Your Android Requirements
+
+List all permissions your plugin needs. Common sources:
+- Android documentation for APIs you use
+- Your native Kotlin/Java code's imports
+- Runtime permission requests in your code
+
+Example for alarm-manager:
+```
+✅ SCHEDULE_EXACT_ALARM - setAlarmClock() API
+✅ WAKE_LOCK - Keep device awake
+✅ RECEIVE_BOOT_COMPLETED - Reschedule after reboot
+✅ USE_FULL_SCREEN_INTENT - Lock screen notification
+✅ FOREGROUND_SERVICE - Background alarm audio
+✅ FOREGROUND_SERVICE_MEDIA_PLAYBACK - Specific service type
+✅ VIBRATE - Haptic feedback
+✅ POST_NOTIFICATIONS - Show notifications (Android 13+)
+```
+
+### Step 3: Determine What to Feature-Gate
+
+Some permissions are "policy-sensitive" and users might not want them enabled by default:
+
+**Candidates for feature-gating:**
+- `USE_FULL_SCREEN_INTENT` - Aggressive lockscreen takeover
+- `POST_NOTIFICATIONS` - Can be annoying if overused
+- `CAMERA`, `MICROPHONE` - Privacy-sensitive
+- `READ_CONTACTS`, `READ_SMS` - Privacy-sensitive
+
+**Example feature definition:**
+```toml
+# Cargo.toml
+[features]
+default = ["basic-alarms"]
+basic-alarms = []
+full-screen-intents = []  # Opt-in for lockscreen takeover
+```
+
+### Step 4: Implement the Injection
+
+Create or update your `build.rs`:
+
+```rust
+// plugins/{your-plugin}/build.rs
+
+// TODO: Replace with your actual Tauri command names
+const COMMANDS: &[&str] = &[
+    "your_command_1",
+    "your_command_2",
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .build();
+
+    inject_android_permissions()
+        .expect("Failed to inject Android manifest permissions");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![
+        // Always-required permissions
+        r#"<uses-permission android:name="android.permission.YOUR_PERMISSION" />"#,
+    ];
+
+    // Feature-gated permissions
+    #[cfg(feature = "full-screen-intents")]
+    permissions.push(r#"<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />"#);
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-YOUR-PLUGIN.permissions",  // ⚠️ Replace YOUR-PLUGIN
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+**Key Points:**
+- ⚠️ Replace `YOUR-PLUGIN` with your plugin name
+- ⚠️ Replace `COMMANDS` with your actual command list
+- ✅ Use raw string literals: `r#"..."#` (no need to escape quotes)
+- ✅ Use `#[cfg(feature = "...")]` for conditional permissions
+
+### Step 5: Update Your Library Manifest
+
+Edit `android/src/main/AndroidManifest.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Permissions are now injected via build.rs - remove them from here -->
+    
+    <application>
+        <!-- Keep your components here - they merge correctly -->
+        <service 
+            android:name=".YourService"
+            android:exported="false" />
+
+        <receiver 
+            android:name=".YourReceiver" 
+            android:exported="false">
+            <intent-filter>
+                <action android:name="your.custom.ACTION" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>
+```
+
+**What to Remove:** Any `<uses-permission>` declarations you're now injecting.  
+**What to Keep:** All `<service>`, `<receiver>`, `<activity>`, `<provider>` declarations.
+
+### Step 6: Document the Permissions
+
+Add a comment block in your `build.rs` explaining **why** each permission is needed:
+
+```rust
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![
+        // Core alarm scheduling - required for exact alarm triggers
+        r#"<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />"#,
+        
+        // Keep device awake during alarm processing
+        r#"<uses-permission android:name="android.permission.WAKE_LOCK" />"#,
+        
+        // Restore alarms after device reboot
+        r#"<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />"#,
+    ];
+
+    // ... rest of function
+}
+```
+
+This helps future maintainers understand the permission requirements.
+
+---
+
+## Template Code
+
+### Complete build.rs Template
+
+```rust
+// plugins/tauri-plugin-YOUR-PLUGIN/build.rs
+
+const COMMANDS: &[&str] = &[
+    "command_1",
+    "command_2",
+    // Add all your Tauri command names here
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .build();
+
+    inject_android_permissions()
+        .expect("Failed to inject Android manifest permissions for YOUR-PLUGIN");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![
+        // ========================================
+        // Core permissions - always included
+        // ========================================
+        
+        // Example: r#"<uses-permission android:name="android.permission.INTERNET" />"#,
+    ];
+
+    // ========================================
+    // Feature-gated permissions
+    // ========================================
+    
+    #[cfg(feature = "your-feature-name")]
+    permissions.extend_from_slice(&[
+        // r#"<uses-permission android:name="android.permission.SENSITIVE_PERMISSION" />"#,
+    ]);
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-YOUR-PLUGIN.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+### Alarm Manager Reference Implementation
+
+For a complete working example, see `plugins/alarm-manager/build.rs`:
+
+```rust
+const COMMANDS: &[&str] = &[
+    "schedule_alarm",
+    "cancel_alarm",
+    "list_alarms",
+    "is_permission_granted",
+    "request_permissions",
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .build();
+
+    inject_android_permissions()
+        .expect("Failed to inject alarm-manager Android permissions");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions = vec![
+        // Core alarm scheduling permissions
+        r#"<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />"#,
+        r#"<uses-permission android:name="android.permission.USE_EXACT_ALARM" />"#,
+        
+        // Power management
+        r#"<uses-permission android:name="android.permission.WAKE_LOCK" />"#,
+        
+        // Boot persistence
+        r#"<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />"#,
+        
+        // Lockscreen experience
+        r#"<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />"#,
+        
+        // Foreground service for reliable alarm audio
+        r#"<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />"#,
+        r#"<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />"#,
+        
+        // User feedback
+        r#"<uses-permission android:name="android.permission.VIBRATE" />"#,
+        r#"<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />"#,
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-alarm-manager.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+---
+
+## Testing Procedures
+
+### Phase 1: Initial Implementation Test
+
+1. **Implement the pattern** in your plugin's `build.rs`
+
+2. **Build the Android project:**
+   ```bash
+   cd apps/threshold  # Or your main app
+   pnpm tauri android build
+   # or
+   pnpm tauri android dev
+   ```
+
+3. **Locate the generated manifest:**
+   ```bash
+   cat apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+   ```
+
+4. **Verify injection markers:**
+   ```xml
+   <!-- tauri-plugin-YOUR-PLUGIN.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+   <uses-permission android:name="..." />
+   <uses-permission android:name="..." />
+   <!-- tauri-plugin-YOUR-PLUGIN.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+   ```
+
+   ✅ **Success indicators:**
+   - Comment markers are present
+   - Your permissions are between the markers
+   - Permissions match what you specified in `build.rs`
+
+   ❌ **Failure indicators:**
+   - No comment markers visible
+   - Permissions missing
+   - Build errors
+
+### Phase 2: Idempotency Test
+
+5. **Rebuild without changes:**
+   ```bash
+   pnpm tauri android build
+   ```
+
+6. **Check the generated manifest again:**
+   - ✅ Block should be in the same location
+   - ✅ No duplicate permissions
+   - ✅ Comment markers unchanged
+
+### Phase 3: Feature Gate Test (if applicable)
+
+7. **Build with feature enabled:**
+   ```bash
+   cargo build --features your-feature-name
+   pnpm tauri android build
+   ```
+
+8. **Verify feature-gated permissions appear**
+
+9. **Build without feature:**
+   ```bash
+   cargo build --no-default-features
+   pnpm tauri android build
+   ```
+
+10. **Verify feature-gated permissions are absent**
+
+### Phase 4: Runtime Test
+
+11. **Install on device/emulator:**
+    ```bash
+    pnpm tauri android dev
+    ```
+
+12. **Verify runtime behaviour:**
+    - ✅ No "SecurityException: Permission denied" errors
+    - ✅ All plugin features work correctly
+    - ✅ Components (services/receivers) are registered
+
+13. **Check App Info:**
+    - Open Android Settings → Apps → Threshold
+    - Navigate to Permissions
+    - ✅ Verify all expected permissions are listed
+
+### Phase 5: Cleanup Test
+
+14. **Remove plugin from app dependencies**
+
+15. **Rebuild:**
+    ```bash
+    pnpm tauri android build
+    ```
+
+16. **Verify generated manifest:**
+    - ✅ Your plugin's permission block should be gone
+    - ✅ Other plugin blocks unaffected
+
+---
+
+## Common Patterns
+
+### Pattern 1: Simple Static Permissions
+
+**Use when:** Your plugin always needs the same permissions, no conditional logic.
+
+```rust
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions = vec![
+        r#"<uses-permission android:name="android.permission.CAMERA" />"#,
+        r#"<uses-permission android:name="android.permission.VIBRATE" />"#,
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-barcode-scanner.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+**Examples:** barcode-scanner, flashlight, haptics
+
+---
+
+### Pattern 2: Feature-Gated Permissions
+
+**Use when:** Some permissions are sensitive or optional.
+
+```rust
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![
+        // Always required
+        r#"<uses-permission android:name="android.permission.VIBRATE" />"#,
+    ];
+
+    // Optional sensitive permission
+    #[cfg(feature = "background-location")]
+    permissions.push(r#"<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />"#);
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-location.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+**Examples:** location-tracking, notification-manager
+
+---
+
+### Pattern 3: Configuration-Driven Injection
+
+**Use when:** Permissions depend on user configuration in `tauri.conf.json`.
+
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct PluginConfig {
+    enable_camera: bool,
+    enable_microphone: bool,
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![];
+
+    if let Some(config) = tauri_plugin::plugin_config::<PluginConfig>("your-plugin") {
+        if config.enable_camera {
+            permissions.push(r#"<uses-permission android:name="android.permission.CAMERA" />"#);
+        }
+        if config.enable_microphone {
+            permissions.push(r#"<uses-permission android:name="android.permission.RECORD_AUDIO" />"#);
+        }
+    }
+
+    if permissions.is_empty() {
+        return Ok(()); // No permissions needed
+    }
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-media.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+**Examples:** deep-link (dynamic intent filters)
+
+---
+
+### Pattern 4: Android API Level Conditional
+
+**Use when:** Permissions only apply to certain Android versions.
+
+```rust
+fn inject_android_permissions() -> std::io::Result<()> {
+    let mut permissions = vec![
+        r#"<uses-permission android:name="android.permission.VIBRATE" />"#,
+    ];
+
+    // Android 13+ requires explicit notification permission
+    permissions.push(
+        r#"<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />"#
+    );
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-notification.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+**Note:** You can't conditionally inject based on runtime API level in `build.rs`, but you can document that certain permissions only apply to newer Android versions. The permission will be in the manifest but ignored on older versions.
+
+---
+
+### Pattern 5: Injecting Application Components (Advanced)
+
+**Use when:** You need to conditionally include services or receivers.
+
+**⚠️ WARNING:** Only use this if you have a strong reason. Prefer the library manifest for components.
+
+```rust
+fn inject_android_components() -> std::io::Result<()> {
+    #[cfg(feature = "background-sync")]
+    {
+        let components = r#"
+<service
+    android:name="com.yourplugin.BackgroundSyncService"
+    android:exported="false"
+    android:foregroundServiceType="dataSync" />
+
+<receiver
+    android:name="com.yourplugin.SyncReceiver"
+    android:exported="false">
+    <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+    </intent-filter>
+</receiver>
+"#;
+
+        tauri_plugin::mobile::update_android_manifest(
+            "tauri-plugin-sync.application",
+            "application",
+            components.trim().to_string(),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+    inject_android_permissions().expect("Failed to inject permissions");
+    inject_android_components().expect("Failed to inject components");
+}
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Permissions Not Appearing in Generated Manifest
+
+**Symptoms:**
+- Built successfully but no comment markers in generated manifest
+- Plugin permissions missing
+
+**Causes & Solutions:**
+
+1. **`TAURI_ANDROID_PROJECT_PATH` not set**
+   - This only gets set during Android builds
+   - ✅ Run `pnpm tauri android build` or `pnpm tauri android dev`
+   - ❌ Don't run `cargo build` directly
+
+2. **Build feature not enabled**
+   ```toml
+   # ❌ Wrong
+   tauri-plugin = "2.0.0"
+   
+   # ✅ Correct
+   tauri-plugin = { version = "2.0.0", features = ["build"] }
+   ```
+
+3. **Function never called**
+   - Ensure `inject_android_permissions()` is called in `main()`
+   - Check for early returns or panics before the call
+
+4. **Wrong parent tag**
+   - Permissions must use `parent_tag = "manifest"`
+   - Services/receivers use `parent_tag = "application"`
+
+---
+
+### Issue: Build Fails with "failed to rewrite AndroidManifest.xml"
+
+**Symptoms:**
+```
+thread 'main' panicked at 'Failed to inject Android permissions: ...'
+```
+
+**Causes & Solutions:**
+
+1. **Malformed XML**
+   - Check for unmatched quotes, missing `/>` closures
+   - Validate XML syntax in your permission strings
+
+2. **Invalid parent tag**
+   - Only `manifest`, `application`, and `activity` are valid
+   - Don't use custom tag names
+
+3. **File system permissions**
+   - Rare, but generated manifest might be read-only
+   - Check file permissions in `gen/android/` directory
+
+---
+
+### Issue: Duplicate Permissions After Multiple Builds
+
+**Symptoms:**
+- Same permission appears 2-3 times in manifest
+- Comment markers repeated
+
+**Cause:** You're using different block identifiers across builds.
+
+**Solution:**
+```rust
+// ❌ Wrong - changing block ID
+tauri_plugin::mobile::update_android_manifest(
+    format!("my-plugin-{}", timestamp),  // DON'T DO THIS
+    "manifest",
+    permissions,
+)
+
+// ✅ Correct - stable block ID
+tauri_plugin::mobile::update_android_manifest(
+    "tauri-plugin-my-plugin.permissions",  // Same every time
+    "manifest",
+    permissions,
+)
+```
+
+---
+
+### Issue: Runtime SecurityException Despite Manifest Injection
+
+**Symptoms:**
+- Build succeeds, permissions in manifest
+- App crashes with "Permission denied" at runtime
+
+**Causes & Solutions:**
+
+1. **Runtime permissions not requested (Android 6+)**
+   - Some permissions require runtime requests
+   - Examples: `CAMERA`, `LOCATION`, `RECORD_AUDIO`
+   - ✅ Add runtime permission request code in your plugin
+
+2. **Special access permissions**
+   - Some "permissions" are actually special access toggles
+   - Examples: `SCHEDULE_EXACT_ALARM`, `USE_FULL_SCREEN_INTENT`
+   - ✅ Add code to check and request these via Settings intents
+
+3. **Permission spelling mistake**
+   - Double-check permission names against Android docs
+   - Common mistake: `SCHEDULE_ALARMS` vs `SCHEDULE_EXACT_ALARM`
+
+---
+
+### Issue: Components Not Registered
+
+**Symptoms:**
+- Permissions work fine
+- Services/receivers don't respond to intents
+
+**Cause:** You removed components from library manifest but didn't inject them.
+
+**Solution:**
+Keep components in `android/src/main/AndroidManifest.xml`:
+```xml
+<application>
+    <service android:name=".YourService" ... />
+    <receiver android:name=".YourReceiver" ... />
+</application>
+```
+
+The manifest merger will handle these correctly. You usually don't need to inject components.
+
+---
+
+### Issue: Feature Gates Not Working
+
+**Symptoms:**
+- Built with feature enabled but permission missing
+- Built without feature but permission still present
+
+**Cause:** Cargo feature conditional not evaluated correctly.
+
+**Debug steps:**
+
+1. **Verify feature is defined in Cargo.toml:**
+   ```toml
+   [features]
+   your-feature = []
+   ```
+
+2. **Check syntax:**
+   ```rust
+   // ✅ Correct
+   #[cfg(feature = "your-feature")]
+   permissions.push(...);
+   
+   // ❌ Wrong
+   #[cfg(feature = "your_feature")]  // Uses underscore
+   permissions.push(...);
+   ```
+
+3. **Verify build command:**
+   ```bash
+   # Enable feature
+   cargo build --features your-feature
+   pnpm tauri android build
+   
+   # Disable feature
+   cargo build --no-default-features
+   pnpm tauri android build
+   ```
+
+4. **Add debug logging:**
+   ```rust
+   #[cfg(feature = "your-feature")]
+   {
+       println!("cargo:warning=Feature 'your-feature' is ENABLED");
+       permissions.push(...);
+   }
+   
+   #[cfg(not(feature = "your-feature"))]
+   println!("cargo:warning=Feature 'your-feature' is DISABLED");
+   ```
+
+---
+
+## Advanced Topics
+
+### Multi-Inject Pattern
+
+Some plugins might need to inject into multiple parent tags:
+
+```rust
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).build();
+    
+    // Inject permissions
+    inject_permissions()
+        .expect("Failed to inject permissions");
+    
+    // Inject application components (if needed)
+    inject_application_components()
+        .expect("Failed to inject components");
+    
+    // Inject activity metadata (if needed)
+    inject_activity_metadata()
+        .expect("Failed to inject metadata");
+}
+
+fn inject_permissions() -> std::io::Result<()> {
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-my-plugin.permissions",
+        "manifest",
+        build_permissions_xml(),
+    )
+}
+
+fn inject_application_components() -> std::io::Result<()> {
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-my-plugin.application",
+        "application",
+        build_components_xml(),
+    )
+}
+
+fn inject_activity_metadata() -> std::io::Result<()> {
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-my-plugin.activity",
+        "activity",
+        build_metadata_xml(),
+    )
+}
+```
+
+**Important:** Use different block identifiers for each injection point.
+
+---
+
+### Version-Specific Permissions
+
+Some permissions have different names across Android versions:
+
+```rust
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions = vec![
+        // Android 12+ (API 31+)
+        r#"<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />"#,
+        
+        // Backwards compatibility for older Android versions
+        r#"<uses-permission android:name="android.permission.USE_EXACT_ALARM" />"#,
+    ];
+
+    // Android will ignore permissions it doesn't recognize, so it's safe to include both
+    
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-alarm-manager.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+}
+```
+
+---
+
+### Permission Rationale Documentation
+
+For sensitive permissions, add a README section explaining why they're needed:
+
+```markdown
+## Android Permissions
+
+This plugin requires the following Android permissions:
+
+### `CAMERA` (Required)
+- **Why:** To scan barcodes using the device camera
+- **When:** Only when `scan()` is called
+- **Privacy:** Camera data is processed locally and never transmitted
+
+### `VIBRATE` (Optional)
+- **Why:** To provide haptic feedback when a barcode is detected
+- **When:** Only if `hapticFeedback: true` in config
+- **Privacy:** No data is collected
+
+### Feature Gates
+
+Enable sensitive permissions with Cargo features:
+
+```toml
+tauri-plugin-barcode = { version = "1.0", features = ["haptics"] }
+```
+```
+
+---
+
+## Checklist for Plugin Authors
+
+Use this checklist when implementing the pattern in your plugin:
+
+- [ ] **Prerequisites**
+  - [ ] Added `tauri-plugin` with `build` feature to `[build-dependencies]`
+  - [ ] Identified all required Android permissions
+  - [ ] Identified all required components (services/receivers/activities)
+
+- [ ] **Implementation**
+  - [ ] Created/updated `build.rs` with permission injection
+  - [ ] Used correct block identifier: `tauri-plugin-{name}.permissions`
+  - [ ] Used raw string literals (no escaped quotes)
+  - [ ] Added comments explaining each permission
+  - [ ] Defined Cargo features for optional permissions (if needed)
+  - [ ] Updated library manifest to remove injected permissions
+  - [ ] Kept components in library manifest
+
+- [ ] **Documentation**
+  - [ ] Added permissions list to plugin README
+  - [ ] Explained why each permission is needed
+  - [ ] Documented Cargo features (if any)
+  - [ ] Added privacy/security notes for sensitive permissions
+
+- [ ] **Testing**
+  - [ ] Verified injection markers in generated manifest
+  - [ ] Tested idempotency (multiple builds)
+  - [ ] Tested feature gates (if applicable)
+  - [ ] Verified runtime behaviour (no SecurityException)
+  - [ ] Checked App Info in Android Settings
+  - [ ] Tested plugin removal (cleanup)
+
+- [ ] **Code Review**
+  - [ ] Pattern follows Threshold conventions
+  - [ ] Block identifiers are unique
+  - [ ] Error messages are clear
+  - [ ] No hardcoded paths or assumptions
+
+---
+
+## References
+
+### Official Tauri Examples
+
+Study these official plugins for real-world patterns:
+
+1. **Simple static injection (NFC):**
+   - Path: `plugins/nfc/build.rs`
+   - Pattern: Fixed intent-filters for activity
+
+2. **Configuration-driven injection (Deep-Link):**
+   - Path: `plugins/deep-link/build.rs`
+   - Pattern: Reads config, generates intent-filters dynamically
+
+3. **Library manifest only (Notification):**
+   - Path: `plugins/notification/android/src/main/AndroidManifest.xml`
+   - Pattern: No injection, pure manifest merger
+
+### Android Documentation
+
+- [Permissions Overview](https://developer.android.com/guide/topics/permissions/overview)
+- [Manifest Permissions Reference](https://developer.android.com/reference/android/Manifest.permission)
+- [Manifest Merger](https://developer.android.com/build/manage-manifests#merge-manifests)
+
+### Tauri Documentation
+
+- [Tauri v2 Plugin Guide](https://v2.tauri.app/develop/plugins/)
+- [Mobile Development](https://v2.tauri.app/develop/mobile/)
+
+---
+
+## Contact & Support
+
+**Questions about this pattern?**
+- Create an issue in the Threshold repository
+- Tag issues with `plugin-development` and `android`
+
+**Found a bug in this document?**
+- Submit a PR to update `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`
+
+**Need help implementing?**
+- Review the alarm-manager reference implementation
+- Check the troubleshooting section
+- Ask in Threshold development discussions
+
+---
+
+## Changelog
+
+### Version 1.0 (January 2026)
+- Initial pattern documentation
+- Validated against Tauri v2 official plugins
+- Established Threshold plugin conventions
+- Added comprehensive troubleshooting guide
+
+---
+
+**This pattern is a Threshold standard. All Android plugins should follow it.**


### PR DESCRIPTION
This PR significantly improves the documentation infrastructure by reducing ambiguity for both human developers and AI agents. It establishes strict standards for plugin permission management and provides clear guardrails to prevent common Tauri v1 pitfalls.

## Changes

### 📚 Documentation
- **New `AGENTS.md` Sections:**
  - Added "Common v1 Pitfalls" to actively discourage deprecated v1 patterns (e.g., `allowlist`, old `fs` API).
  - Clarified commit message standards and body formatting.
  - Added a Table of Contents for better navigation.
- **New Plugin Standards (`docs/patterns/`):**
  - `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`: The single source of truth for Android permission injection.
  - `PLUGIN_MANIFEST_QUICKSTART.md`: A copy-paste friendly guide for new plugins.
  - `PLUGIN_MANIFEST_PR_CHECKLIST.md`: A standard checklist for reviewing plugin PRs.
- **New Agent Guide (`docs/guides/`):**
  - Added `AI_AGENT_USAGE_GUIDE.md` to help agents navigate the project structure and context.

### 🔧 Developer Experience
- Standardized the `threshold://` protocol documentation.
- Clarified UI project structure and recommended directory layout.
- Added cross-references to specific documentation files (e.g., `DESKTOP_DEEPLINKS.md`, `ALARM_MANAGER.md`) to improve discoverability.

## Reasoning
As the codebase grows, inconsistent plugin implementations and "hallucinated" v1 code from AI assistants have become a bottleneck. By explicitly documenting the *correct* patterns (and the *incorrect* ones to avoid), we ensure stability and consistency across the monorepo.