### PR TITLE
Expand gitignore with Android build logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ vault/*
 
 # Codex backup
 codex-backup.tar.gz
+
+# Android
+android-build-results.log
+logcat*.log
+
+# Antigravity Backup
+antigravity-backup.tar.gz   


### PR DESCRIPTION
Add logcat log file to the `.gitignore` along with an Antigravity backup file.