### PR TITLE
feat: add android toast plugin and wire it into Tauri runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
+checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
  "png",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3508,7 +3508,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -4475,9 +4474,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.9.5"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3868da5508446a7cd08956d523ac3edf0a8bc20bf7e4038f9a95c2800d2033"
+checksum = "463ae8677aa6d0f063a900b9c41ecd4ac2b7ca82f0b058cc4491540e55b20129"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4526,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.3"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
+checksum = "ca7bd893329425df750813e95bd2b643d5369d929438da96d5bbb7cc2c918f74"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4548,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa9844cefcf99554a16e0a278156ae73b0d8680bbc0e2ad1e4287aadd8489cf"
+checksum = "aac423e5859d9f9ccdd32e3cf6a5866a15bedbf25aa6630bcb2acde9468f6ae3"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4575,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3764a12f886d8245e66b7ee9b43ccc47883399be2019a61d80cf0f4117446fde"
+checksum = "1b6a1bd2861ff0c8766b1d38b32a6a410f6dc6532d4ef534c47cfb2236092f59"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4725,8 +4724,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+source = "git+https://github.com/ScottMorris/tauri-plugins-workspace.git?branch=notification-actions-fix#ad0a41affa608bc8ecd0df20719726bb082ea7af"
 dependencies = [
  "log",
  "notify-rust",
@@ -4824,6 +4822,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-toast"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "tauri-plugin-window-state"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f766fe9f3d1efc4b59b17e7a891ad5ed195fa8d23582abb02e6c9a01137892"
+checksum = "b885ffeac82b00f1f6fd292b6e5aabfa7435d537cef57d11e38a489956535651"
 dependencies = [
  "cookie",
  "dpi",
@@ -4865,9 +4873,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.9.3"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
+checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
 dependencies = [
  "gtk",
  "http",
@@ -4892,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a423c51176eb3616ee9b516a9fa67fed5f0e78baaba680e44eb5dd2cc37490"
+checksum = "fcd169fccdff05eff2c1033210b9b94acd07a47e6fa9a3431cf09cfd4f01c87e"
 dependencies = [
  "anyhow",
  "brotli",
@@ -5037,6 +5045,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tauri-plugin-theme-utils",
  "tauri-plugin-time-prefs",
+ "tauri-plugin-toast",
  "tauri-plugin-window-state",
 ]
 
@@ -5661,9 +5670,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5684,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -5708,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk-sys"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62daa38afc514d1f8f12b8693d30d5993ff77ced33ce30cd04deebc267a6d57c"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -6316,9 +6325,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.53.5"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
+checksum = "5ed1a195b0375491dd15a7066a10251be217ce743cf4bbbbdcf5391d6473bee0"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "plugins/alarm-manager",
     "plugins/theme-utils",
     "plugins/time-prefs",
+    "plugins/toast",
 ]
 resolver = "2"
 

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -34,7 +34,8 @@
 		"motion": "^12.27.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
-		"tauri-plugin-app-events-api": "^0.2.0"
+		"tauri-plugin-app-events-api": "^0.2.0",
+		"tauri-plugin-toast-api": "workspace:*"
 	},
 	"devDependencies": {
 		"@tauri-apps/cli": "^2",

--- a/apps/threshold/src-tauri/Cargo.toml
+++ b/apps/threshold/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.0.0", features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2.10.2", features = [] }
 log = "0.4"
 tauri-plugin-sql = { version = "2.0.0", features = ["sqlite"] }
 
@@ -21,9 +21,11 @@ tauri-plugin-alarm-manager = { path = "../../../plugins/alarm-manager" }
 tauri-plugin-time-prefs = { path = "../../../plugins/time-prefs" }
 tauri-plugin-theme-utils = { path = "../../../plugins/theme-utils" }
 tauri-plugin-app-management = { path = "../../../plugins/app-management" }
+tauri-plugin-toast = { path = "../../../plugins/toast" }
 tauri-plugin-deep-link = { version = "2.0.0", features = [] }
 tauri-plugin-log = { version = "2.0.0", features = [] }
-tauri-plugin-notification = { version = "2.0.0", features = [] }
+# tauri-plugin-notification = { version = "2.0.0", features = [] }
+tauri-plugin-notification = { git = "https://github.com/ScottMorris/tauri-plugins-workspace.git", branch = "notification-actions-fix" }
 tauri-plugin-os = { version = "2.0.0", features = [] }
 tauri-plugin-opener = { version = "2.0.0", features = [] }
 tauri-plugin-fs = { version = "2.0.0", features = [] }

--- a/apps/threshold/src-tauri/capabilities/default.json
+++ b/apps/threshold/src-tauri/capabilities/default.json
@@ -35,6 +35,7 @@
 		"alarm-manager:default",
 		"time-prefs:default",
 		"theme-utils:default",
-		"dialog:default"
+		"dialog:default",
+		"toast:default"
 	]
 }

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -65,7 +65,7 @@ pub fn run() {
         event_logs::get_event_logs
     ]);
 
