### PR TITLE
Stop scheduler window tests from using wall-clock-relative bounds

### DIFF
--- a/apps/threshold/src-tauri/src/alarm/scheduler.rs
+++ b/apps/threshold/src-tauri/src/alarm/scheduler.rs
@@ -414,7 +414,17 @@ mod tests {
 
     #[test]
     fn test_window_samples_remaining_time_when_already_open() {
-        let now = Local::now();
+        // Use a synthetic mid-day "now" (rather than the real wall clock) so
+        // this can't flake when the suite happens to run within 20 minutes
+        // of local midnight, where a naive "now +/- offset" window would
+        // straddle the date boundary that .format("%H:%M") silently drops.
+        let now = Local::now()
+            .date_naive()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .earliest()
+            .unwrap();
         let today_idx = now.weekday().num_days_from_sunday() as i32;
         let start = (now - chrono::Duration::minutes(10)).format("%H:%M").to_string();
         let end = (now + chrono::Duration::minutes(20)).format("%H:%M").to_string();
@@ -428,7 +438,7 @@ mod tests {
             ..Default::default()
         };
 
-        let trigger_ts = calculate_next_trigger(&input).unwrap().unwrap();
+        let trigger_ts = calculate_next_trigger_from(&input, now, ReferenceKind::Fresh).unwrap().unwrap();
         let trigger_dt = DateTime::from_timestamp_millis(trigger_ts).unwrap().with_timezone(&Local);
 
         // Should sample from the remaining time of today's window, not skip to next week.
@@ -474,7 +484,14 @@ mod tests {
 
     #[test]
     fn test_after_occurrence_does_not_resample_open_window() {
-        let now = Local::now();
+        // Synthetic mid-day "now" for the same reason as the sibling test above.
+        let now = Local::now()
+            .date_naive()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+            .and_local_timezone(Local)
+            .earliest()
+            .unwrap();
         let today_idx = now.weekday().num_days_from_sunday() as i32;
         let start = (now - chrono::Duration::minutes(10)).format("%H:%M").to_string();
         let end = (now + chrono::Duration::minutes(20)).format("%H:%M").to_string();


### PR DESCRIPTION
## Summary

Two of the scheduler tests added in #218 build window bounds from `now +/- minutes(...).format("%H:%M")`, which drops the date component. Right at local midnight, a window intended to span "10 minutes ago to 20 minutes from now" gets misread as starting *tomorrow* night rather than *last* night — the trigger lands a day (or, with only today active, a full week) away, failing the assertion.

This is a test-construction bug, not a scheduler bug: the dedicated overnight tests use fixed time strings ("23:00"/"01:00") and are unaffected, and the production code path (real user-configured window strings, never derived from `now`) was already correct.

## Fix

Both tests now anchor to a synthetic mid-day "now" (`12:00:00` today) instead of the real wall clock, matching the approach the overnight test already used for the same reason.

## Test plan

- [x] `cargo test --workspace` — all 34 Rust tests pass
- [x] Ran the two fixed tests 3x in isolation to confirm determinism

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2