### PR TITLE
Create A Dedicated Release Bump Commit Before Tagging

### DIFF
--- a/apps/threshold-wear/README.md
+++ b/apps/threshold-wear/README.md
@@ -315,7 +315,7 @@ The release TUI supports:
 - right click (or a mouse back button) for back actions where supported
 - terminal resize redraw while the TUI is running
 
-It also validates release tags before applying updates.
+It also validates release tags, can create a dedicated release bump commit, and can place the local release tag on that bump commit.
 
 For development with a watch emulator, pair a Wear OS emulator with a phone emulator in Android Studio and deploy to the watch target.
 


### PR DESCRIPTION
## Summary
- add an explicit automatic mode in the release TUI to create a dedicated version bump commit before tagging
- keep manual commit/tag behaviour available as an opt-out path
- show the commit + tag plan in the review step before apply
- warn when unrelated staged/unstaged changes exist and require confirmation to continue
- update release flow documentation in the Wear README

## Testing
- ran `node --check scripts/update-release-version.mjs`
- verified the release flow in terminal and confirmed generated release commit + tag behaviour

Closes #161