-    builder
+    builder = builder
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_theme_utils::init())
         .plugin(tauri_plugin_alarm_manager::init())
@@ -76,7 +76,14 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_app_management::init())
+        .plugin(tauri_plugin_app_management::init());
+
+    #[cfg(target_os = "android")]
+    {
+        builder = builder.plugin(tauri_plugin_toast::init());
+    }
+
+    builder
         .setup(|app| {
             #[cfg(mobile)]
             app.handle().plugin(tauri_plugin_app_events::init())?;

--- a/plugins/toast/.gitignore
+++ b/plugins/toast/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/toast/Cargo.toml
+++ b/plugins/toast/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tauri-plugin-toast"
+version = "0.1.0"
+authors = ["Threshold"]
+edition = "2021"
+rust-version = "1.77.2"
+description = "Generic native toast bridge for Tauri"
+exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
+links = "tauri-plugin-toast"
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+tauri = { version = "2.0.0", features = [] }
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+
+[build-dependencies]
+tauri-plugin = { version = "2.0.0", features = ["build"] }
+
+[features]
+default = []

--- a/plugins/toast/README.md
+++ b/plugins/toast/README.md
@@ -1,0 +1,22 @@
+# tauri-plugin-toast
+
+Generic Android-first toast bridge plugin for Tauri v2.
+
+## Purpose
+
+This plugin exposes a minimal command surface to show native toast messages.
+It intentionally does not include app-specific alarm logic.
+
+## Command
+
+- `show`
+  - payload:
+    - `message` (required)
+    - `duration` (`short` | `long`, default `short`)
+    - `position` (`top` | `centre` | `bottom`, default `bottom`)
+
+## Platform support
+
+- Android: native `Toast`
+- Desktop: no-op
+- iOS: not currently supported by this plugin

--- a/plugins/toast/android/.gitignore
+++ b/plugins/toast/android/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.tauri

--- a/plugins/toast/android/build.gradle.kts
+++ b/plugins/toast/android/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.plugin.toast"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 21
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.0")
+    implementation("com.google.android.material:material:1.7.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    implementation(project(":tauri-android"))
+}

--- a/plugins/toast/android/proguard-rules.pro
+++ b/plugins/toast/android/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/plugins/toast/android/settings.gradle
+++ b/plugins/toast/android/settings.gradle
@@ -1,0 +1,31 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            switch (requested.id.id) {
+                case "com.android.library":
+                    useVersion("8.0.2")
+                    break
+                case "org.jetbrains.kotlin.android":
+                    useVersion("1.8.20")
+                    break
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        google()
+
+    }
+}
+
+include ':tauri-android'
+project(':tauri-android').projectDir = new File('./.tauri/tauri-api')

--- a/plugins/toast/android/src/androidTest/java/ExampleInstrumentedTest.kt
+++ b/plugins/toast/android/src/androidTest/java/ExampleInstrumentedTest.kt
@@ -1,0 +1,24 @@
+package com.plugin.toast
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        // Context of the app under test.
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("com.plugin.toast", appContext.packageName)
+    }
+}

