### PR TITLE
Re-arm repeating alarms on dismiss, and move native dismiss/snooze fully into Rust

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,16 @@ SharedPreferences for boot recovery) → `AlarmReceiver` → `AlarmRingingServic
 `alarm:fired` → wear-sync mirrors ringing to the watch. Desktop uses tokio timers in
 `alarm-manager/src/desktop.rs` emitting `alarm-ring`.
 
+**Dismiss/snooze from the notification also go straight to Rust.** `AlarmRingingService`'s
+Dismiss/Snooze actions post through the same channel pattern
+(`alarm-manager:dismiss-requested` / `alarm-manager:snooze-requested`), handled directly
+in `lib.rs` — mirrors `wear:alarm:dismiss`/`wear:alarm:snooze`, no TS involvement, per the
+Channels rule above. Snooze reads `SnoozeLengthState` (Rust's own copy of the snooze-length
+setting, kept in sync via `set_snooze_length`) rather than depending on TS to compute the
+anchor. The confirmation toast is a separate concern: `AlarmManagerService` listens for
+`alarm:snoozed` unconditionally so every snooze source (native, watch, upcoming
+notification, in-app) gets the same toast, rather than each call site publishing its own.
+
 **Wear sync:** phone publishes FullSync snapshots to the Data Layer at
 `/threshold/alarms` (revision-stamped); the watch sends mutations back as messages
 (`/threshold/save_alarm`, `delete_alarm`, `sync_request`, `alarm_dismiss`,

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -436,6 +436,69 @@ pub fn run() {
                 }
             });
 
+            // Native phone alarm-dismissed callback from alarm-manager plugin (notification
+            // Dismiss action on AlarmRingingService). Handled directly in Rust core, same
+            // as alarm-manager:native-fired and the wear:alarm:* listeners above — no TS
+            // round-trip needed since dismiss_alarm requires nothing but the alarm ID.
+            let native_dismiss_handle = app.handle().clone();
+            app.handle().listen("alarm-manager:dismiss-requested", move |event| {
+                #[derive(serde::Deserialize)]
+                struct NativeDismissRequested {
+                    id: i32,
+                }
+
+                if let Ok(payload) = serde_json::from_str::<NativeDismissRequested>(event.payload()) {
+                    let handle = native_dismiss_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Some(coord) = handle.try_state::<AlarmCoordinator>() {
+                            if let Err(error) = coord.dismiss_alarm(&handle, payload.id).await {
+                                log::error!(
+                                    "alarm-manager: failed to dismiss native-requested alarm {}: {error}",
+                                    payload.id
+                                );
+                            }
+                        }
+                    });
+                }
+            });
+
+            // Native phone alarm-snoozed callback from alarm-manager plugin (notification
+            // Snooze action on AlarmRingingService). Handled directly in Rust core, mirroring
+            // wear:alarm:snooze — reads the same SnoozeLengthState the frontend keeps synced
+            // via set_snooze_length, so no TS round-trip is needed here either.
+            let native_snooze_handle = app.handle().clone();
+            app.handle().listen("alarm-manager:snooze-requested", move |event| {
+                #[derive(serde::Deserialize)]
+                struct NativeSnoozeRequested {
+                    id: i32,
+                }
+
+                if let Ok(payload) = serde_json::from_str::<NativeSnoozeRequested>(event.payload()) {
+                    let handle = native_snooze_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let minutes = handle
+                            .try_state::<SnoozeLengthState>()
+                            .map(|s| s.load(std::sync::atomic::Ordering::Relaxed))
+                            .unwrap_or(10) as i64;
+                        let snoozed_until = chrono::Utc::now().timestamp_millis() + minutes * 60 * 1000;
+
+                        if let Some(coord) = handle.try_state::<AlarmCoordinator>() {
+                            match coord.snooze_alarm(&handle, payload.id, snoozed_until).await {
+                                Ok(_) => log::info!(
+                                    "alarm-manager: snoozed native-requested alarm {} for {} min",
+                                    payload.id,
+                                    minutes
+                                ),
+                                Err(error) => log::error!(
+                                    "alarm-manager: failed to snooze native-requested alarm {}: {error}",
+                                    payload.id
+                                ),
+                            }
+                        }
+                    });
+                }
+            });
+
             #[cfg(mobile)]
             if let Err(error) = app.handle().wear_sync().mark_watch_pipeline_ready() {
                 log::warn!("watch: failed to mark watch pipeline ready: {error}");

--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -419,7 +419,6 @@ describe('AlarmManagerService', () => {
 		expect(actionCallback).not.toBeNull();
 
 		(invoke as any).mockClear();
-		const before = Date.now();
 		await actionCallback!({
 			actionId: 'snooze_alarm',
 			notification: {
@@ -433,8 +432,9 @@ describe('AlarmManagerService', () => {
 		expect(calledId).toBe(11);
 		expect(calledTimestamp).toBe(nextTrigger + 10 * 60_000);
 		expect(invoke).not.toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
-		expect(showToast).toHaveBeenCalled();
-		void before;
+		// Toast confirmation is a separate reaction to the alarm:snoozed event
+		// (Rust emits it after AlarmService.snooze succeeds) — see the dedicated
+		// 'publishes a snooze confirmation toast' test below.
 	});
 
 	it('clears upcoming notification when alarm starts ringing', async () => {
@@ -564,6 +564,25 @@ describe('AlarmManagerService', () => {
 		expect((service as any).scheduledSignatures.has(5)).toBe(false);
 	});
 
+	it('publishes a snooze confirmation toast when alarm:snoozed fires, for any snooze source', async () => {
+		const service = new AlarmManagerService();
+		(PlatformUtils.isMobile as any).mockReturnValue(true);
+		(PlatformUtils.getPlatform as any).mockReturnValue('android');
+
+		await service.init();
+
+		const snoozedHandlers = eventListeners.get('alarm:snoozed') ?? [];
+		expect(snoozedHandlers.length).toBe(1);
+
+		const originalTrigger = Date.now();
+		const snoozedUntil = originalTrigger + 10 * 60_000;
+		for (const handler of snoozedHandlers) {
+			await handler({ payload: { id: 8, originalTrigger, snoozedUntil } });
+		}
+
+		expect(showToast).toHaveBeenCalled();
+	});
+
 	it('deleteAlarm only calls AlarmService.delete and relies on alarm:cancelled listener', async () => {
 		const service = new AlarmManagerService();
 		await service.deleteAlarm(99);
@@ -589,31 +608,12 @@ describe('AlarmManagerService', () => {
 		expect(calledTimestamp).toBeLessThanOrEqual(after + 60_000 + 100);
 	});
 
-	it('snooze-from-ringing-notification calls snoozeRinging with the alarm ID', async () => {
-		const service = new AlarmManagerService();
-		(PlatformUtils.isMobile as any).mockReturnValue(true);
+	// Note: the native AlarmRingingService dismiss/snooze actions are handled
+	// entirely in Rust (apps/threshold-tauri/src/lib.rs's alarm-manager:*-requested
+	// listeners) and never reach TS, so there's nothing to unit-test here for that
+	// path — same as the pre-existing wear:alarm:dismiss/snooze listeners.
 
-		localStorageState.set('threshold_snooze_length', '10');
-		await service.init();
-
-		// Simulate the alarm-manager:snooze-requested event from the Android bridge
-		const snoozeRequestHandlers = eventListeners.get('alarm-manager:snooze-requested') ?? [];
-		expect(snoozeRequestHandlers.length).toBe(1);
-
-		const before = Date.now();
-		for (const handler of snoozeRequestHandlers) {
-			await handler({ payload: { id: 15 } });
-		}
-		const after = Date.now();
-
-		const [calledId, calledTimestamp] = (AlarmService.snooze as any).mock.calls[0];
-		expect(calledId).toBe(15);
-		expect(calledTimestamp).toBeGreaterThanOrEqual(before + 10 * 60_000);
-		expect(calledTimestamp).toBeLessThanOrEqual(after + 10 * 60_000);
-		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
-	});
-
-	it('falls back to stopping ringing when the alarm_trigger snooze action has no alarm ID', async () => {
+	it('stops ringing for the alarm_trigger snooze action (no alarm ID available)', async () => {
 		const service = new AlarmManagerService();
 		let actionCallback: ((notification: any) => Promise<void>) | null = null;
 
@@ -627,8 +627,6 @@ describe('AlarmManagerService', () => {
 		expect(actionCallback).not.toBeNull();
 
 		(invoke as any).mockClear();
-		// The JS-driven 'alarm_trigger' notification carries no alarm ID (unlike the
-		// native AlarmRingingService channel bridge, tested above).
 		await actionCallback!({
 			actionId: 'snooze',
 			notification: {
@@ -640,25 +638,7 @@ describe('AlarmManagerService', () => {
 		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
 	});
 
-	it('dismiss-from-ringing-notification calls AlarmService.dismiss with the alarm ID', async () => {
-		const service = new AlarmManagerService();
-		(PlatformUtils.isMobile as any).mockReturnValue(true);
-
-		await service.init();
-
-		// Simulate the alarm-manager:dismiss-requested event from the Android bridge
-		const dismissRequestHandlers = eventListeners.get('alarm-manager:dismiss-requested') ?? [];
-		expect(dismissRequestHandlers.length).toBe(1);
-
-		for (const handler of dismissRequestHandlers) {
-			await handler({ payload: { id: 21 } });
-		}
-
-		expect(AlarmService.dismiss).toHaveBeenCalledWith(21);
-		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
-	});
-
-	it('falls back to stopping ringing when the alarm_trigger dismiss action has no alarm ID', async () => {
+	it('stops ringing for the alarm_trigger dismiss action (no alarm ID available)', async () => {
 		const service = new AlarmManagerService();
 		let actionCallback: ((notification: any) => Promise<void>) | null = null;
 
@@ -672,8 +652,6 @@ describe('AlarmManagerService', () => {
 		expect(actionCallback).not.toBeNull();
 
 		(invoke as any).mockClear();
-		// The JS-driven 'alarm_trigger' notification carries no alarm ID (unlike the
-		// native AlarmRingingService channel bridge, tested above).
 		await actionCallback!({
 			actionId: 'dismiss',
 			notification: {
@@ -683,5 +661,14 @@ describe('AlarmManagerService', () => {
 
 		expect(AlarmService.dismiss).not.toHaveBeenCalled();
 		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+	});
+
+	it('seeds Rust snooze-length state from the persisted setting on init', async () => {
+		const service = new AlarmManagerService();
+		localStorageState.set('threshold_snooze_length', '15');
+
+		await service.init();
+
+		expect(invoke).toHaveBeenCalledWith('set_snooze_length', { minutes: 15 });
 	});
 });

--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -639,4 +639,49 @@ describe('AlarmManagerService', () => {
 		expect(AlarmService.snooze).not.toHaveBeenCalled();
 		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
 	});
+
+	it('dismiss-from-ringing-notification calls AlarmService.dismiss with the alarm ID', async () => {
+		const service = new AlarmManagerService();
+		(PlatformUtils.isMobile as any).mockReturnValue(true);
+
+		await service.init();
+
+		// Simulate the alarm-manager:dismiss-requested event from the Android bridge
+		const dismissRequestHandlers = eventListeners.get('alarm-manager:dismiss-requested') ?? [];
+		expect(dismissRequestHandlers.length).toBe(1);
+
+		for (const handler of dismissRequestHandlers) {
+			await handler({ payload: { id: 21 } });
+		}
+
+		expect(AlarmService.dismiss).toHaveBeenCalledWith(21);
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+	});
+
+	it('falls back to stopping ringing when the alarm_trigger dismiss action has no alarm ID', async () => {
+		const service = new AlarmManagerService();
+		let actionCallback: ((notification: any) => Promise<void>) | null = null;
+
+		(PlatformUtils.isMobile as any).mockReturnValue(true);
+		(onAction as any).mockImplementation(async (cb: (notification: any) => Promise<void>) => {
+			actionCallback = cb;
+			return undefined;
+		});
+
+		await service.init();
+		expect(actionCallback).not.toBeNull();
+
+		(invoke as any).mockClear();
+		// The JS-driven 'alarm_trigger' notification carries no alarm ID (unlike the
+		// native AlarmRingingService channel bridge, tested above).
+		await actionCallback!({
+			actionId: 'dismiss',
+			notification: {
+				actionTypeId: 'alarm_trigger',
+			},
+		});
+
+		expect(AlarmService.dismiss).not.toHaveBeenCalled();
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+	});
 });

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -103,17 +103,23 @@ export class AlarmManagerService {
 			try {
 				console.log('[AlarmManager] Starting service initialisation...');
 
+				// Seed Rust's snooze-length state from the persisted setting. Rust only
+				// otherwise learns this reactively when the user changes it in Settings,
+				// so without this, a native (Kotlin-to-Rust) snooze early in a session
+				// would use the hardcoded default instead of the user's preference.
+				SettingsService.syncSnoozeLengthToRust(SettingsService.getSnoozeLength());
+
 				await notificationToastService.init();
 
-				console.log('[AlarmManager] Setting up event listener 1/4: alarm-ring...');
+				console.log('[AlarmManager] Setting up event listener 1/6: alarm-ring...');
 				// Listen for alarms ringing from the Rust Backend (Desktop)
 				await listen<{ id: number }>('alarm-ring', (event) => {
 					console.log(`[AlarmManager] Received alarm-ring event for ID: ${event.payload.id}`);
 					this.handleAlarmRing(event.payload.id);
 				});
-				console.log('[AlarmManager] Event listener 1/4 registered.');
+				console.log('[AlarmManager] Event listener 1/6 registered.');
 
-				console.log('[AlarmManager] Setting up event listener 2/5: alarms:batch:updated...');
+				console.log('[AlarmManager] Setting up event listener 2/6: alarms:batch:updated...');
 				// Listen for batch events and refresh native schedule
 				await listen('alarms:batch:updated', async () => {
 					console.log('[AlarmManager] Received alarms:batch:updated event');
@@ -123,9 +129,9 @@ export class AlarmManagerService {
 						reason: 'alarm-batch-updated',
 					});
 				});
-				console.log('[AlarmManager] Event listener 2/5 registered.');
+				console.log('[AlarmManager] Event listener 2/6 registered.');
 
-				console.log('[AlarmManager] Setting up event listener 3/5: alarm:cancelled...');
+				console.log('[AlarmManager] Setting up event listener 3/6: alarm:cancelled...');
 				// Eagerly cancel native alarm and upcoming notification when Rust emits alarm:cancelled.
 				// This fires before alarms:batch:updated and closes the race window where a cancelled
 				// alarm could still fire if the BroadcastReceiver was already dispatched.
@@ -136,9 +142,9 @@ export class AlarmManagerService {
 					await alarmNotificationService.cancelUpcomingNotification(id);
 					this.scheduledSignatures.delete(id);
 				});
-				console.log('[AlarmManager] Event listener 3/5 registered.');
+				console.log('[AlarmManager] Event listener 3/6 registered.');
 
-				console.log('[AlarmManager] Setting up event listener 4/5: settings-changed...');
+				console.log('[AlarmManager] Setting up event listener 4/6: settings-changed...');
 				await listen<{ key?: string; value?: unknown }>('settings-changed', async (event) => {
 					if (event.payload?.key !== 'is24h') return;
 					if (!PlatformUtils.isMobile()) return;
@@ -148,16 +154,29 @@ export class AlarmManagerService {
 						reason: 'settings-24h-changed',
 					});
 				});
-				console.log('[AlarmManager] Event listener 4/5 registered.');
+				console.log('[AlarmManager] Event listener 4/6 registered.');
 
-				console.log('[AlarmManager] Setting up event listener 5/5: notifications:upcoming:resync...');
+				console.log('[AlarmManager] Setting up event listener 5/6: notifications:upcoming:resync...');
 				await listen<NotificationUpcomingResyncEvent>(
 					'notifications:upcoming:resync',
 					async (event) => {
 						await this.resyncUpcomingNotifications(event.payload);
 					},
 				);
-				console.log('[AlarmManager] Event listener 5/5 registered.');
+				console.log('[AlarmManager] Event listener 5/6 registered.');
+
+				console.log('[AlarmManager] Setting up event listener 6/6: alarm:snoozed...');
+				// Unified snooze confirmation toast — Rust emits alarm:snoozed for every
+				// snooze regardless of source (native ringing notification, watch, upcoming
+				// notification, in-app Ringing screen), so one listener here covers all of
+				// them instead of each call site publishing its own toast.
+				await listen<{ id: number; originalTrigger: number; snoozedUntil: number }>(
+					'alarm:snoozed',
+					async (event) => {
+						await this.publishSnoozeToast(event.payload);
+					},
+				);
+				console.log('[AlarmManager] Event listener 6/6 registered.');
 
 				console.log('[AlarmManager] Checking for native imports...');
 				await this.checkImports();
@@ -178,29 +197,19 @@ export class AlarmManagerService {
 					try {
 						this.registerNotificationActionTypes();
 						await alarmNotificationService.initialiseMobileNotificationActions({
-							onDismissRinging: async (alarmId) => {
-								console.log('[AlarmManager] Action: Dismiss', alarmId);
-								if (alarmId == null) {
-									// The JS-driven ringing notification action has no alarm ID to
-									// re-arm against yet — fall back to stopping ringing only, same
-									// as before this alarm ID plumbing existed.
-									await this.stopRinging();
-									return;
-								}
-								await this.dismissRinging(alarmId);
+							onDismissRinging: async () => {
+								// The native AlarmRingingService dismiss action is handled entirely
+								// in Rust (apps/threshold/src-tauri/src/lib.rs); this only fires
+								// from the older JS-driven 'alarm_trigger' notification action, which
+								// has no alarm ID to re-arm against.
+								console.log('[AlarmManager] Action: Dismiss');
+								await this.stopRinging();
 							},
-							onSnoozeRinging: async (alarmId) => {
-								console.log('[AlarmManager] Action: Snooze ringing', alarmId);
-								if (alarmId == null) {
-									// The JS-driven ringing notification action has no alarm ID to
-									// recalculate against yet — fall back to stopping ringing only,
-									// same as before this alarm ID plumbing existed.
-									await this.stopRinging();
-									return;
-								}
-								const snoozeLength = SettingsService.getSnoozeLength();
-								await this.snoozeRinging(alarmId, snoozeLength);
-								await this.emitUpcomingSnoozeToast(alarmId, snoozeLength);
+							onSnoozeRinging: async () => {
+								// Same story as onDismissRinging — the native snooze action is
+								// handled entirely in Rust; this is the ID-less JS fallback only.
+								console.log('[AlarmManager] Action: Snooze');
+								await this.stopRinging();
 							},
 							onDismissUpcoming: async (alarmId) => {
 								console.log('[AlarmManager] Action: Dismiss upcoming alarm', alarmId);
@@ -209,7 +218,7 @@ export class AlarmManagerService {
 							onSnoozeUpcoming: async (alarmId, snoozeLength) => {
 								console.log('[AlarmManager] Action: Snooze upcoming alarm', alarmId);
 								await this.snoozeUpcoming(alarmId, snoozeLength);
-								await this.emitUpcomingSnoozeToast(alarmId, snoozeLength);
+								// Toast is published by the alarm:snoozed listener registered in init().
 							},
 						});
 						console.log('[AlarmManager] Notification actions registered.');
@@ -236,18 +245,15 @@ export class AlarmManagerService {
 		await AlarmService.dismiss(alarmId);
 	}
 
-	private async emitUpcomingSnoozeToast(alarmId: number, durationMinutes: number): Promise<void> {
-		let message = `Alarm snoozed for ${durationMinutes} min`;
-		try {
-			const alarm = await AlarmService.get(alarmId);
-			if (alarm?.nextTrigger) {
-				const is24h = SettingsService.getIs24h();
-				const formattedTime = TimeFormatHelper.format(alarm.nextTrigger, is24h);
-				message = `${message} and will go off at ${formattedTime}`;
-			}
-		} catch (e) {
-			console.warn('[AlarmManager] Failed to load snoozed alarm details for toast', e);
-		}
+	private async publishSnoozeToast(payload: {
+		id: number;
+		originalTrigger: number;
+		snoozedUntil: number;
+	}): Promise<void> {
+		const durationMinutes = Math.round((payload.snoozedUntil - payload.originalTrigger) / 60_000);
+		const is24h = SettingsService.getIs24h();
+		const formattedTime = TimeFormatHelper.format(payload.snoozedUntil, is24h);
+		const message = `Alarm snoozed for ${durationMinutes} min and will go off at ${formattedTime}`;
 
 		try {
 			await alarmNotificationService.publishToast({
@@ -377,13 +383,6 @@ export class AlarmManagerService {
 	async deleteAlarm(id: number) {
 		// Cancellation is handled by the alarm:cancelled listener registered in init().
 		await AlarmService.delete(id);
-	}
-
-	async dismissRinging(id: number) {
-		console.log(`[AlarmManager] Dismissing ringing alarm ${id}`);
-		await alarmNotificationService.cancelUpcomingNotification(id);
-		await AlarmService.dismiss(id);
-		await this.stopRinging();
 	}
 
 	async snoozeRinging(id: number, minutes: number) {

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -178,9 +178,16 @@ export class AlarmManagerService {
 					try {
 						this.registerNotificationActionTypes();
 						await alarmNotificationService.initialiseMobileNotificationActions({
-							onDismissRinging: async () => {
-								console.log('[AlarmManager] Action: Dismiss');
-								await this.stopRinging();
+							onDismissRinging: async (alarmId) => {
+								console.log('[AlarmManager] Action: Dismiss', alarmId);
+								if (alarmId == null) {
+									// The JS-driven ringing notification action has no alarm ID to
+									// re-arm against yet — fall back to stopping ringing only, same
+									// as before this alarm ID plumbing existed.
+									await this.stopRinging();
+									return;
+								}
+								await this.dismissRinging(alarmId);
 							},
 							onSnoozeRinging: async (alarmId) => {
 								console.log('[AlarmManager] Action: Snooze ringing', alarmId);
@@ -370,6 +377,13 @@ export class AlarmManagerService {
 	async deleteAlarm(id: number) {
 		// Cancellation is handled by the alarm:cancelled listener registered in init().
 		await AlarmService.delete(id);
+	}
+
+	async dismissRinging(id: number) {
+		console.log(`[AlarmManager] Dismissing ringing alarm ${id}`);
+		await alarmNotificationService.cancelUpcomingNotification(id);
+		await AlarmService.dismiss(id);
+		await this.stopRinging();
 	}
 
 	async snoozeRinging(id: number, minutes: number) {

--- a/apps/threshold/src/services/AlarmNotificationService.ts
+++ b/apps/threshold/src/services/AlarmNotificationService.ts
@@ -18,10 +18,10 @@ const EVENT_NOTIFICATIONS_UPCOMING_RESYNC = 'notifications:upcoming:resync';
 const EVENT_NOTIFICATIONS_TOAST = 'notifications:toast';
 
 type NotificationActionHandlers = {
-	onDismissRinging: () => Promise<void>;
 	// The JS-driven 'alarm_trigger' notification action (unlike the native
-	// AlarmRingingService channel bridge) doesn't carry an alarm ID yet, so this
-	// must tolerate being called with none.
+	// AlarmRingingService channel bridge) doesn't carry an alarm ID yet, so both
+	// of these must tolerate being called with none.
+	onDismissRinging: (alarmId?: number) => Promise<void>;
 	onSnoozeRinging: (alarmId?: number) => Promise<void>;
 	onDismissUpcoming: (alarmId: number) => Promise<void>;
 	onSnoozeUpcoming: (alarmId: number, snoozeMinutes: number) => Promise<void>;
@@ -260,6 +260,15 @@ export class AlarmNotificationService {
 			const { id } = event.payload;
 			console.log(`[AlarmNotifications] Snooze requested from ringing notification for alarm ${id}`);
 			await handlers.onSnoozeRinging(id);
+		});
+
+		// Listen for dismiss-from-ringing-notification events bridged from AlarmRingingService.
+		// The Android service emits ACTION_DISMISS (with a real alarm ID) which Kotlin routes
+		// through the plugin channel.
+		await listen<{ id: number }>('alarm-manager:dismiss-requested', async (event) => {
+			const { id } = event.payload;
+			console.log(`[AlarmNotifications] Dismiss requested from ringing notification for alarm ${id}`);
+			await handlers.onDismissRinging(id);
 		});
 	}
 

--- a/apps/threshold/src/services/AlarmNotificationService.ts
+++ b/apps/threshold/src/services/AlarmNotificationService.ts
@@ -18,11 +18,12 @@ const EVENT_NOTIFICATIONS_UPCOMING_RESYNC = 'notifications:upcoming:resync';
 const EVENT_NOTIFICATIONS_TOAST = 'notifications:toast';
 
 type NotificationActionHandlers = {
-	// The JS-driven 'alarm_trigger' notification action (unlike the native
-	// AlarmRingingService channel bridge) doesn't carry an alarm ID yet, so both
-	// of these must tolerate being called with none.
-	onDismissRinging: (alarmId?: number) => Promise<void>;
-	onSnoozeRinging: (alarmId?: number) => Promise<void>;
+	// The native AlarmRingingService dismiss/snooze actions go straight from
+	// Kotlin to Rust (see apps/threshold/src-tauri/src/lib.rs) without coming
+	// through TS at all, so these only ever fire from the JS-driven
+	// 'alarm_trigger' notification action, which has no alarm ID.
+	onDismissRinging: () => Promise<void>;
+	onSnoozeRinging: () => Promise<void>;
 	onDismissUpcoming: (alarmId: number) => Promise<void>;
 	onSnoozeUpcoming: (alarmId: number, snoozeMinutes: number) => Promise<void>;
 };
@@ -254,22 +255,10 @@ export class AlarmNotificationService {
 			await handler(parsed.actionId, { id: parsed.notificationId });
 		});
 
-		// Listen for snooze-from-ringing-notification events bridged from AlarmRingingService.
-		// The Android service emits ACTION_SNOOZE which Kotlin routes through the plugin channel.
-		await listen<{ id: number }>('alarm-manager:snooze-requested', async (event) => {
-			const { id } = event.payload;
-			console.log(`[AlarmNotifications] Snooze requested from ringing notification for alarm ${id}`);
-			await handlers.onSnoozeRinging(id);
-		});
-
-		// Listen for dismiss-from-ringing-notification events bridged from AlarmRingingService.
-		// The Android service emits ACTION_DISMISS (with a real alarm ID) which Kotlin routes
-		// through the plugin channel.
-		await listen<{ id: number }>('alarm-manager:dismiss-requested', async (event) => {
-			const { id } = event.payload;
-			console.log(`[AlarmNotifications] Dismiss requested from ringing notification for alarm ${id}`);
-			await handlers.onDismissRinging(id);
-		});
+		// Note: the native AlarmRingingService dismiss/snooze actions (ACTION_DISMISS,
+		// ACTION_SNOOZE) are handled entirely in Rust — see the
+		// alarm-manager:dismiss-requested / alarm-manager:snooze-requested listeners in
+		// apps/threshold/src-tauri/src/lib.rs. TS never sees those events.
 	}
 
 	async cancelUpcomingNotification(alarmId: number): Promise<void> {

--- a/apps/threshold/src/services/SettingsService.ts
+++ b/apps/threshold/src/services/SettingsService.ts
@@ -90,7 +90,15 @@ export const SettingsService = {
 	setSnoozeLength: (minutes: number) => {
 		localStorage.setItem(KEY_SNOOZE_LENGTH, String(minutes));
 		emit('settings-changed', { key: 'snoozeLength', value: minutes });
-		// Sync to Rust state so alarm:fired events include the correct duration
+		SettingsService.syncSnoozeLengthToRust(minutes);
+	},
+
+	// Rust's snooze-length state starts at a hardcoded default (10) and is only
+	// ever updated reactively when the user changes the setting — it's never
+	// seeded from the persisted value at startup. Call this once during app
+	// init so a snooze requested natively (no TS round-trip) before the user
+	// has touched Settings this session still uses their actual preference.
+	syncSnoozeLengthToRust: (minutes: number) => {
 		invoke('set_snooze_length', { minutes }).catch((e) =>
 			console.warn('[Settings] Failed to sync snooze length to Rust:', e),
 		);

--- a/docs/architecture/event-architecture.md
+++ b/docs/architecture/event-architecture.md
@@ -361,7 +361,7 @@ pub struct AlarmRecord {
 ### Overview
 
 ```
