### PR TITLE
Run vitest in single-pass mode for apps/threshold's test script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ pnpm workspace monorepo + Cargo workspace:
 pnpm install                      # setup (Node 20+, pnpm, Rust stable)
 pnpm dev:desktop                  # run desktop app
 pnpm dev:android                  # run on Android (needs SDK/NDK)
-pnpm test                         # all workspace JS/TS tests (vitest)
-pnpm --filter threshold test      # app tests only (watch mode locally — Ctrl+C to exit)
+pnpm test                         # all workspace JS/TS tests (vitest run, single pass)
+pnpm --filter threshold test:watch  # app tests in watch mode
 cargo test --workspace            # Rust tests (app + plugins)
 pnpm format                       # prettier
 pnpm build:desktop | build:android | build:wear
@@ -96,8 +96,6 @@ plugins must be added to the root `Cargo.toml` workspace members and registered 
 
 ## Gotchas
 
-- `apps/threshold`'s `pnpm test` runs vitest in watch mode locally; CI passes because
-  vitest detects `CI`.
 - Capabilities live in `apps/threshold/src-tauri/capabilities/*.json`; a plugin command
   that works in Rust can still be ACL-denied from TS, and service code often swallows
   the error — check the ACL first when an invoke "does nothing".

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -8,7 +8,8 @@
 		"build": "tsc && vite build",
 		"preview": "vite preview",
 		"tauri": "tauri",
-		"test": "vitest",
+		"test": "vitest run",
+		"test:watch": "vitest",
 		"test:ci": "vitest run --reporter=junit --reporter=default --outputFile.junit=junit.xml"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

- `apps/threshold`'s `test` script ran plain `vitest`, which stays in watch mode locally, so `pnpm test` at the workspace root never exits during local dev. CI was never actually affected: it invokes `test:ci` (already `vitest run`), and vitest auto-disables watch when `CI` is set anyway.
- Changed `test` to `vitest run` (matching `packages/core`'s existing script) and added `test:watch` for anyone who wants the previous watch behaviour.
- Updated `CLAUDE.md`'s Commands and Gotchas sections, which documented the watch-mode hang as expected behaviour rather than a bug.

Closes #202.

## Test plan

- [x] `pnpm --filter threshold test` exits cleanly, 40/40 passing, exit code 0
- [x] `pnpm test` from the workspace root exits cleanly (all packages)
- [x] `packages/core` and CI's `test:ci` path unaffected (unchanged)