--- a/plugins/toast/android/src/main/AndroidManifest.xml
+++ b/plugins/toast/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/plugins/toast/android/src/main/java/com/plugin/toast/Toast.kt
+++ b/plugins/toast/android/src/main/java/com/plugin/toast/Toast.kt
@@ -1,0 +1,24 @@
+package com.plugin.toast
+
+import android.app.Activity
+import android.view.Gravity
+import android.widget.Toast
+
+class ToastBridge(private val activity: Activity) {
+    fun show(message: String, duration: String?, position: String?) {
+        val toastDuration = when (duration?.lowercase()) {
+            "long" -> Toast.LENGTH_LONG
+            else -> Toast.LENGTH_SHORT
+        }
+
+        activity.runOnUiThread {
+            val toast = Toast.makeText(activity.applicationContext, message, toastDuration)
+            when (position?.lowercase()) {
+                "top" -> toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 180)
+                "centre" -> toast.setGravity(Gravity.CENTER, 0, 0)
+                else -> toast.setGravity(Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL, 0, 180)
+            }
+            toast.show()
+        }
+    }
+}

--- a/plugins/toast/android/src/main/java/com/plugin/toast/ToastPlugin.kt
+++ b/plugins/toast/android/src/main/java/com/plugin/toast/ToastPlugin.kt
@@ -1,0 +1,34 @@
+package com.plugin.toast
+
+import android.app.Activity
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.Plugin
+
+@InvokeArg
+class ShowToastArgs {
+    var message: String? = null
+    var duration: String? = null
+    var position: String? = null
+}
+
+@TauriPlugin
+class ToastPlugin(private val activity: Activity) : Plugin(activity) {
+    private val implementation = ToastBridge(activity)
+
+    @Command
+    fun show(invoke: Invoke) {
+        val args = invoke.parseArgs(ShowToastArgs::class.java)
+        val message = args.message?.trim()
+
+        if (message.isNullOrEmpty()) {
+            invoke.reject("message is required")
+            return
+        }
+
+        implementation.show(message, args.duration, args.position)
+        invoke.resolve()
+    }
+}

--- a/plugins/toast/android/src/test/java/ExampleUnitTest.kt
+++ b/plugins/toast/android/src/test/java/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package com.plugin.toast
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/plugins/toast/build.rs
+++ b/plugins/toast/build.rs
@@ -1,0 +1,23 @@
+const COMMANDS: &[&str] = &["show"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+
+    inject_android_permissions()
+        .expect("Failed to inject Android manifest permissions for toast");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions: Vec<&str> = vec![
+        // No explicit Android permissions required for Toast usage.
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-toast.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+}

--- a/plugins/toast/guest-js/index.ts
+++ b/plugins/toast/guest-js/index.ts
@@ -1,0 +1,20 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export type ToastDuration = 'short' | 'long';
+export type ToastPosition = 'top' | 'centre' | 'bottom';
+
+export interface ShowToastOptions {
+	message: string;
+	duration?: ToastDuration;
+	position?: ToastPosition;
+}
+
+export async function showToast(options: ShowToastOptions): Promise<void> {
+	await invoke('plugin:toast|show', {
+		payload: {
+			message: options.message,
+			duration: options.duration ?? 'short',
+			position: options.position ?? 'bottom',
+		},
+	});
+}

--- a/plugins/toast/package.json
+++ b/plugins/toast/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "tauri-plugin-toast-api",
+  "version": "0.1.0",
+  "author": "Threshold",
+  "description": "",
+  "type": "module",
+  "types": "./guest-js/index.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
+  "exports": {
+    "types": "./guest-js/index.ts",
+    "source": "./guest-js/index.ts",
+    "import": "./dist-js/index.js",
+    "require": "./dist-js/index.cjs",
+    "default": "./dist-js/index.js"
+  },
+  "files": [
+    "dist-js",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
+    "rollup": "^4.9.6",
+    "typescript": "^5.3.3",
+    "tslib": "^2.6.2"
+  }
+}

