### PR TITLE
Add a TypeScript type-check step, gated in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type-check JS/TS
+        run: |
+          pnpm -r run typecheck
+
       - name: Run JS/TS Tests
         run: |
           pnpm -r run test:ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,15 @@ pnpm dev:desktop                  # run desktop app
 pnpm dev:android                  # run on Android (needs SDK/NDK)
 pnpm test                         # all workspace JS/TS tests (vitest run, single pass)
 pnpm --filter threshold test:watch  # app tests in watch mode
+pnpm -r run typecheck              # tsc --noEmit across all TS packages (CI-gated; vitest alone won't catch type errors)
 cargo test --workspace            # Rust tests (app + plugins)
 pnpm format                       # prettier
 pnpm build:desktop | build:android | build:wear
 pnpm version:release              # interactive release TUI (phone + wear versions)
 ```
 
-CI (`.github/workflows/test.yml`) runs vitest and `cargo nextest` with JUnit output.
+CI (`.github/workflows/test.yml`) runs a TS type-check, vitest, and `cargo nextest` with
+JUnit output.
 
 ## Architecture — the key things to understand
 

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -10,7 +10,8 @@
 		"tauri": "tauri",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:ci": "vitest run --reporter=junit --reporter=default --outputFile.junit=junit.xml"
+		"test:ci": "vitest run --reporter=junit --reporter=default --outputFile.junit=junit.xml",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@emotion/react": "^11.14.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,8 @@
 	"scripts": {
 		"build": "tsc",
 		"test": "vitest run",
-		"test:ci": "vitest run --reporter=junit --reporter=default --outputFile.junit=junit.xml"
+		"test:ci": "vitest run --reporter=junit --reporter=default --outputFile.junit=junit.xml",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"date-fns": "^3.0.0"

--- a/plugins/toast/package.json
+++ b/plugins/toast/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "rollup -c",
     "prepublishOnly": "pnpm build",
-    "pretest": "pnpm build"
+    "pretest": "pnpm build",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0"


### PR DESCRIPTION
## Summary

- Discovered while reviewing PR #192: `onSnoozeRinging`'s signature changed to require an `alarmId: number` argument, but one caller still invoked it with zero arguments — a real `tsc` compile error (`TS2554: Expected 1 arguments, but got 0`) that sat completely undetected, because CI only runs `vitest` (esbuild-transpiled, doesn't type-check) and never runs `pnpm build` (which would have caught it via `apps/threshold`'s own `tsc && vite build` script).
- Added a `typecheck` script (`tsc --noEmit`) to every workspace TS package that has its own tsconfig: `apps/threshold`, `packages/core`, `plugins/toast` (`tools/release-tui` already had one, just never wired into CI).
- Wired `pnpm -r run typecheck` into the `test-js` job, run before the test suite so a type error fails fast rather than silently shipping alongside green tests.
- Documented the new command in `CLAUDE.md`.

## Test plan

- [x] `pnpm -r run typecheck` — clean across all 4 packages against current `main`
- [x] `pnpm test` (apps/threshold) — 41/41 green, unaffected
- [x] Verified the exact bug class this catches independently on PR #192's branch (real `TS2554` error, now fixed there separately)