### PR TITLE
Add CI Kotlin Tests For Core Plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,7 @@ jobs:
       packages: read
     container:
       image: ghcr.io/liminal-hq/threshold/ci-base:latest
+      options: --user root
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -151,8 +152,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /home/vscode/.gradle/caches
-            /home/vscode/.gradle/wrapper
+            /github/home/.gradle/caches
+            /github/home/.gradle/wrapper
           key: ${{ runner.os }}-gradle-kotlin-${{ hashFiles('apps/threshold-wear/**/*.gradle*', 'apps/threshold-wear/**/gradle-wrapper.properties', 'apps/threshold-wear/gradle/libs.versions.toml', 'plugins/**/android/**/*.gradle*', 'plugins/**/android/**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-kotlin-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            /home/vscode/.gradle/caches
+            /home/vscode/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-kotlin-${{ hashFiles('apps/threshold-wear/**/*.gradle*', 'apps/threshold-wear/**/gradle-wrapper.properties', 'apps/threshold-wear/gradle/libs.versions.toml', 'plugins/**/android/**/*.gradle*', 'plugins/**/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-kotlin-
+
       - name: Run Wear app unit tests
         working-directory: apps/threshold-wear
         run: ./gradlew testDebugUnitTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,7 @@ jobs:
               print substr($0, RSTART + 1, RLENGTH - 2);
               exit
             }
-          ' apps/threshold/src-tauri/Cargo.lock)"
+          ' Cargo.lock)"
           if [ -z "${TAURI_VERSION}" ]; then
             echo "Failed to determine tauri version from Cargo.lock"
             exit 1
@@ -199,8 +199,8 @@ jobs:
             resolutionStrategy {
               eachPlugin {
                 when (requested.id.id) {
-                  "com.android.library" -> useVersion("8.0.2")
-                  "org.jetbrains.kotlin.android" -> useVersion("1.8.20")
+                  "com.android.library" -> useVersion("8.11.0")
+                  "org.jetbrains.kotlin.android" -> useVersion("1.9.25")
                 }
               }
             }
@@ -232,10 +232,10 @@ jobs:
                   eachPlugin {
                       switch (requested.id.id) {
                           case "com.android.library":
-                              useVersion("8.0.2")
+                              useVersion("8.11.0")
                               break
                           case "org.jetbrains.kotlin.android":
-                              useVersion("1.8.20")
+                              useVersion("1.9.25")
                               break
                       }
                   }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,27 +133,19 @@ jobs:
 
   test-kotlin:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/liminal-hq/threshold/ci-base:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: gradle
-          cache-dependency-path: |
-            apps/threshold-wear/**/*.gradle*
-            apps/threshold-wear/**/gradle-wrapper.properties
-            apps/threshold-wear/gradle/libs.versions.toml
-            plugins/**/android/**/*.gradle*
-            plugins/**/android/**/gradle-wrapper.properties
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3.2.2
 
       - name: Run Wear app unit tests
         working-directory: apps/threshold-wear

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
       # - name: Rust Clippy
       #   run: cargo clippy --all-features -- -D warnings
 
-  test-kotlin:
+  test-kotlin-wear:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -154,13 +154,47 @@ jobs:
           path: |
             /github/home/.gradle/caches
             /github/home/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-kotlin-${{ hashFiles('apps/threshold-wear/**/*.gradle*', 'apps/threshold-wear/**/gradle-wrapper.properties', 'apps/threshold-wear/gradle/libs.versions.toml', 'plugins/**/android/**/*.gradle*', 'plugins/**/android/**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-wear-${{ hashFiles('apps/threshold-wear/**/*.gradle*', 'apps/threshold-wear/**/gradle-wrapper.properties', 'apps/threshold-wear/gradle/libs.versions.toml') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-kotlin-
+            ${{ runner.os }}-gradle-wear-
 
       - name: Run Wear app unit tests
         working-directory: apps/threshold-wear
         run: ./gradlew testDebugUnitTest
+
+      - name: Upload Kotlin Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: kotlin-wear-test-results
+          path: apps/threshold-wear/build/test-results/**/*.xml
+
+  test-kotlin-plugins:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/liminal-hq/threshold/ci-base:latest
+      options: --user root
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            /github/home/.gradle/caches
+            /github/home/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-plugins-${{ hashFiles('plugins/**/android/**/*.gradle*', 'plugins/**/android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-plugins-
 
       - name: Run core plugin Android unit tests
         run: |
@@ -273,15 +307,13 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: kotlin-test-results
-          path: |
-            apps/threshold-wear/build/test-results/**/*.xml
-            plugins/**/android/build/test-results/**/*.xml
+          name: kotlin-plugin-test-results
+          path: plugins/**/android/build/test-results/**/*.xml
 
   report:
     runs-on: ubuntu-24.04
     if: always()
-    needs: [test-js, test-rust, test-kotlin, lint-mermaid]
+    needs: [test-js, test-rust, test-kotlin-wear, test-kotlin-plugins, lint-mermaid]
     permissions:
       contents: read
       checks: write
@@ -304,11 +336,17 @@ jobs:
           name: rust-test-results
           path: test-results/rust
 
-      - name: Download Kotlin Test Results
+      - name: Download Kotlin Wear Test Results
         uses: actions/download-artifact@v8
         with:
-          name: kotlin-test-results
-          path: test-results/kotlin
+          name: kotlin-wear-test-results
+          path: test-results/kotlin-wear
+
+      - name: Download Kotlin Plugin Test Results
+        uses: actions/download-artifact@v8
+        with:
+          name: kotlin-plugin-test-results
+          path: test-results/kotlin-plugins
 
       - name: Publish Test Report
         uses: dorny/test-reporter@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,14 +161,50 @@ jobs:
         run: ./gradlew testDebugUnitTest
 
       - name: Run core plugin Android unit tests
-        working-directory: apps/threshold/src-tauri/gen/android
         run: |
-          ./gradlew \
-            :tauri-plugin-alarm-manager:testDebugUnitTest \
-            :tauri-plugin-app-management:testDebugUnitTest \
-            :tauri-plugin-theme-utils:testDebugUnitTest \
-            :tauri-plugin-time-prefs:testDebugUnitTest \
-            :tauri-plugin-wear-sync:testDebugUnitTest
+          ensure_plugin_settings() {
+            local plugin_dir="$1"
+            cat > "${plugin_dir}/settings.gradle.kts" <<'EOF'
+          pluginManagement {
+            repositories {
+              mavenCentral()
+              gradlePluginPortal()
+              google()
+            }
+            resolutionStrategy {
+              eachPlugin {
+                when (requested.id.id) {
+                  "com.android.library" -> useVersion("8.0.2")
+                  "org.jetbrains.kotlin.android" -> useVersion("1.8.20")
+                }
+              }
+            }
+          }
+
+          dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+              mavenCentral()
+              google()
+            }
+          }
+
+          include(":tauri-android")
+          project(":tauri-android").projectDir = file(".tauri/tauri-api")
+          EOF
+          }
+
+          ensure_plugin_settings "plugins/alarm-manager/android"
+          ensure_plugin_settings "plugins/theme-utils/android"
+          ensure_plugin_settings "plugins/time-prefs/android"
+          ensure_plugin_settings "plugins/wear-sync/android"
+
+          ./apps/threshold-wear/gradlew -p plugins/alarm-manager/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/app-management/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/theme-utils/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/time-prefs/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/wear-sync/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/toast/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
 
       - name: Upload Kotlin Test Results
         uses: actions/upload-artifact@v7
@@ -177,7 +213,7 @@ jobs:
           name: kotlin-test-results
           path: |
             apps/threshold-wear/build/test-results/**/*.xml
-            apps/threshold/src-tauri/gen/android/**/build/test-results/**/*.xml
+            plugins/**/android/build/test-results/**/*.xml
 
   report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,9 +149,8 @@ jobs:
             apps/threshold-wear/**/*.gradle*
             apps/threshold-wear/**/gradle-wrapper.properties
             apps/threshold-wear/gradle/libs.versions.toml
-            apps/threshold/src-tauri/gen/android/**/*.gradle*
-            apps/threshold/src-tauri/gen/android/**/gradle-wrapper.properties
-            apps/threshold/src-tauri/gen/android/gradle/libs.versions.toml
+            plugins/**/android/**/*.gradle*
+            plugins/**/android/**/gradle-wrapper.properties
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.2
@@ -162,9 +161,32 @@ jobs:
 
       - name: Run core plugin Android unit tests
         run: |
-          ensure_plugin_settings() {
+          TAURI_VERSION="$(awk '
+            BEGIN { in_tauri = 0 }
+            /^\[\[package\]\]$/ { in_tauri = 0; next }
+            /^name = "tauri"$/ { in_tauri = 1; next }
+            in_tauri == 1 && /^version = "/ {
+              match($0, /"([^"]+)"/);
+              print substr($0, RSTART + 1, RLENGTH - 2);
+              exit
+            }
+          ' apps/threshold/src-tauri/Cargo.lock)"
+          if [ -z "${TAURI_VERSION}" ]; then
+            echo "Failed to determine tauri version from Cargo.lock"
+            exit 1
+          fi
+
+          mkdir -p .ci
+          curl -LsSf "https://crates.io/api/v1/crates/tauri/${TAURI_VERSION}/download" | tar -xz -C .ci
+          TAURI_ANDROID_PATH="$(pwd)/.ci/tauri-${TAURI_VERSION}/mobile/android"
+          if [ ! -f "${TAURI_ANDROID_PATH}/build.gradle.kts" ]; then
+            echo "tauri-android source not found at ${TAURI_ANDROID_PATH}"
+            exit 1
+          fi
+
+          write_kts_settings() {
             local plugin_dir="$1"
-            cat > "${plugin_dir}/settings.gradle.kts" <<'EOF'
+            cat > "${plugin_dir}/settings.gradle.kts" <<EOF
           pluginManagement {
             repositories {
               mavenCentral()
@@ -190,14 +212,52 @@ jobs:
           }
 
           include(":tauri-android")
-          project(":tauri-android").projectDir = file(".tauri/tauri-api")
+          project(":tauri-android").projectDir = file("${TAURI_ANDROID_PATH}")
           EOF
           }
 
-          ensure_plugin_settings "plugins/alarm-manager/android"
-          ensure_plugin_settings "plugins/theme-utils/android"
-          ensure_plugin_settings "plugins/time-prefs/android"
-          ensure_plugin_settings "plugins/wear-sync/android"
+          write_groovy_settings() {
+            local plugin_dir="$1"
+            cat > "${plugin_dir}/settings.gradle" <<EOF
+          pluginManagement {
+              repositories {
+                  mavenCentral()
+                  gradlePluginPortal()
+                  google()
+              }
+              resolutionStrategy {
+                  eachPlugin {
+                      switch (requested.id.id) {
+                          case "com.android.library":
+                              useVersion("8.0.2")
+                              break
+                          case "org.jetbrains.kotlin.android":
+                              useVersion("1.8.20")
+                              break
+                      }
+                  }
+              }
+          }
+
+          dependencyResolutionManagement {
+              repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+              repositories {
+                  mavenCentral()
+                  google()
+              }
+          }
+
+          include ':tauri-android'
+          project(':tauri-android').projectDir = new File('${TAURI_ANDROID_PATH}')
+          EOF
+          }
+
+          write_kts_settings "plugins/alarm-manager/android"
+          write_kts_settings "plugins/theme-utils/android"
+          write_kts_settings "plugins/time-prefs/android"
+          write_kts_settings "plugins/wear-sync/android"
+          write_groovy_settings "plugins/app-management/android"
+          write_groovy_settings "plugins/toast/android"
 
           ./apps/threshold-wear/gradlew -p plugins/alarm-manager/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
           ./apps/threshold-wear/gradlew -p plugins/app-management/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: gradle
+          cache-dependency-path: |
+            apps/threshold-wear/**/*.gradle*
+            apps/threshold-wear/**/gradle-wrapper.properties
+            apps/threshold-wear/gradle/libs.versions.toml
+            apps/threshold/src-tauri/gen/android/**/*.gradle*
+            apps/threshold/src-tauri/gen/android/**/gradle-wrapper.properties
+            apps/threshold/src-tauri/gen/android/gradle/libs.versions.toml
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.2
@@ -152,12 +160,24 @@ jobs:
         working-directory: apps/threshold-wear
         run: ./gradlew testDebugUnitTest
 
+      - name: Run core plugin Android unit tests
+        working-directory: apps/threshold/src-tauri/gen/android
+        run: |
+          ./gradlew \
+            :tauri-plugin-alarm-manager:testDebugUnitTest \
+            :tauri-plugin-app-management:testDebugUnitTest \
+            :tauri-plugin-theme-utils:testDebugUnitTest \
+            :tauri-plugin-time-prefs:testDebugUnitTest \
+            :tauri-plugin-wear-sync:testDebugUnitTest
+
       - name: Upload Kotlin Test Results
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: kotlin-test-results
-          path: apps/threshold-wear/build/test-results/**/*.xml
+          path: |
+            apps/threshold-wear/build/test-results/**/*.xml
+            apps/threshold/src-tauri/gen/android/**/build/test-results/**/*.xml
 
   report:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,7 @@ jobs:
           fi
 
           mkdir -p .ci
-          curl -LsSf "https://crates.io/api/v1/crates/tauri/${TAURI_VERSION}/download" | tar -xz -C .ci
+          curl -LsSf -A "liminal-hq/threshold CI (https://github.com/liminal-hq/threshold)" "https://crates.io/api/v1/crates/tauri/${TAURI_VERSION}/download" | tar -xz -C .ci
           TAURI_ANDROID_PATH="$(pwd)/.ci/tauri-${TAURI_VERSION}/mobile/android"
           if [ ! -f "${TAURI_ANDROID_PATH}/build.gradle.kts" ]; then
             echo "tauri-android source not found at ${TAURI_ANDROID_PATH}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - [Commit Messages](#commit-messages)
 - [Play Console Release Notes](#play-console-release-notes)
 - [Pull Request Titles](#pull-request-titles)
+- [Pull Request Labels](#pull-request-labels)
 - [Application Protocol](#application-protocol)
 - [Code Organization](#code-organization)
 - [Best Practices](#best-practices)
@@ -82,6 +83,15 @@ Enter or paste your release notes for en-CA here
 - If one title in a stack is updated, update the rest of the open stack titles to match style and scope.
 - Do not rename merged PRs unless explicitly requested.
 - Keep linked issues and merge order aligned after any title changes in a stack.
+
+## Pull Request Labels
+
+**REQUIREMENT:** Add labels to every PR when it is created or updated.
+
+- Apply labels that match scope and impact (for example: `build`, `plugin`, `android`, `release`, `bug`).
+- Prefer 2-4 labels that clearly describe the PR; avoid label spam.
+- Keep labels consistent across open PRs in the same stack.
+- If scope changes during review, update labels so they stay accurate.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- extend the Kotlin CI job to run Android unit tests for core plugin modules in `apps/threshold/src-tauri/gen/android`
- include generated Android Gradle files in the workflow cache dependency paths
- upload plugin test result XML files together with Wear Kotlin test reports

## Testing
- workflow change only
- plugin test tasks are now invoked in CI from the generated Android Gradle project
