### PR TITLE
Register Android module with Tauri

### DIFF
--- a/apps/threshold/src-tauri/gen/android/app/build.gradle.kts
+++ b/apps/threshold/src-tauri/gen/android/app/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")
-    implementation(project(":tauri-plugin-alarm-manager"))
 }
 
 apply(from = "tauri.build.gradle.kts")

--- a/apps/threshold/src-tauri/gen/android/settings.gradle
+++ b/apps/threshold/src-tauri/gen/android/settings.gradle
@@ -1,6 +1,3 @@
 include ':app'
 
 apply from: 'tauri.settings.gradle'
-
-include ':tauri-plugin-alarm-manager'
-project(':tauri-plugin-alarm-manager').projectDir = new File('../../../../../plugins/alarm-manager/android')

--- a/plugins/alarm-manager/build.rs
+++ b/plugins/alarm-manager/build.rs
@@ -8,7 +8,9 @@ const COMMANDS: &[&str] = &[
 ];
 
 fn main() {
-    tauri_plugin::Builder::new(COMMANDS).build();
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
 
     inject_android_permissions();
 }


### PR DESCRIPTION
## Summary

Fixes the alarm-manager plugin's Gradle integration by adding the missing `.android_path("android")` call to `build.rs`. This eliminates the need for fragile manual Gradle edits that were previously required and would get overwritten on clean rebuilds.

## Problem

The alarm-manager plugin required manual edits to:

- `gen/android/settings.gradle` - to include the plugin module
- `gen/android/app/build.gradle.kts` - to add the implementation dependency

These manual edits would be lost whenever the generated Android project was cleaned and rebuilt, causing build failures and requiring developers to remember to re-add them.

## Root Cause

The plugin's `build.rs` was missing the `.android_path("android")` call that tells Tauri's build system about the Android native code. Without this, Tauri doesn't know to include the plugin in the generated Gradle configuration.

## Solution

Added `.android_path("android")` to the plugin builder in `plugins/alarm-manager/build.rs`:

```rust
fn main() {
    tauri_plugin::Builder::new(COMMANDS)
        .android_path("android")  // ← Added this
        .build();
}
```

This enables automatic Gradle integration:

- ✅ Plugin automatically included in `gen/android/settings.gradle`
- ✅ Dependency automatically added to `gen/android/app/build.gradle.kts`
- ✅ Tauri API bindings copied to `android/.tauri/` during builds
- ✅ No manual edits required

## Changes

- **Updated** `plugins/alarm-manager/build.rs` - Added `.android_path("android")`
- **Removed** manual gradle entries from generated files (now auto-generated)

## Verification

- ✅ Clean build successful
- ✅ Plugin appears in auto-generated `tauri.build.gradle.kts`
- ✅ APK builds without manual intervention

## Related

This follows the same pattern implemented for `time-prefs` plugin and is documented in the updated plugin development guides.
