### PR TITLE
Fix missing jest-dom types in vitest environment

### DIFF
--- a/apps/threshold/tsconfig.json
+++ b/apps/threshold/tsconfig.json
@@ -5,7 +5,8 @@
 		"moduleResolution": "bundler",
 		"jsx": "react-jsx",
 		"noEmit": true,
-		"allowImportingTsExtensions": true
+		"allowImportingTsExtensions": true,
+		"types": ["vitest/globals", "@testing-library/jest-dom"]
 	},
 	"include": ["src"],
 	"references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
Fixes a build error in `apps/threshold` where `tsc` failed to recognize `jest-dom` matchers (like `toBeInTheDocument`) in test files.

## Changes
- **`apps/threshold/tsconfig.json`**: Added `"types": ["vitest/globals", "@testing-library/jest-dom"]` to `compilerOptions`.

## Motivation
The Android build command (`pnpm build:android --debug`) fails during the compilation step because TypeScript could not see the augmented `Assertion` interface from `jest-dom` in the global scope. Explicitly adding these types ensures the compiler picks them up.

## Verification
- Reference Issue: Fixes build failure in `src/screens/Ringing.test.tsx`.
- **Manual Verification**:
    - Ran `pnpm build` (passed).
    - Ran `pnpm test` (all 14 tests passed).