### PR TITLE
Add event log downloader and improve logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,6 +5017,7 @@ dependencies = [
  "tauri-plugin-app-events",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-opener",

--- a/apps/threshold/README.md
+++ b/apps/threshold/README.md
@@ -73,6 +73,17 @@ tauri_plugin_log::Builder::default()
     .build(),
 ```
 
+### Event Log Downloader
+
+Desktop and Android builds include an event log downloader for sending diagnostics to the developer.
+
+1. Open **Settings → Developer**.
+2. Select **Download Event Logs**.
+3. Choose where to save the log file, then share it with the developer.
+
+The export bundles the app log files into a single text file with an app/version header.
+On Android, the export includes app logs only (system logcat access is restricted).
+
 ## Android Transitions
 
 The application uses native-like page transitions on Android using the View Transitions API.

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -21,6 +21,7 @@
 		"@tauri-apps/api": "^2",
 		"@tauri-apps/plugin-deep-link": "^2.4.6",
 		"@tauri-apps/plugin-dialog": "~2.6.0",
+		"@tauri-apps/plugin-fs": "^2.4.2",
 		"@tauri-apps/plugin-log": "^2.8.0",
 		"@tauri-apps/plugin-notification": "^2.3.3",
 		"@tauri-apps/plugin-opener": "^2",

--- a/apps/threshold/src-tauri/Cargo.toml
+++ b/apps/threshold/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-log = { version = "2.0.0", features = [] }
 tauri-plugin-notification = { version = "2.0.0", features = [] }
 tauri-plugin-os = { version = "2.0.0", features = [] }
 tauri-plugin-opener = { version = "2.0.0", features = [] }
+tauri-plugin-fs = { version = "2.0.0", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri-plugin-dialog = "2"
@@ -34,4 +35,3 @@ tauri-plugin-window-state = "2"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 tauri-plugin-app-events = "0.2"
-

--- a/apps/threshold/src-tauri/capabilities/default.json
+++ b/apps/threshold/src-tauri/capabilities/default.json
@@ -17,6 +17,8 @@
 		"core:window:default",
 		"core:window:allow-start-dragging",
 		"log:default",
+		"fs:default",
+		"fs:allow-write-text-file",
 		"core:window:allow-show",
 		"core:window:allow-set-focus",
 		"core:window:allow-maximize",

--- a/apps/threshold/src-tauri/capabilities/mobile.json
+++ b/apps/threshold/src-tauri/capabilities/mobile.json
@@ -5,6 +5,9 @@
   "windows": ["*"],
   "platforms": ["android", "iOS"],
   "permissions": [
-    "app-events:default"
+    "app-events:default",
+    "dialog:default",
+    "fs:default",
+    "fs:allow-write-text-file"
   ]
 }

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -1,0 +1,179 @@
+use std::{fs, path::PathBuf, time::SystemTime};
+
+use tauri::{AppHandle, Manager};
+
+const MAX_EVENT_LOG_BYTES: usize = 512_000;
+
+fn truncate_to_limit(value: &str, limit: usize) -> (String, bool) {
+    if value.len() <= limit {
+        return (value.to_string(), false);
+    }
+
+    if limit == 0 {
+        return (String::new(), true);
+    }
+
+    let mut end = 0;
+    for (index, ch) in value.char_indices() {
+        let next = index + ch.len_utf8();
+        if next > limit {
+            break;
+        }
+        end = next;
+    }
+
+    (value[..end].to_string(), true)
+}
+
+fn collect_event_logs(app: &AppHandle) -> Result<String, String> {
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|err| format!("Failed to locate log directory: {err}"))?;
+    let app_name = app.package_info().name.clone();
+    let app_version = app.package_info().version.to_string();
+
+    let mut entries: Vec<(PathBuf, SystemTime)> = Vec::new();
+    let read_dir = fs::read_dir(&log_dir)
+        .map_err(|err| format!("Failed to read log directory: {err}"))?;
+
+    for entry in read_dir {
+        let entry = entry.map_err(|err| format!("Failed to read log entry: {err}"))?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let file_name = match path.file_name().and_then(|name| name.to_str()) {
+            Some(name) => name,
+            None => continue,
+        };
+        if !file_name.starts_with(&app_name) || !file_name.ends_with(".log") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|meta| meta.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        entries.push((path, modified));
+    }
+
+    entries.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let mut output = String::new();
+    output.push_str(&format!("{app_name} event logs\n"));
+    output.push_str(&format!("Version: {app_version}\n"));
+    output.push_str(&format!("Log directory: {}\n\n", log_dir.display()));
+
+    if entries.is_empty() {
+        output.push_str("No log files were found.\n");
+        return Ok(output);
+    }
+
+    let mut remaining = MAX_EVENT_LOG_BYTES.saturating_sub(output.len());
+    for (path, _) in entries {
+        if remaining == 0 {
+            break;
+        }
+
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown.log");
+        let header = format!("==== {file_name} ====\n");
+        let (header_chunk, _) = truncate_to_limit(&header, remaining);
+        output.push_str(&header_chunk);
+        remaining = remaining.saturating_sub(header_chunk.len());
+        if remaining == 0 {
+            break;
+        }
+
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                let (chunk, truncated) = truncate_to_limit(&content, remaining);
+                output.push_str(&chunk);
+                remaining = remaining.saturating_sub(chunk.len());
+                if truncated {
+                    output.push_str("\n[Log output truncated]\n");
+                    break;
+                }
+            }
+            Err(err) => {
+                let message = format!("(Unable to read {file_name}: {err})\n");
+                let (chunk, truncated) = truncate_to_limit(&message, remaining);
+                output.push_str(&chunk);
+                remaining = remaining.saturating_sub(chunk.len());
+                if truncated {
+                    break;
+                }
+            }
+        }
+
+        let (divider, _) = truncate_to_limit("\n", remaining);
+        output.push_str(&divider);
+        remaining = remaining.saturating_sub(divider.len());
+    }
+
+    Ok(output)
+}
+
+#[tauri::command]
+pub fn export_event_logs(app: AppHandle, destination: String) -> Result<String, String> {
+    let content = collect_event_logs(&app)?;
+    if destination.starts_with("content://") {
+        return Err(
+            "Android content URIs are not supported for log export. Please choose a file path."
+                .to_string(),
+        );
+    }
+
+    let normalised_destination = destination
+        .strip_prefix("file://")
+        .unwrap_or(destination.as_str());
+    let destination_path = PathBuf::from(normalised_destination);
+    if let Some(parent) = destination_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|err| format!("Failed to create log export directory: {err}"))?;
+        }
+    }
+
+    fs::write(&destination_path, content)
+        .map_err(|err| {
+            format!(
+                "Failed to write event logs to {normalised_destination}: {err}"
+            )
+        })?;
+    Ok(normalised_destination.to_string())
+}
+
+#[tauri::command]
+pub fn get_event_logs(app: AppHandle) -> Result<String, String> {
+    collect_event_logs(&app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_to_limit;
+
+    #[test]
+    fn truncate_to_limit_returns_full_string_when_under_limit() {
+        let (value, truncated) = truncate_to_limit("threshold", 20);
+        assert_eq!(value, "threshold");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_to_limit_handles_empty_limit() {
+        let (value, truncated) = truncate_to_limit("threshold", 0);
+        assert_eq!(value, "");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn truncate_to_limit_respects_utf8_boundaries() {
+        let original = "log🚀file";
+        let (value, truncated) = truncate_to_limit(original, 5);
+        assert_eq!(value, "log");
+        assert!(truncated);
+    }
+}

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -17,15 +17,17 @@ import {
     Typography,
     Dialog,
     DialogTitle,
-    DialogContent
+    DialogContent,
+    CircularProgress
 } from '@mui/material';
 import { MobileToolbar } from '../components/MobileToolbar';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { ArrowBack as ArrowBackIcon, FileDownload as FileDownloadIcon } from '@mui/icons-material';
 import { useNavigate } from '@tanstack/react-router';
 import { PlatformUtils } from '../utils/PlatformUtils';
 import { SettingsService, Theme } from '../services/SettingsService';
 import { alarmManagerService } from '../services/AlarmManagerService';
 import { useThemeContext } from '../contexts/ThemeContext';
+import { eventLogService } from '../services/EventLogService';
 
 const Settings: React.FC = () => {
     const navigate = useNavigate();
@@ -42,6 +44,7 @@ const Settings: React.FC = () => {
     const [silenceAfter, setSilenceAfter] = useState<number>(SettingsService.getSilenceAfter());
     const [snoozeLength, setSnoozeLength] = useState<number>(SettingsService.getSnoozeLength());
     const [snoozeDialogOpen, setSnoozeDialogOpen] = useState(false);
+    const [isExportingLogs, setIsExportingLogs] = useState(false);
 
     useEffect(() => {
         setIsMobile(PlatformUtils.isMobile());
@@ -51,6 +54,16 @@ const Settings: React.FC = () => {
     const handleTimeFormatChange = (enabled: boolean) => {
         setIs24h(enabled);
         SettingsService.setIs24h(enabled);
+    };
+
+    const handleExportLogs = async () => {
+        if (isExportingLogs) return;
+        setIsExportingLogs(true);
+        try {
+            await eventLogService.downloadEventLogs();
+        } finally {
+            setIsExportingLogs(false);
+        }
     };
 
     return (
@@ -254,6 +267,31 @@ const Settings: React.FC = () => {
                                     }}
                                 >
                                     <span style={{ fontSize: '1.2rem' }}>📩</span>
+                                </IconButton>
+                            </ListItem>
+
+                            <ListItem sx={{ px: isMobile ? 2 : 0 }}>
+                                <ListItemText
+                                    primary="Download Event Logs"
+                                    secondary="Save event logs to send to the developer"
+                                />
+                                <IconButton
+                                    edge="end"
+                                    onClick={handleExportLogs}
+                                    disabled={isExportingLogs}
+                                    sx={{
+                                        bgcolor: 'info.main',
+                                        color: 'info.contrastText',
+                                        '&:hover': {
+                                            bgcolor: 'info.dark',
+                                        }
+                                    }}
+                                >
+                                    {isExportingLogs ? (
+                                        <CircularProgress size={20} color="inherit" />
+                                    ) : (
+                                        <FileDownloadIcon />
+                                    )}
                                 </IconButton>
                             </ListItem>
                         </List>

--- a/apps/threshold/src/services/EventLogService.ts
+++ b/apps/threshold/src/services/EventLogService.ts
@@ -1,0 +1,45 @@
+import { invoke } from '@tauri-apps/api/core';
+import { message, save } from '@tauri-apps/plugin-dialog';
+import { writeTextFile } from '@tauri-apps/plugin-fs';
+
+const buildDefaultFileName = () => {
+	const now = new Date();
+	const pad = (value: number) => value.toString().padStart(2, '0');
+	const stamp = [
+		now.getFullYear(),
+		pad(now.getMonth() + 1),
+		pad(now.getDate()),
+	].join('-');
+	const time = [pad(now.getHours()), pad(now.getMinutes()), pad(now.getSeconds())].join('-');
+	return `threshold-event-logs-${stamp}_${time}.txt`;
+};
+
+export class EventLogService {
+	async downloadEventLogs(): Promise<void> {
+		const destination = await save({
+			title: 'Save Event Logs',
+			defaultPath: buildDefaultFileName(),
+			filters: [{ name: 'Text', extensions: ['txt'] }],
+		});
+
+		if (!destination) {
+			return;
+		}
+
+		try {
+			const content = await invoke<string>('get_event_logs');
+			await writeTextFile(destination, content);
+			await message('Event logs saved. Send the file to the developer.', {
+				title: 'Event Logs',
+			});
+		} catch (error) {
+			console.error('Failed to export event logs:', error);
+			await message('Unable to export event logs. Check the console for details.', {
+				title: 'Event Logs',
+				kind: 'error',
+			});
+		}
+	}
+}
+
+export const eventLogService = new EventLogService();

--- a/apps/threshold/src/utils/logger.ts
+++ b/apps/threshold/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { warn, debug, trace, info, error } from '@tauri-apps/plugin-log';
+import { warn, debug, info, error } from '@tauri-apps/plugin-log';
 
 function forwardConsole(
 	fnName: 'log' | 'debug' | 'info' | 'warn' | 'error',
@@ -15,7 +15,7 @@ function forwardConsole(
 }
 
 export const initLogger = () => {
-	forwardConsole('log', trace);
+	forwardConsole('log', info);
 	forwardConsole('debug', debug);
 	forwardConsole('info', info);
 	forwardConsole('warn', warn);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ~2.6.0
         version: 2.6.0
+      '@tauri-apps/plugin-fs':
+        specifier: ^2.4.2
+        version: 2.4.5
       '@tauri-apps/plugin-log':
         specifier: ^2.8.0
         version: 2.8.0
@@ -1014,6 +1017,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
+
+  '@tauri-apps/plugin-fs@2.4.5':
+    resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
@@ -2641,6 +2647,10 @@ snapshots:
       '@tauri-apps/api': 2.9.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-fs@2.4.5':
     dependencies:
       '@tauri-apps/api': 2.9.1
 


### PR DESCRIPTION
- add backend log export command and frontend export flow for desktop and Android
- support Android save dialogs via the filesystem plugin and required capabilities
- improve log usefulness by mapping console.log to info and reducing noisy mobile targets
- document the event log downloader in the desktop app README

**Why**
- make it easier to capture and share diagnostics from real devices