### PR TITLE
Add Gemini Backup Utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ android-build-results.log
 logcat*.log
 
 # Antigravity Backup
+gemini-backup.tar.gz
 antigravity-backup.tar.gz
 
 # Tauri plugin build artifacts

--- a/gemini-utils.sh
+++ b/gemini-utils.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Alias to backup the .gemini folder to the current workspace
+# Usage: backup-gemini
+alias backup-gemini='tar -cv -I "gzip -9" -f /workspaces/tauri-mobile-test/gemini-backup.tar.gz -C /home/vscode .gemini'
+
+# Alias to restore the .gemini folder from the current workspace
+# Usage: restore-gemini
+alias restore-gemini='tar -xzvf /workspaces/tauri-mobile-test/gemini-backup.tar.gz -C /home/vscode'
+
+echo "Gemini backup/restore aliases loaded!"
+echo "Use 'backup-gemini' to save your settings."
+echo "Use 'restore-gemini' to restore them."


### PR DESCRIPTION
This PR introduces a set of utility aliases to facilitate the backup and restoration of the `.gemini` folder in the dev container. This ensures that agentic settings and memory are preserved across container rebuilds.

## Changes
- Created `gemini-utils.sh`: A shell script containing `backup-gemini` and `restore-gemini` aliases.
- Updated `.gitignore`: Added `gemini-backup.tar.gz` to ignore the local backup archive.

## Usage
1. Source the utilities: `source gemini-utils.sh`
2. Backup: `backup-gemini` (creates `gemini-backup.tar.gz` in repository root)
3. Restore: `restore-gemini` (restores from `gemini-backup.tar.gz` to `~/.gemini`)