### PR TITLE
Guard release-trigger diff against an unresolvable before-SHA

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -85,7 +85,14 @@ jobs:
           fi
 
           if [ "$event_name" = "push" ] && [ "$ref_name" = "main" ]; then
-            changed_files="$(git diff --name-only "${{ github.event.before }}" "${GITHUB_SHA}")"
+            before_sha="${{ github.event.before }}"
+            if [ -z "$before_sha" ] || ! git cat-file -e "$before_sha" 2>/dev/null; then
+              echo "Cannot resolve previous commit (force-push or unknown history); skipping automatic release detection"
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            changed_files="$(git diff --name-only "$before_sha" "${GITHUB_SHA}")"
             if echo "$changed_files" | grep -q '^apps/threshold/package.json$'; then
               version="$(node -p "require('./apps/threshold/package.json').version")"
               echo "Release candidate merged to main; using tag v$version"


### PR DESCRIPTION
## Summary

- `prepare-release`'s release-trigger detection diffs `github.event.before` against `GITHUB_SHA` to spot a version-bump merge to `main`, but never checked that `before` still resolves to a real object.
- A force-push to `main` (today's PR #211 merge-commit redo) left the previous `before` SHA unreachable, so the job crashed with `fatal: bad object` / exit 128 instead of just skipping — even though no release was actually warranted (docs-only change, no `package.json` bump).
- Adds a `git cat-file -e` check before the diff; falls back to the existing `should_release=false` skip path if the commit can't be resolved, matching how the rest of the script already treats non-release pushes.

Relates to today's `main` force-push incident (see `docs/audits/2026-07-07-repo-audit.md` for the broader audit context this CI setup was surfaced from).

## Test plan

- [x] Reviewed the full `prepare-release` trigger-resolution script for other unvalidated push-event inputs — none found
- [ ] No local runner for `workflow_dispatch`/`push` event payloads; verifying by re-running the workflow after merge (the job is a shell script, no unit tests cover `.github/workflows/`)
