### PR TITLE
Schedule upcoming alarm notifications with label and window-aware copy

### DIFF
--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -219,4 +219,28 @@ describe('AlarmManagerService', () => {
 			}),
 		);
 	});
+
+	it('routes upcoming dismiss actions to dismiss-next-occurrence handler', async () => {
+		const service = new AlarmManagerService();
+		(PlatformUtils.isMobile as any).mockReturnValue(true);
+		let actionCallback: ((notification: any) => Promise<void>) | null = null;
+
+		(onAction as any).mockImplementation(async (cb: (notification: any) => Promise<void>) => {
+			actionCallback = cb;
+			return undefined;
+		});
+
+		const dismissSpy = vi.spyOn(service as any, 'dismissNextOccurrence').mockResolvedValue(undefined);
+
+		await service.init();
+		expect(actionCallback).not.toBeNull();
+
+		await actionCallback!({
+			actionTypeId: 'upcoming_alarm',
+			actionId: 'dismiss_alarm',
+			id: 1_000_009,
+		});
+
+		expect(dismissSpy).toHaveBeenCalledWith(9);
+	});
 });

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -161,6 +161,16 @@ export class AlarmManagerService {
 									},
 								],
 							},
+							{
+								id: 'upcoming_alarm',
+								actions: [
+									{
+										id: 'dismiss_alarm',
+										title: 'Dismiss alarm',
+										foreground: false,
+									},
+								],
+							},
 						]);
 
 						await onAction(async (notification) => {
@@ -210,6 +220,27 @@ export class AlarmManagerService {
 									const snoozeLength = SettingsService.getSnoozeLength();
 									// Snooze again
 									await this.snoozeAlarm(alarmId, snoozeLength);
+								}
+								return;
+							}
+
+							if (actionTypeId === 'upcoming_alarm') {
+								if (!alarmId) {
+									console.error('[AlarmManager] Upcoming action missing notification ID');
+									return;
+								}
+
+								const upcomingAlarmId = this.getAlarmIdFromUpcomingNotificationId(alarmId);
+								if (!upcomingAlarmId) {
+									console.error(
+										`[AlarmManager] Invalid upcoming notification ID received: ${alarmId}`,
+									);
+									return;
+								}
+
+								if (actionId === 'dismiss_alarm') {
+									console.log('[AlarmManager] Action: Dismiss upcoming alarm', upcomingAlarmId);
+									await this.dismissNextOccurrence(upcomingAlarmId);
 								}
 								return;
 							}
@@ -270,6 +301,11 @@ export class AlarmManagerService {
 		return UPCOMING_NOTIFICATION_ID_OFFSET + alarmId;
 	}
 
+	private getAlarmIdFromUpcomingNotificationId(notificationId: number): number | null {
+		const alarmId = notificationId - UPCOMING_NOTIFICATION_ID_OFFSET;
+		return alarmId > 0 ? alarmId : null;
+	}
+
 	private getUpcomingTitle(alarm: Alarm, is24h: boolean): string {
 		if (alarm.mode === AlarmMode.RandomWindow && alarm.windowStart && alarm.windowEnd) {
 			const start = TimeFormatHelper.formatTimeString(alarm.windowStart, is24h);
@@ -316,12 +352,28 @@ export class AlarmManagerService {
 				id: notificationId,
 				title: this.getUpcomingTitle(alarm, is24h),
 				body: this.getUpcomingBody(alarm, nextTrigger, is24h),
+				actionTypeId: 'upcoming_alarm',
 				autoCancel: true,
 				schedule: shouldSendImmediately ? undefined : Schedule.at(new Date(notifyAt), false, true),
 			});
 		} catch (e) {
 			console.error(`[AlarmManager] Failed to schedule upcoming notification for alarm ${alarm.id}`, e);
 		}
+	}
+
+	private async dismissNextOccurrence(alarmId: number): Promise<void> {
+		const alarm = await this.getAlarm(alarmId);
+		if (!alarm || !alarm.nextTrigger) {
+			console.error(`[AlarmManager] Cannot dismiss next occurrence for alarm ${alarmId}: not found`);
+			return;
+		}
+
+		await this.cancelNativeAlarm(alarmId);
+		await this.cancelUpcomingNotification(alarmId);
+		await this.saveAndSchedule({
+			...alarm,
+			lastFiredAt: alarm.nextTrigger,
+		});
 	}
 
 	private async markAlarmFired(id: number, firedAt: number) {


### PR DESCRIPTION
**Summary**
- schedule upcoming alarm notifications with fixed and random-window copy variants
- include alarm label in body and immediate-send behaviour for under-10-minute cases
- keep upcoming notifications in sync across alarm lifecycle changes

**What changed**
- upcoming notification scheduling/cancellation logic in `AlarmManagerService`
- copy helpers for title/body formatting
- tests for immediate and delayed scheduling paths

**Validation**
- `pnpm exec vitest run src/services/AlarmManagerService.test.ts`
- `pnpm --filter threshold build`

Resolves #137