--- a/plugins/toast/permissions/autogenerated/commands/show.toml
+++ b/plugins/toast/permissions/autogenerated/commands/show.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-show"
+description = "Enables the show command without any pre-configured scope."
+commands.allow = ["show"]
+
+[[permission]]
+identifier = "deny-show"
+description = "Denies the show command without any pre-configured scope."
+commands.deny = ["show"]

--- a/plugins/toast/permissions/autogenerated/reference.md
+++ b/plugins/toast/permissions/autogenerated/reference.md
@@ -1,0 +1,56 @@
+## Default Permission
+
+Default permissions for the toast plugin
+
+#### This default permission set includes the following:
+
+- `allow-show`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`toast:allow-show`
+
+</td>
+<td>
+
+Enables the show command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`toast:deny-show`
+
+</td>
+<td>
+
+Denies the show command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`toast:allow-show`
+
+</td>
+<td>
+
+Enables the show command
+
+</td>
+</tr>
+</table>

--- a/plugins/toast/permissions/default.toml
+++ b/plugins/toast/permissions/default.toml
@@ -1,0 +1,10 @@
+[default]
+description = "Default permissions for the toast plugin"
+permissions = [
+    "allow-show",
+]
+
+[[permission]]
+identifier = "allow-show"
+description = "Enables the show command"
+commands.allow = ["show"]