-Event System (11 events across 4 categories)
+Event System (10 events across 4 categories)
 ├── CRUD Events (3) ─────────── UI updates, wear-sync state
 │   ├── alarm:created         
 │   ├── alarm:updated         
@@ -374,7 +374,7 @@ Event System (11 events across 4 categories)
 ├── Lifecycle Events (3) ────── Analytics, toasts, history
 │   ├── alarm:fired           
 │   ├── alarm:dismissed       
-│   └── alarm:snoozed (future)
+│   └── alarm:snoozed         
 │
 └── Batch Events (2) ────────── Sync optimization
     ├── alarms:batch:updated  
@@ -626,6 +626,12 @@ pub struct AlarmFired {
 
 **Purpose:** User stopped ringing alarm
 
+**Triggered from four sources, all funnelling through `AlarmCoordinator::dismiss_alarm`:**
+the native `AlarmRingingService` Dismiss action (`alarm-manager:dismiss-requested`,
+handled directly in `lib.rs`), the watch (`wear:alarm:dismiss`, also handled directly
+in `lib.rs`), the upcoming-notification Dismiss action (TS-invoked), and the in-app
+Ringing screen's own Dismiss button (TS-invoked).
+
 **Payload:**
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -641,9 +647,39 @@ pub struct AlarmDismissed {
 
 ---
 
+#### 8. alarm:snoozed
+
+**Purpose:** User snoozed a ringing (or upcoming) alarm
+
+**Triggered from four sources, all funnelling through `AlarmCoordinator::snooze_alarm`:**
+the native `AlarmRingingService` Snooze action (`alarm-manager:snooze-requested`,
+handled directly in `lib.rs`), the watch (`wear:alarm:snooze`, also handled directly
+in `lib.rs`), the upcoming-notification Snooze action (TS-invoked), and the in-app
+Ringing screen's own Snooze button (TS-invoked). The TS layer computes
+`snoozed_until` for the two TS-invoked paths; the two native paths compute it in
+Rust from `SnoozeLengthState`, Rust's own synced copy of the snooze-length setting.
+
+`AlarmManagerService` listens for this event unconditionally (not tied to any one
+call site) to publish the snooze confirmation toast, so every source above gets the
+same confirmation.
+
+**Payload:**
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AlarmSnoozed {
+    pub id: i32,
+    pub original_trigger: i64,
+    pub snoozed_until: i64,
+    pub revision: i64,
+}
+```
+
+---
+
 ### Batch Events (Critical for Sync)
 
-#### 8. alarms:batch:updated
+#### 9. alarms:batch:updated
 
 **Purpose:** Multiple alarms changed (with revision seal)
 
@@ -674,7 +710,7 @@ pub struct AlarmsBatchUpdated {
 
 ---
 
-#### 9. alarms:sync:needed
+#### 10. alarms:sync:needed
 
 **Purpose:** Explicit sync trigger
 
@@ -1063,6 +1099,7 @@ pub fn run() {
             commands::toggle_alarm,
             commands::delete_alarm,
             commands::dismiss_alarm,
+            commands::snooze_alarm,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -1393,7 +1430,7 @@ graph TB
 
     Life --> Fired["alarm:fired<br/>Alarm ringing"]
     Life --> Dismissed["alarm:dismissed<br/>User dismissed"]
-    Life --> Snoozed["alarm:snoozed<br/>User snoozed (future)"]
+    Life --> Snoozed["alarm:snoozed<br/>User snoozed"]
 
     Batch --> BatchUpdate["alarms:batch:updated<br/>Changes buffered"]
     Batch --> SyncNeeded["alarms:sync:needed<br/>Explicit sync request"]

--- a/docs/plugins/wear-sync.md
+++ b/docs/plugins/wear-sync.md
@@ -120,7 +120,9 @@ plugins/wear-sync/
    - `wear:alarm:save` → `toggle_alarm(id, enabled)` → saves + re-publishes to watch
    - `wear:alarm:delete` → `delete_alarm(id)` → deletes + re-publishes to watch
    - `wear:alarm:dismiss` → `stop_ringing()` + `dismiss_alarm(id)` → stops phone alarm
-   - `wear:alarm:snooze` → `stop_ringing()` + `snooze_alarm(id, minutes)` → snoozes phone alarm
+   - `wear:alarm:snooze` → `stop_ringing()` + `snooze_alarm(id, snoozed_until)` → snoozes phone alarm
+     (watch sends `snoozeLengthMinutes`; the phone converts it to a now-anchored absolute
+     timestamp before calling `snooze_alarm`, same as the native and upcoming-notification paths)
    - `wear:sync:request` → `emit_sync_needed(ForceSync)` → publishes FullSync to watch
 
 ### Phone → Watch (Ring Notification)
@@ -231,7 +233,7 @@ The app crate (`apps/threshold/src-tauri/src/lib.rs`) listens for the events abo
 | `wear:alarm:save` | `coordinator.toggle_alarm(id, enabled)` |
 | `wear:alarm:delete` | `coordinator.delete_alarm(id)` |
 | `wear:alarm:dismiss` | `stop_ringing()` + `coordinator.dismiss_alarm(id)` |
-| `wear:alarm:snooze` | `stop_ringing()` + `coordinator.snooze_alarm(id, minutes)` |
+| `wear:alarm:snooze` | `stop_ringing()` + `coordinator.snooze_alarm(id, snoozed_until)` |
 | `wear:sync:request` | `coordinator.emit_sync_needed(ForceSync)` |
 | `wear:sync:batch_ready` | `coordinator.emit_sync_needed(BatchComplete)` |
 

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -166,8 +166,8 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         }
     }
 
-    override fun load(webview: WebView) {
-        super.load(webview)
+    override fun load(webView: WebView) {
+        super.load(webView)
         instance = this
         Log.d(TAG, "Plugin loaded.")
         drainPendingAlarmEvents()

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -68,10 +68,16 @@ class SnoozeEventHandlerArgs {
     lateinit var handler: Channel
 }
 
+@InvokeArg
+class DismissEventHandlerArgs {
+    lateinit var handler: Channel
+}
+
 @TauriPlugin
 class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(activity) {
     private var alarmEventChannel: Channel? = null
     private var snoozeEventChannel: Channel? = null
+    private var dismissEventChannel: Channel? = null
     @Volatile
     private var alarmPipelineReady: Boolean = false
 
@@ -80,6 +86,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         private const val CALLBACK_PREFS = "AlarmManagerCallbacks"
         private const val KEY_PENDING_ALARM_EVENTS = "pending_alarm_events"
         private const val KEY_PENDING_SNOOZE_EVENTS = "pending_snooze_events"
+        private const val KEY_PENDING_DISMISS_EVENTS = "pending_dismiss_events"
 
         @Volatile
         var instance: AlarmManagerPlugin? = null
@@ -114,6 +121,20 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         }
 
         @Synchronized
+        fun notifyAlarmDismissed(context: Context, alarmId: Int) {
+            if (alarmId <= 0) return
+
+            val plugin = instance
+            if (plugin != null && plugin.dispatchDismissRequestedEvent(alarmId)) {
+                Log.d(TAG, "Dispatched dismiss requested immediately: id=$alarmId")
+                return
+            }
+
+            queueDismissEvent(context, alarmId)
+            Log.i(TAG, "Queued dismiss requested event (plugin/channel not ready): id=$alarmId")
+        }
+
+        @Synchronized
         private fun queueAlarmEvent(context: Context, alarmId: Int, actualFiredAt: Long) {
             val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
             val queue = JSONArray(prefs.getString(KEY_PENDING_ALARM_EVENTS, "[]"))
@@ -133,14 +154,25 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             })
             prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, queue.toString()).apply()
         }
+
+        @Synchronized
+        private fun queueDismissEvent(context: Context, alarmId: Int) {
+            val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
+            val queue = JSONArray(prefs.getString(KEY_PENDING_DISMISS_EVENTS, "[]"))
+            queue.put(JSONObject().apply {
+                put("id", alarmId)
+            })
+            prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, queue.toString()).apply()
+        }
     }
-    
+
     override fun load(webview: WebView) {
         super.load(webview)
         instance = this
         Log.d(TAG, "Plugin loaded.")
         drainPendingAlarmEvents()
         drainPendingSnoozeEvents()
+        drainPendingDismissEvents()
     }
 
     @Command
@@ -207,11 +239,20 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
     }
 
     @Command
+    fun setDismissEventHandler(invoke: Invoke) {
+        val args = invoke.parseArgs(DismissEventHandlerArgs::class.java)
+        dismissEventChannel = args.handler
+        Log.d(TAG, "Dismiss event handler channel registered")
+        invoke.resolve()
+    }
+
+    @Command
     fun markAlarmPipelineReady(invoke: Invoke) {
         alarmPipelineReady = true
         Log.d(TAG, "Alarm pipeline marked ready")
         drainPendingAlarmEvents()
         drainPendingSnoozeEvents()
+        drainPendingDismissEvents()
         invoke.resolve()
     }
 
@@ -314,6 +355,21 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         }
     }
 
+    private fun dispatchDismissRequestedEvent(alarmId: Int): Boolean {
+        if (!alarmPipelineReady) return false
+        val channel = dismissEventChannel ?: return false
+        return try {
+            val event = JSObject().apply {
+                put("id", alarmId)
+            }
+            channel.send(event)
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to dispatch dismiss requested event", e)
+            false
+        }
+    }
+
     private fun dispatchAlarmFiredEvent(alarmId: Int, actualFiredAt: Long): Boolean {
         if (!alarmPipelineReady) return false
         val channel = alarmEventChannel ?: return false
@@ -390,5 +446,35 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, remaining.toString()).apply()
         Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued snooze requested event(s)")
+    }
+
+    @Synchronized
+    private fun drainPendingDismissEvents() {
+        if (!alarmPipelineReady) return
+        val channel = dismissEventChannel ?: return
+        val prefs = activity.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
+        val rawQueue = prefs.getString(KEY_PENDING_DISMISS_EVENTS, "[]") ?: "[]"
+        val queue = JSONArray(rawQueue)
+        if (queue.length() == 0) return
+
+        val remaining = JSONArray()
+        for (i in 0 until queue.length()) {
+            val item = queue.optJSONObject(i) ?: continue
+            val id = item.optInt("id", -1)
+            if (id <= 0) continue
+
+            try {
+                val event = JSObject().apply {
+                    put("id", id)
+                }
+                channel.send(event)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to replay queued dismiss requested event id=$id", e)
+                remaining.put(item)
+            }
+        }
+
+        prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, remaining.toString()).apply()
+        Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued dismiss requested event(s)")
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
@@ -60,6 +60,9 @@ class AlarmRingingService : Service() {
         }
 
         if (intent.action == ACTION_DISMISS) {
+            val alarmId = intent.getIntExtra("ALARM_ID", -1)
+            Log.d(TAG, "Dismiss action received for alarm $alarmId")
+            AlarmManagerPlugin.notifyAlarmDismissed(applicationContext, alarmId)
             stopSelf()
             return START_NOT_STICKY
         }

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -26,6 +26,12 @@ struct SnoozeEventHandler {
     handler: Channel,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DismissEventHandler {
+    handler: Channel,
+}
+
 // Initialize the plugin
 pub fn init<R: Runtime>(
     app: &tauri::AppHandle<R>,
@@ -82,6 +88,33 @@ pub fn init<R: Runtime>(
                         let _ = snooze_app_handle.emit("alarm-manager:snooze-requested", &payload);
                     } else {
                         log::warn!("alarm-manager: failed to parse snooze requested payload");
+                    }
+                    Ok(())
+                }),
+            },
+        )?;
+
+        // Register a channel for dismiss-from-notification events. The ringing service
+        // posts ACTION_DISMISS (with an ALARM_ID extra when the user tapped a real alarm's
+        // notification) which Kotlin forwards here; we re-emit as a Tauri event so the TS
+        // layer can invoke dismiss_alarm and recalculate the next occurrence.
+        let dismiss_app_handle = app.clone();
+        handle.run_mobile_plugin::<()>(
+            "setDismissEventHandler",
+            DismissEventHandler {
+                handler: Channel::new(move |event| {
+                    let payload = match event {
+                        InvokeResponseBody::Json(payload) => {
+                            serde_json::from_str::<NativeDismissRequestedPayload>(&payload).ok()
+                        }
+                        _ => None,
+                    };
+
+                    if let Some(payload) = payload {
+                        log::info!("alarm-manager: dismiss requested id={}", payload.id);
+                        let _ = dismiss_app_handle.emit("alarm-manager:dismiss-requested", &payload);
+                    } else {
+                        log::warn!("alarm-manager: failed to parse dismiss requested payload");
                     }
                     Ok(())
                 }),

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -63,3 +63,9 @@ pub struct NativeAlarmFiredPayload {
 pub struct NativeSnoozeRequestedPayload {
     pub id: i32,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeDismissRequestedPayload {
+    pub id: i32,
+}


### PR DESCRIPTION
## Summary

**The original bug (#194):** `AlarmRingingService`'s Dismiss action only called `stopSelf()` — nothing told Rust/TS a dismiss happened, so `dismiss_alarm` never ran and a repeating alarm dismissed from the notification wouldn't ring again until the app was opened and the alarm touched manually.

**Architecture review found a better shape for the fix.** The first version of this PR mirrored PR #192's snooze design (Kotlin → Rust plugin → Tauri event → **TS listens and invokes the command**). On reflection, that's not the right precedent to copy for dismiss: the codebase already has an established, simpler pattern — `wear:alarm:dismiss`, `wear:alarm:snooze`, and `alarm-manager:native-fired` are all handled **directly in `apps/threshold/src-tauri/src/lib.rs`**, no TS involvement at all. Snooze went through TS in #192 because computing `snoozed_until` needs the snooze-length setting, which lives in TS (`SettingsService`, backed by `localStorage`) — dismiss has no such dependency, and it turns out neither does snooze once you look closer: Rust already keeps its own synced copy of that exact setting (`SnoozeLengthState`, an `AtomicI32`, already used to correctly label the watch's own snooze button).

So this PR now:
- Adds `alarm-manager:dismiss-requested` and `alarm-manager:snooze-requested` listeners directly in `lib.rs`, mirroring `wear:alarm:*` exactly. Snooze reads `SnoozeLengthState` directly instead of needing TS to compute the anchor.
- Reverts `onDismissRinging`/`onSnoozeRinging` to zero-arg — they only ever fire now from the separate, older JS-driven `'alarm_trigger'` notification action, which still has no alarm ID.
- **Fixes a real, pre-existing gap found along the way:** `SnoozeLengthState` started at a hardcoded default (10) and was only ever updated reactively when the user changed the setting — never seeded from the persisted value at startup. `AlarmManagerService.init()` now pushes the current value once, fixing both a native snooze early in a session *and* the watch's snooze-button label after a phone restart (same underlying gap).
- **Fixes a regression this refactor would otherwise have introduced:** the snooze confirmation toast (from #192) was tied to the specific TS call site being removed. Unified it instead — Rust's `snooze_alarm` already emits `alarm:snoozed` for every snooze regardless of source, so one listener now handles the toast for all of them (native, watch, upcoming notification, in-app Ringing screen), computing the message directly from the event payload. This incidentally adds the toast for watch-originated snoozes too, which previously showed nothing on the phone.
- Considered — and deliberately didn't do — moving the toast display itself into Rust (the toast plugin has a Rust API too), since Rust has no equivalent of `TimeFormatHelper`'s time formatting and it's a purely cosmetic, non-blocking confirmation that fires after the real mutation already succeeded. The "avoid TS" argument applies to the alarm mutation, which needs to survive OS backgrounding reliably — not to a toast shown after the fact.

Closes #194.

## Test plan

- [x] `cargo build --workspace` / `cargo test --workspace` — clean
- [x] `npx tsc --noEmit` (apps/threshold) — clean
- [x] `pnpm test` (apps/threshold) — 49/49 green, including new tests for: the seeding fix, the unified snooze toast (fired via `alarm:snoozed` regardless of source), and the zero-arg fallback behaviour for both dismiss and snooze on the older JS notification path
- [ ] Manual on-device test (no Android SDK in this environment): fire a repeating alarm, dismiss from the lock-screen notification, confirm it rings again at the next scheduled occurrence; separately confirm snooze from the same notification shows the correct confirmation toast and reschedules correctly