### PR TITLE
⚡ Optimize Home screen rendering by removing synchronous storage read

### DIFF
--- a/apps/threshold/src/screens/Home.perf.test.tsx
+++ b/apps/threshold/src/screens/Home.perf.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import Home from './Home';
+import { SettingsService } from '../services/SettingsService';
+import { alarmManagerService } from '../services/AlarmManagerService';
+
+// Mock dependencies
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../services/AlarmManagerService', () => ({
+    alarmManagerService: {
+        init: vi.fn().mockResolvedValue(undefined),
+        loadAlarms: vi.fn().mockResolvedValue([]),
+        toggleAlarm: vi.fn(),
+        deleteAlarm: vi.fn(),
+    },
+}));
+
+vi.mock('../components/MobileToolbar', () => ({
+    MobileToolbar: () => <div>Toolbar</div>,
+}));
+
+vi.mock('../components/AlarmItem', () => ({
+    AlarmItem: () => <div>AlarmItem</div>,
+}));
+
+vi.mock('../utils/PlatformUtils', () => ({
+    PlatformUtils: {
+        isMobile: vi.fn().mockReturnValue(false),
+    },
+}));
+
+// Mock SettingsService
+vi.mock('../services/SettingsService', () => ({
+    SettingsService: {
+        getIs24h: vi.fn().mockReturnValue(true),
+    },
+}));
+
+// Mock Tauri APIs
+vi.mock('@tauri-apps/api/event', () => ({
+    emit: vi.fn(),
+    listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+describe('Home Screen Performance', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should access SettingsService.getIs24h() only once on mount', async () => {
+        // Setup initial alarms to cause a state update
+        const alarms = [{ id: 1, time: '10:00', enabled: true, label: 'Test', days: [], soundUri: '' }];
+        (alarmManagerService.loadAlarms as any).mockResolvedValue(alarms);
+
+        // Render
+        render(<Home />);
+
+        // Initial render (Mount) -> getIs24h called once.
+        // useEffect -> loadData -> loadAlarms -> setAlarms(alarms) -> Re-render.
+        // Re-render -> getIs24h called again (if unoptimized).
+
+        await waitFor(() => expect(alarmManagerService.loadAlarms).toHaveBeenCalled());
+
+        // Wait for potential re-renders to settle
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const callCount = (SettingsService.getIs24h as any).mock.calls.length;
+        console.log(`[Perf Baseline] SettingsService.getIs24h called ${callCount} times`);
+
+        // Expectation for optimized code: strictly 1 call
+        expect(callCount).toBe(1);
+    });
+});

--- a/apps/threshold/src/screens/Home.tsx
+++ b/apps/threshold/src/screens/Home.tsx
@@ -21,14 +21,29 @@ import { alarmManagerService } from '../services/AlarmManagerService';
 import { AlarmItem } from '../components/AlarmItem';
 import { SettingsService } from '../services/SettingsService';
 import { APP_NAME } from '../constants';
+import { listen } from '@tauri-apps/api/event';
 
 const Home: React.FC = () => {
     const navigate = useNavigate();
     const [alarms, setAlarms] = useState<Alarm[]>([]);
     const [isMobile, setIsMobile] = useState(false);
-    const is24h = SettingsService.getIs24h();
+    const [is24h, setIs24h] = useState(() => SettingsService.getIs24h());
+
     useEffect(() => {
         setIsMobile(PlatformUtils.isMobile());
+    }, []);
+
+    // Listen for settings changes to update is24h
+    useEffect(() => {
+        const unlistenPromise = listen<any>('settings-changed', (event) => {
+            if (event.payload.key === 'is24h') {
+                setIs24h(event.payload.value);
+            }
+        });
+
+        return () => {
+            unlistenPromise.then((unlisten) => unlisten());
+        };
     }, []);
 
     const handleSettingsClick = () => {

--- a/apps/threshold/src/screens/Home.tsx
+++ b/apps/threshold/src/screens/Home.tsx
@@ -23,6 +23,11 @@ import { SettingsService } from '../services/SettingsService';
 import { APP_NAME } from '../constants';
 import { listen } from '@tauri-apps/api/event';
 
+interface SettingsChangedEvent {
+    key: string;
+    value: boolean | string | number;
+}
+
 const Home: React.FC = () => {
     const navigate = useNavigate();
     const [alarms, setAlarms] = useState<Alarm[]>([]);
@@ -35,8 +40,8 @@ const Home: React.FC = () => {
 
     // Listen for settings changes to update is24h
     useEffect(() => {
-        const unlistenPromise = listen<any>('settings-changed', (event) => {
-            if (event.payload.key === 'is24h') {
+        const unlistenPromise = listen<SettingsChangedEvent>('settings-changed', (event) => {
+            if (event.payload.key === 'is24h' && typeof event.payload.value === 'boolean') {
                 setIs24h(event.payload.value);
             }
         });


### PR DESCRIPTION
💡 **What:** 
- Refactored `Home.tsx` to initialize `is24h` state lazily using `useState(() => SettingsService.getIs24h())`.
- Added a `useEffect` hook to listen for `settings-changed` events and update the `is24h` state dynamically.
- Included a regression test `Home.perf.test.tsx` to verify the optimization.

🎯 **Why:** 
- `SettingsService.getIs24h()` performs a synchronous `localStorage` read, which was previously executing on every render of the `Home` component. This optimization moves the read to the initialization phase (mounting only), improving render performance.

📊 **Measured Improvement:** 
- **Baseline:** `SettingsService.getIs24h()` was called 2 times during a standard render/update cycle in tests.
- **Optimized:** `SettingsService.getIs24h()` is now called strictly 1 time (on mount).
- Verified via `apps/threshold/src/screens/Home.perf.test.tsx`.

---
*PR created automatically by Jules for task [2859715591558299929](https://jules.google.com/task/2859715591558299929) started by @ScottMorris*