### PR TITLE
Automate Android Release Builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -75,7 +75,7 @@ RUN yes | sdkmanager --licenses && \
     "platform-tools" \
     "platforms;android-36" \
     "build-tools;36.0.0" \
-    "ndk;28.0.12674087"
+    "ndk;28.2.13676358"
 
 # Install Rust toolchain (stable)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
 	"name": "Threshold Dev",
 	"dockerFile": "Dockerfile",
-	// "workspaceFolder": "/workspaces/{{PROJECT_NAME}}",
 	"forwardPorts": [
 		5173,
 		1420
@@ -12,6 +11,14 @@
 		"--env=PULSE_SERVER=unix:/run/user/1000/pulse/native",
 		"--volume=/run/user/1000/pulse/native:/run/user/1000/pulse/native"
 	],
+	
+	// Mount keystore directory from host (read-only for security)
+	// Comment out on machines without ~/threshold-keys/ (like laptop)
+	// git update-index --assume-unchanged .devcontainer/devcontainer.json
+	"mounts": [
+		"source=${localEnv:HOME}/threshold-keys,target=/keys,type=bind,readonly"
+	],
+	
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -21,7 +28,18 @@
 				"tauri-apps.tauri-vscode",
 				"ms-vscode.vscode-typescript-next",
 				"streetsidesoftware.code-spell-checker"
-			]
+			],
+			"settings": {
+				"files.exclude": {
+					"**/*.jks": true,
+					"**/*.keystore": true,
+					"**/keystore.properties": true
+				},
+				"files.watcherExclude": {
+					"**/*.jks": true,
+					"**/*.keystore": true
+				}
+			}
 		}
 	},
 	"postCreateCommand": "pnpm install"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ antigravity-backup.tar.gz
 
 # Tauri plugin build artifacts
 plugins/**/android/.tauri/
+
+# Android Keystores (CRITICAL - never commit!)
+*.jks
+*.keystore
+keystore.properties
+keys
+.threshold-keys

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Colour"
+    ]
+}

