### PR TITLE
Update Notification Plugin Lockfile to Rebasing Branch Head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4727,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
-source = "git+https://github.com/ScottMorris/tauri-plugins-workspace.git?branch=notification-actions-fix#c0992031493aeb06fdf8bba40aaea5ddd0c63cde"
+source = "git+https://github.com/ScottMorris/tauri-plugins-workspace.git?branch=notification-actions-fix#45004aa01a3b6752221142b42d8f1a48a7f65bc0"
 dependencies = [
  "log",
  "notify-rust",
@@ -5824,7 +5824,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update Cargo.lock to resolve tauri-plugin-notification from ScottMorris/tauri-plugins-workspace branch notification-actions-fix
- Point the lockfile revision at the rebased branch head so Threshold validates the latest notification plugin fixes

## Notes
- This PR intentionally contains only the lockfile update
- Follow-up updates to the plugin branch will be reflected by refreshing this lockfile if needed

## Related Upstream PRs
- Plugin implementation: tauri-apps/plugins-workspace#3296
- Companion docs update: tauri-apps/tauri-docs#3743