### PR TITLE
Release version 0.1.8 updates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,58 @@ This document tracks all releases of the Threshold application.
 
 ---
 
+## Version 0.1.8
+
+**Release Date:** February 22, 2026  
+**Status:** Released
+
+> [!NOTE]
+> This release focuses on Android notification reliability, alarm rescheduling resilience, and stability improvements for phone and Wear OS companion interactions.
+
+### ✨ Improvements
+
+**Threshold Phone App**
+
+- Improved Android notification action replay and event-driven synchronisation reliability
+- Strengthened ringing flow resilience when ringing notification delivery fails
+- Normalised Android notification action payload parsing for more consistent callback handling
+- Reduced redundant native rescheduling when alarm triggers are unchanged
+- Improved upcoming alarm dismissal behaviour by skipping the current occurrence when appropriate
+
+**Threshold Wear OS Companion App**
+
+- Improved watch-to-phone action reliability through hardened payload handling and replay paths
+- Improved sync consistency during alarm and notification state updates shared with companion flows
+
+### 🐛 Bug Fixes
+
+- Fixed wrapped Android notification action payload handling edge cases
+- Fixed alarm rescheduling on sound changes with retry support after native failures
+- Fixed forwarded console argument serialisation for safer log ingestion
+
+### 🛠️ Build and Release
+
+- Added a Wear debug build helper script for faster companion debugging
+- Stabilised notification plugin dependency wiring with vendored workspace sources
+- Improved release workflow to ensure a dedicated version bump commit before tagging
+
+### 📝 Technical Details
+
+**Major PRs Merged (selected):**
+
+- [#166](https://github.com/liminal-hq/threshold/pull/166) - Stabilise Android notification action replay and plugin dependency wiring
+- [#167](https://github.com/liminal-hq/threshold/pull/167) - Create a dedicated release bump commit before tagging
+- [#163](https://github.com/liminal-hq/threshold/pull/163) - Restore notification parity and refine event-driven notification flows
+- [#162](https://github.com/liminal-hq/threshold/pull/162) - Finalize 0.1.7 release flow, notes, and Play release
+
+**Commit/Contributor Summary (`0.1.7` → `0.1.8`):**
+
+- **Commits:** 36
+- **Merged PRs:** 4
+- **Contributors:** Scott Morris
+
+---
+
 ## Version 0.1.7
 
 **Release Date:** February 19, 2026  

--- a/apps/threshold-wear/build.gradle.kts
+++ b/apps/threshold-wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ca.liminalhq.threshold"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1000001007
-        versionName = "0.1.7"
+        versionCode = 1000001008
+        versionName = "0.1.8"
     }
 
     signingConfigs {

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "threshold",
 	"private": true,
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/threshold/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -50,9 +50,15 @@
                 android:resource="@xml/file_paths" />
         </provider>
     </application>
+    <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    
+    <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     
     <!-- tauri-plugin-wear-sync.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
+    
+    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <!-- tauri-plugin-alarm-manager.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
@@ -65,10 +71,4 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <!-- tauri-plugin-alarm-manager.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
-    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
-    
-    <!-- tauri-plugin-time-prefs.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
-    <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
-    
-    <!-- tauri-plugin-toast.permissions. AUTO-GENERATED. DO NOT REMOVE. -->
 </manifest>

--- a/apps/threshold/src-tauri/tauri.conf.json
+++ b/apps/threshold/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Threshold",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"identifier": "ca.liminalhq.threshold",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bump Threshold phone and Wear app versions to `0.1.8`
- Update release notes for `0.1.8`
- Sync Android/Tauri release metadata for the new version

## Validation
- Confirmed version updates in app metadata files
- Confirmed `RELEASE_NOTES.md` includes `Version 0.1.8`