--- a/scripts/build-release-devcontainer.sh
+++ b/scripts/build-release-devcontainer.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Build script for use with VS Code Dev Containers
+# Automatically uses keystore.properties from /keys mount
+# NO MANUAL SETUP REQUIRED! 🎉
+
+set -e
+
+# Colours for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+MAGENTA='\033[0;35m'
+NC='\033[0m' # No Colour
+
+echo -e "${BLUE}╔════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║   Threshold Android Release Builder    ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════╝${NC}\n"
+
+# Check we're in the right directory
+if [ ! -f "pnpm-workspace.yaml" ]; then
+    echo -e "${RED}Error: Must be run from repo root${NC}"
+    exit 1
+fi
+
+# Check for keystore.properties at /keys mount
+KEYS_PROPS="/keys/keystore.properties"
+KEYS_DIR="/keys"
+
+if [ ! -f "$KEYS_PROPS" ]; then
+    echo -e "${RED}Error: keystore.properties not found${NC}"
+    echo ""
+    echo -e "${YELLOW}Setup required:${NC}"
+    echo ""
+    echo "  1. On your HOST machine, create keystore.properties:"
+    echo "     cat > ~/threshold-keys/keystore.properties <<EOF"
+    echo "     keyAlias=google-play-upload"
+    echo "     password=YOUR_KEYSTORE_PASSWORD"
+    echo "     storeFile=/keys/upload-keystore.jks"
+    echo "     EOF"
+    echo ""
+    echo "  2. Make sure .devcontainer/devcontainer.json has the mount:"
+    echo "     \"mounts\": ["
+    echo "       \"source=\${localEnv:HOME}/threshold-keys,target=/keys,type=bind,readonly\""
+    echo "     ]"
+    echo ""
+    echo "  3. Rebuild your dev container"
+    echo ""
+    exit 1
+fi
+
+# Verify the keystore file exists
+KEYSTORE_FILE=$(grep "^storeFile=" "$KEYS_PROPS" | cut -d'=' -f2)
+
+# If the keystore path is absolute, use it directly
+# If relative, it's relative to the keys directory
+if [[ "$KEYSTORE_FILE" =~ ^/ ]]; then
+    # Absolute path - check if it exists or needs to be mapped
+    if [ ! -f "$KEYSTORE_FILE" ]; then
+        # Try mapping /keys to actual location
+        if [ -n "$KEYS_DIR" ]; then
+            KEYSTORE_FILE="${KEYSTORE_FILE//\/keys/$KEYS_DIR}"
+        fi
+    fi
+else
+    # Relative path - make it relative to keys directory
+    KEYSTORE_FILE="$KEYS_DIR/$KEYSTORE_FILE"
+fi
+
+if [ ! -f "$KEYSTORE_FILE" ]; then
+    echo -e "${RED}Error: Keystore file not found: $KEYSTORE_FILE${NC}"
+    echo "Check that your keys are accessible:"
+    echo "  ls -la $KEYS_DIR"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Keystore configuration found${NC}"
+echo -e "  Location: $KEYS_PROPS"
+echo -e "  Keystore: $KEYSTORE_FILE${NC}\n"
+
+# Check NDK
+if [ -z "$NDK_HOME" ]; then
+    echo -e "${YELLOW}⚠ NDK_HOME not set, attempting to find NDK...${NC}"
+    
+    if [ -d "$ANDROID_HOME/ndk" ]; then
+        # Find latest NDK (preferably r28+)
+        NDK_VERSION=$(ls -1 "$ANDROID_HOME/ndk" | sort -V | tail -n1)
+        export NDK_HOME="$ANDROID_HOME/ndk/$NDK_VERSION"
+        export ANDROID_NDK_HOME="$NDK_HOME"
+        echo -e "${GREEN}✓ Found NDK: $NDK_HOME${NC}\n"
+    else
+        echo -e "${RED}Error: No NDK found. Install with: sdkmanager 'ndk;28.0.12674558'${NC}"
+        exit 1
+    fi
+else
+    echo -e "${GREEN}✓ NDK configured: $NDK_HOME${NC}\n"
+fi
+
+# Ensure Rust targets are installed
+echo -e "${BLUE}📦 Checking Rust Android targets...${NC}"
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android 2>/dev/null || true
+echo -e "${GREEN}✓ Rust targets ready${NC}\n"
+
+# Link keystore.properties into Android project
+ANDROID_PROJECT="apps/threshold/src-tauri/gen/android"
+TARGET_PROPS="$ANDROID_PROJECT/keystore.properties"
+
+echo -e "${BLUE}🔗 Linking keystore.properties...${NC}"
+
+# Remove existing link/file if present
+if [ -L "$TARGET_PROPS" ] || [ -f "$TARGET_PROPS" ]; then
+    rm "$TARGET_PROPS"
+fi
+
+# Create symlink
+ln -s "$KEYS_PROPS" "$TARGET_PROPS"
+
+if [ ! -L "$TARGET_PROPS" ]; then
+    echo -e "${RED}Error: Failed to create symlink${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ keystore.properties linked${NC}\n"
+
+# Set up cleanup trap to ensure symlink is removed even on failure
+cleanup() {
+    if [ -L "$TARGET_PROPS" ]; then
+        echo -e "\n${BLUE}🧹 Cleaning up keystore symlink...${NC}"
+        rm "$TARGET_PROPS"
+        echo -e "${GREEN}✓ Removed keystore.properties symlink${NC}"
+    fi
+}
+trap cleanup EXIT
+
+# Build
+echo -e "${MAGENTA}╔════════════════════════════════════════╗${NC}"
+echo -e "${MAGENTA}║         Building Release AAB...        ║${NC}"
+echo -e "${MAGENTA}╚════════════════════════════════════════╝${NC}\n"
+
+pnpm build:android -- --aab
+
+BUILD_RESULT=$?
+
+# Check if build succeeded
+if [ $BUILD_RESULT -ne 0 ]; then
+    echo -e "\n${RED}╔════════════════════════════════════════╗${NC}"
+    echo -e "${RED}║           Build Failed ❌              ║${NC}"
+    echo -e "${RED}╚════════════════════════════════════════╝${NC}\n"
+    exit 1
+fi
+
+AAB_PATH=$(find apps/threshold/src-tauri/gen/android/app/build/outputs/bundle/release -name "*.aab" -type f 2>/dev/null | head -n1)
+
+if [ -z "$AAB_PATH" ]; then
+    echo -e "\n${RED}✗ Build completed but no AAB found${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}╔════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║     ✓ Release Build Successful! 🎉     ║${NC}"
+echo -e "${GREEN}╚════════════════════════════════════════╝${NC}\n"
+
+# Show file info
+AAB_SIZE=$(du -h "$AAB_PATH" | cut -f1)
+echo -e "${BLUE}📍 AAB Location:${NC}"
+echo "   $AAB_PATH"
+echo ""
+echo -e "${BLUE}📦 File Size:${NC} $AAB_SIZE"
+echo ""
+
+# Verify signature
+echo -e "${BLUE}🔐 Verifying signature...${NC}"
+if command -v jarsigner &> /dev/null; then
+    SIGNER=$(jarsigner -verify -verbose -certs "$AAB_PATH" 2>&1 | grep "CN=" | head -n1 | sed 's/.*CN=/CN=/g')
+    if [ -n "$SIGNER" ]; then
+        echo -e "${GREEN}✓ Signed by: $SIGNER${NC}"
+    else
+        echo -e "${YELLOW}⚠ Could not verify signature (but build succeeded)${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠ jarsigner not found, skipping signature verification${NC}"
+fi
+
+echo ""
+echo -e "${MAGENTA}╔════════════════════════════════════════╗${NC}"
+echo -e "${MAGENTA}║            Next Steps                  ║${NC}"
+echo -e "${MAGENTA}╚════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${YELLOW}1.${NC} Copy AAB to host (if needed):"
+echo "   docker cp <container>:/workspace/$AAB_PATH ."
+echo ""
+echo -e "${YELLOW}2.${NC} Upload to Play Console:"
+echo "   https://play.google.com/console"
+echo ""
+echo -e "${YELLOW}3.${NC} Before next build, increment version in:"
+echo "   apps/threshold/src-tauri/tauri.conf.json"
+echo "   (Look for 'versionCode' under bundle.android)"
+echo ""
+echo -e "${GREEN}✨ Build complete! Happy releasing! ✨${NC}"
+echo ""


### PR DESCRIPTION
This PR introduces a robust automation script for building Android release artifacts (AABs) directly within the `devcontainer`. It streamlines the process of handling keystores and signatures by automatically detecting keys from mounted volumes or workspace symlinks, eliminating manual configuration steps.

## Changes

- **New Script**: Added `scripts/build-release-devcontainer.sh` to handle environment setup, keystore linking, NDK configuration, and release builds.
- **Dev Container**: Updated `.devcontainer` configurations to support key mounting and environment prerequisites.
- **Git Ignore**: Updated `.gitignore` to explicitly exclude sensitive keystore files (_.jks, _.keystore, keystore.properties) to prevent accidental commits.
- **VS Code**: Added `.vscode/settings.json` for consistent environment settings.

## Usage

Run the build script from the repository root:

```bash
./scripts/build-release-devcontainer.sh
```

The script will:

- Locate your keystore (checking `/keys` mount or workspace symlinks).
- Configure the Android NDK and Rust targets.
- Build the release AAB.
- Verify the signature of the generated artifact.
