### PR TITLE
Add .android_path() requirement to plugin patterns

### DIFF
--- a/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md
+++ b/docs/patterns/PLUGIN_MANIFEST_QUICKSTART.md
@@ -36,7 +36,9 @@ const COMMANDS: &[&str] = &[
 ];
 
 fn main() {
-    tauri_plugin::Builder::new(COMMANDS).build();
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")  // Required: Registers Android module with Tauri
+        .build();
 
     inject_android_permissions()
         .expect("Failed to inject Android permissions");
@@ -65,7 +67,7 @@ fn inject_android_permissions() -> std::io::Result<()> {
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Remove <uses-permission> tags you're now injecting -->
-    
+
     <application>
         <!-- Keep services, receivers, activities here -->
     </application>
@@ -83,6 +85,7 @@ cat src-tauri/gen/android/app/src/main/AndroidManifest.xml
 ```
 
 Look for:
+
 ```xml
 <!-- tauri-plugin-YOUR-PLUGIN-NAME.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
 <uses-permission android:name="..." />
@@ -145,6 +148,7 @@ fn inject_android_permissions() -> std::io::Result<()> {
 ```
 
 Users enable with:
+
 ```toml
 tauri-plugin-your-plugin = { version = "1.0", features = ["camera-access"] }
 ```
@@ -163,6 +167,9 @@ For complete documentation, read `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`.
 
 **Problem:** Permissions not appearing  
 **Fix:** Ensure you run `pnpm tauri android build`, not `cargo build`
+
+**Problem:** Plugin not appearing in Gradle files  
+**Fix:** Add `.android_path("android")` to your `build.rs` before `.build()` - this registers your Android module with Tauri's build system
 
 **Problem:** Build fails  
 **Fix:** Check XML syntax, verify block identifier is unique


### PR DESCRIPTION
## Summary
Updates plugin development documentation to include the critical `.android_path("android")` requirement that was previously undocumented. This requirement is essential for proper Gradle integration of Android plugins.

## Problem
Plugin developers were missing a critical step in `build.rs` that caused:
- Plugins not appearing in generated Gradle files
- `ClassNotFoundException` at runtime
- Need for fragile manual Gradle edits that get overwritten on rebuild

This was discovered while debugging the `time-prefs` plugin, which crashed because it wasn't properly registered with Tauri's build system.

## Changes

### `PLUGIN_MANIFEST_QUICKSTART.md`
- **Updated build.rs template** to include `.android_path("android")` before `.build()`
- **Added troubleshooting entry** for plugins not appearing in Gradle files

### `THRESHOLD_PLUGIN_MANIFEST_PATTERN.md`
- **Added Step 3.5** - New section explaining `.android_path()` requirement
  - Why it matters (prevents ClassNotFoundException)
  - What it does (Gradle integration, API bindings)
  - Distinction from manifest injection
- **Updated all code examples** - All 3 build.rs templates now include `.android_path()`
- **Added comprehensive troubleshooting section** covering:
  - Symptoms of missing `.android_path()`
  - Root cause explanation
  - Before/after code comparison
  - Verification steps

## Context
The `.android_path()` call is used by all official Tauri plugins (deep-link, notification, barcode-scanner, etc.) but wasn't documented in our pattern guides. This gap led to plugins being implemented incorrectly, requiring manual Gradle configuration.

## Verification
- [x] All code examples updated consistently
- [x] Troubleshooting section added with clear symptoms and solutions
- [x] Documentation now matches official Tauri plugin patterns