### PR TITLE
Finalize 0.1.7 release flow, notes, and Play release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - [Localization and Spelling](#localization-and-spelling)
 - [Commit Messages](#commit-messages)
+- [Play Console Release Notes](#play-console-release-notes)
 - [Pull Request Titles](#pull-request-titles)
 - [Application Protocol](#application-protocol)
 - [Code Organization](#code-organization)
@@ -45,6 +46,28 @@ Examples:
 - Prefer writing the message to a file with a single-quoted heredoc and commit with `git commit -F <file>` to prevent shell expansion.
 - If using `-m`, escape shell-sensitive characters explicitly before running the command.
 - After committing, verify the stored message with `git log -1 --pretty=fuller` and amend immediately if interpolation altered content.
+
+## Play Console Release Notes
+
+When drafting release notes for Google Play Console:
+
+- Always use locale blocks in this exact format:
+
+```text
+<en-CA>
+Enter or paste your release notes for en-CA here
+</en-CA>
+```
+
+- Keep each locale block at **500 Unicode characters or fewer**.
+- For this repository, provide **separate sections** for:
+  - Threshold phone app release notes
+  - Threshold Wear OS companion app release notes
+- Use compact, user-facing language suitable for Play Console.
+- Prefer concise headings and bullets (for example: "What's New", "Fixes", "Improvements").
+- Include emoji-led mini headings (for example: `⌚`, `🔔`, `🐛`, `🛠️`) to match the established Play Console style.
+- Use the `•` bullet character inside locale blocks (not markdown `-`) to match accepted Play Console formatting.
+- Keep spelling in Canadian English.
 
 ## Pull Request Titles
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,106 @@ This document tracks all releases of the Threshold application.
 
 ---
 
+## Version 0.1.7
+
+**Release Date:** February 19, 2026  
+**Status:** Released
+
+> [!IMPORTANT]
+> Version `0.1.6` was superseded by `0.1.7` due to a Wear OS versionCode collision risk. Use `0.1.7` as the canonical release for this cycle.
+
+> [!NOTE]
+> This release window includes substantial platform work since `0.1.5`: Wear OS companion delivery, event-driven sync architecture, alarm pipeline refactoring, upcoming reminder actions, and release tooling improvements.
+
+### ✨ New Features
+
+**Wear OS Companion App**
+
+- Shipped the Wear OS companion app with alarms list, edit/toggle flows, and mobile-linked synchronisation
+- Added Tile + Complication support for next-upcoming alarm visibility
+- Applied Material You dynamic accent support with static fallback
+- Added branded launcher icon integration for the watch app
+- Included release/build integration for Wear in the release tooling
+
+**Wear Sync Plugin and Sync Protocol**
+
+- Implemented full Wear sync plugin foundation across Kotlin and Rust bridges
+- Added incremental sync protocol with monotonic revisions
+- Added conflict detection for stale writes and per-alarm revision validation
+- Added offline write queueing and replay for disconnected scenarios
+- Added full sync payload support, lifecycle signalling, and queue readiness coordination
+
+**Alarm Platform Architecture**
+
+- Implemented Rust core alarm scheduler with window randomisation
+- Added Rust SQLite alarm data layer and coordinator wiring
+- Implemented `AlarmService` and migrated UI away from legacy data service patterns
+- Removed legacy `DatabaseService` in favour of unified service paths
+- Added Android boot recovery and event-driven scheduler architecture updates
+
+**Upcoming Reminder Actions**
+
+- Added Android upcoming notification actions for snooze and dismiss
+- Added upcoming alarm scheduling with label/window-aware copy
+- Added Android toast plugin integration for action feedback
+- Fixed startup rehydration and snooze action label refresh behaviour
+
+### 🐛 Bug Fixes
+
+**Wear Sync and App Reliability**
+
+- Fixed stale write rejection, launch argument parsing, and Kotlin mobile init fallback safety
+- Fixed alarm tap dispatch, crown rotary scrolling, and tile/complication selection edge cases
+- Fixed modern Wear message intent filter usage and plugin permission schema duplication
+- Hardened stale toggle recovery and cold-boot behaviour
+
+**Build and Release Tooling**
+
+- Added interactive release version TUI for phone + Wear lockstep updates
+- Added keyboard and mouse-driven TUI controls, terminal resize redraw handling, and improved UX flow
+- Added `pnpm build:release` wrapper for release devcontainer builds
+- Updated release versioning logic to avoid Wear/phone versionCode collisions:
+  - `phoneVC = M*1,000,000 + m*1,000 + p`
+  - `watchVC = phoneVC + 1,000,000,000`
+
+### 📚 Documentation and Testing
+
+- Added and updated Wear companion architecture, setup, troubleshooting, and testing documentation
+- Reorganised and normalised documentation structure with clearer references
+- Added Mermaid linting and CI annotations for diagram quality
+- Added Wear app unit tests and CI integration
+- Expanded wear-sync tests for sync/conflict and queue behaviour
+
+### 📝 Technical Details
+
+**Major PRs Merged (selected):**
+
+- [#98](https://github.com/liminal-hq/threshold/pull/98) - Add Wear OS Watch Companion App
+- [#154](https://github.com/liminal-hq/threshold/pull/154) - Complete Wear OS companion support
+- [#130](https://github.com/liminal-hq/threshold/pull/130) - Wear-sync scaffold, BatchCollector, and Kotlin stubs
+- [#129](https://github.com/liminal-hq/threshold/pull/129) - Implement granular event system with monotonic revisions
+- [#110](https://github.com/liminal-hq/threshold/pull/110) - Event-driven architecture and Android boot recovery
+- [#106](https://github.com/liminal-hq/threshold/pull/106) - Migrate UI to AlarmService and event-driven architecture
+- [#105](https://github.com/liminal-hq/threshold/pull/105) - Implement AlarmService and types
+- [#103](https://github.com/liminal-hq/threshold/pull/103) - Implement AlarmCoordinator and Tauri wiring
+- [#101](https://github.com/liminal-hq/threshold/pull/101) - Implement Rust SQLite database layer
+- [#99](https://github.com/liminal-hq/threshold/pull/99) - Implement alarm scheduler logic in Rust core
+- [#145](https://github.com/liminal-hq/threshold/pull/145) - Add upcoming snooze action with next-occurrence scope
+- [#147](https://github.com/liminal-hq/threshold/pull/147) - Fix upcoming reminder rehydration and snooze action label refresh
+- [#160](https://github.com/liminal-hq/threshold/pull/160) - Modernize release version TUI and add release build shortcut
+
+**Release and Follow-up Issues:**
+
+- [#161](https://github.com/liminal-hq/threshold/issues/161) - Release TUI should create a dedicated version bump commit before tagging
+
+**Commit/Contributor Summary (`0.1.5` → `0.1.7`):**
+
+- **Commits:** 166
+- **Merged PRs:** 22
+- **Contributors:** Scott Morris, google-labs-jules[bot]
+
+---
+
 ## Version 0.1.5
 
 **Release Date:** February 7, 2026  

--- a/apps/threshold-wear/build.gradle.kts
+++ b/apps/threshold-wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ca.liminalhq.threshold"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1006
-        versionName = "0.1.6"
+        versionCode = 1000001007
+        versionName = "0.1.7"
     }
 
     signingConfigs {

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "threshold",
 	"private": true,
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -50,9 +50,9 @@
                 android:resource="@xml/file_paths" />
         </provider>
     </application>
-    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     
-    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <!-- tauri-plugin-alarm-manager.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
@@ -65,9 +65,9 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <!-- tauri-plugin-alarm-manager.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
-    <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     
-    <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     
     <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->

--- a/apps/threshold/src-tauri/tauri.conf.json
+++ b/apps/threshold/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Threshold",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"identifier": "ca.liminalhq.threshold",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- improve release TUI behaviour for same-version runs and tag conflict handling
- switch Wear versionCode derivation to a collision-safe range
- expand release notes coverage for `0.1.7` and mark `0.1.6` as superseded
- document Play Console release-note formatting conventions in `AGENTS.md`

## Key Changes
- `scripts/update-release-version.mjs`
  - derive Wear versionCode as `phoneVC + 1,000,000,000`
  - remove manual Wear versionCode prompt
  - allow no-op file updates to continue into tag workflow
  - improve tag-conflict defaults to avoid dead-end loops
- `RELEASE_NOTES.md`
  - add comprehensive `0.1.7` section based on work since `0.1.5`
- `AGENTS.md`
  - add Play Console release-note guidance (`<en-CA>`, 500 char limit, emoji headings, `•` bullets)

## Validation
- `node --check scripts/update-release-version.mjs`

## Release Status
- `v0.1.7` has been released to Google Play.
- Current tag target: `2ed7f9d` (`fix(release): improve same-version flow and wear version code derivation`).