--- a/plugins/toast/permissions/schemas/schema.json
+++ b/plugins/toast/permissions/schemas/schema.json
@@ -1,0 +1,324 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`"
+        },
+        {
+          "description": "Enables the show command",
+          "type": "string",
+          "const": "allow-show",
+          "markdownDescription": "Enables the show command"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/toast/rollup.config.js
+++ b/plugins/toast/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
+import typescript from '@rollup/plugin-typescript'
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
+
+export default {
+  input: 'guest-js/index.ts',
+  output: [
+    {
+      file: pkg.exports.import,
+      format: 'esm'
+    },
+    {
+      file: pkg.exports.require,
+      format: 'cjs'
+    }
+  ],
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: dirname(pkg.exports.import)
+    })
+  ],
+  external: [
+    /^@tauri-apps\/api/,
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ]
+}

--- a/plugins/toast/src/commands.rs
+++ b/plugins/toast/src/commands.rs
@@ -1,0 +1,10 @@
+use tauri::{command, AppHandle, Runtime};
+
+use crate::models::ShowToastRequest;
+use crate::Result;
+use crate::ToastExt;
+
+#[command]
+pub(crate) async fn show<R: Runtime>(app: AppHandle<R>, payload: ShowToastRequest) -> Result<()> {
+    app.toast().show(payload)
+}

--- a/plugins/toast/src/desktop.rs
+++ b/plugins/toast/src/desktop.rs
@@ -1,0 +1,21 @@
+use serde::de::DeserializeOwned;
+use tauri::{plugin::PluginApi, AppHandle, Runtime};
+
+use crate::models::ShowToastRequest;
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> crate::Result<Toast<R>> {
+    Ok(Toast(app.clone()))
+}
+
+/// Access to the toast APIs.
+pub struct Toast<R: Runtime>(AppHandle<R>);
+
+impl<R: Runtime> Toast<R> {
+    pub fn show(&self, _payload: ShowToastRequest) -> crate::Result<()> {
+        // Desktop is intentionally a no-op for now.
+        Ok(())
+    }
+}

--- a/plugins/toast/src/error.rs
+++ b/plugins/toast/src/error.rs
@@ -1,0 +1,21 @@
+use serde::{ser::Serializer, Serialize};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+  #[error(transparent)]
+  Io(#[from] std::io::Error),
+  #[cfg(mobile)]
+  #[error(transparent)]
+  PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+}
+
+impl Serialize for Error {
+  fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(self.to_string().as_ref())
+  }
+}

--- a/plugins/toast/src/lib.rs
+++ b/plugins/toast/src/lib.rs
@@ -1,0 +1,48 @@
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+
+pub use models::*;
+
+#[cfg(desktop)]
+mod desktop;
+#[cfg(mobile)]
+mod mobile;
+
+mod commands;
+mod error;
+mod models;
+
+pub use error::{Error, Result};
+
+#[cfg(desktop)]
+use desktop::Toast;
+#[cfg(mobile)]
+use mobile::Toast;
+
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the toast APIs.
+pub trait ToastExt<R: Runtime> {
+    fn toast(&self) -> &Toast<R>;
+}
+
+impl<R: Runtime, T: Manager<R>> ToastExt<R> for T {
+    fn toast(&self) -> &Toast<R> {
+        self.state::<Toast<R>>().inner()
+    }
+}
+
+/// Initializes the plugin.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("toast")
+        .invoke_handler(tauri::generate_handler![commands::show])
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let toast = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let toast = desktop::init(app, api)?;
+            app.manage(toast);
+            Ok(())
+        })
+        .build()
+}

--- a/plugins/toast/src/mobile.rs
+++ b/plugins/toast/src/mobile.rs
@@ -1,0 +1,39 @@
+use serde::de::DeserializeOwned;
+use tauri::{
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+use crate::models::ShowToastRequest;
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> crate::Result<Toast<R>> {
+    #[cfg(not(target_os = "android"))]
+    let _ = &api;
+
+    #[cfg(target_os = "android")]
+    {
+        let handle = api.register_android_plugin("com.plugin.toast", "ToastPlugin")?;
+        return Ok(Toast(handle));
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "tauri-plugin-toast currently supports Android only",
+        )
+        .into())
+    }
+}
+
+/// Access to the toast APIs.
+pub struct Toast<R: Runtime>(PluginHandle<R>);
+
+impl<R: Runtime> Toast<R> {
+    pub fn show(&self, payload: ShowToastRequest) -> crate::Result<()> {
+        self.0.run_mobile_plugin("show", payload).map_err(Into::into)
+    }
+}

--- a/plugins/toast/src/models.rs
+++ b/plugins/toast/src/models.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToastDuration {
+    Short,
+    Long,
+}
+
+impl Default for ToastDuration {
+    fn default() -> Self {
+        Self::Short
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToastPosition {
+    Top,
+    Centre,
+    Bottom,
+}
+
+impl Default for ToastPosition {
+    fn default() -> Self {
+        Self::Bottom
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShowToastRequest {
+    pub message: String,
+    #[serde(default)]
+    pub duration: ToastDuration,
+    #[serde(default)]
+    pub position: ToastPosition,
+}

--- a/plugins/toast/tsconfig.json
+++ b/plugins/toast/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["guest-js/*.ts"],
+  "exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       tauri-plugin-app-events-api:
         specifier: ^0.2.0
         version: 0.2.0
+      tauri-plugin-toast-api:
+        specifier: workspace:*
+        version: link:../../plugins/toast
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2
@@ -133,6 +136,25 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.9)(jsdom@27.4.0)
+
+  plugins/toast:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.9.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
 
 packages:
 
@@ -786,6 +808,28 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rollup/plugin-typescript@12.3.0':
+    resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
     cpu: [arm]
@@ -1289,6 +1333,9 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2484,6 +2531,23 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/plugin-typescript@12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
+      resolve: 1.22.11
+      typescript: 5.8.3
+    optionalDependencies:
+      rollup: 4.55.1
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.55.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.55.1
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -2988,6 +3052,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:


### PR DESCRIPTION
**Summary**
- add a new Android-first `tauri-plugin-toast` plugin
- wire plugin registration into Threshold runtime and capabilities
- expose a generic `showToast` guest JS API for app integration

**What changed**
- plugin scaffold and implementation in `plugins/toast/`
- workspace + Cargo wiring updates
- capability addition: `toast:default`

**Validation**
- `cargo check -p tauri-plugin-toast`
- `cargo check -p threshold`

Resolves #140
