### PR TITLE
Tighten two boundary serde contracts flagged in issue #205

### DIFF
--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -28,12 +28,20 @@ pub struct ImportedAlarm {
     pub label: String,
 }
 
+// Kotlin's PickAlarmSoundOptions arg class declares non-null fields with
+// defaults (e.g. `showSilent: Boolean = true`); a JSON `null` fails to
+// deserialise into them, so every field here must be omitted when absent
+// rather than sent as `null`.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PickAlarmSoundOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub existing_uri: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_silent: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub show_default: Option<bool>,
 }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -50,8 +50,11 @@ class SyncRequest {
 class AlarmRingRequest {
     var alarmId: Int = -1
     var label: String = ""
-    var hour: Int = 0
-    var minute: Int = 0
+    // Null means "use the device's current time"; the Rust side omits the
+    // key entirely rather than sending JSON null (see AlarmRingRequest in
+    // wear-sync's models.rs).
+    var hour: Int? = null
+    var minute: Int? = null
     var snoozeLengthMinutes: Int = 10
     var is24Hour: Boolean = false
     var is24HourKnown: Boolean = false
@@ -187,8 +190,8 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
 
                 // Use current device time if Rust didn't provide explicit hour/minute
                 val cal = java.util.Calendar.getInstance()
-                val hour = if (args.hour < 0) cal.get(java.util.Calendar.HOUR_OF_DAY) else args.hour
-                val minute = if (args.minute < 0) cal.get(java.util.Calendar.MINUTE) else args.minute
+                val hour = args.hour ?: cal.get(java.util.Calendar.HOUR_OF_DAY)
+                val minute = args.minute ?: cal.get(java.util.Calendar.MINUTE)
 
                 val json = JSONObject().apply {
                     put("alarmId", args.alarmId)

--- a/plugins/wear-sync/src/lib.rs
+++ b/plugins/wear-sync/src/lib.rs
@@ -119,13 +119,13 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                         tauri::async_runtime::spawn(async move {
                             let wear_sync = app.state::<WearSync<R>>();
 
-                            // Pass hour=-1, minute=-1 to signal the Kotlin side
+                            // Pass hour=None, minute=None to signal the Kotlin side
                             // should use the current device time for the watch display.
                             let request = AlarmRingRequest {
                                 alarm_id: fired.id,
                                 label: fired.label.unwrap_or_default(),
-                                hour: -1,
-                                minute: -1,
+                                hour: None,
+                                minute: None,
                                 snooze_length_minutes: fired.snooze_length_minutes,
                                 is_24_hour: fired.is_24_hour,
                                 is_24_hour_known: fired.is_24_hour_known,

--- a/plugins/wear-sync/src/models.rs
+++ b/plugins/wear-sync/src/models.rs
@@ -158,8 +158,13 @@ fn default_is_24_hour_known() -> bool {
 pub struct AlarmRingRequest {
     pub alarm_id: i32,
     pub label: String,
-    pub hour: i32,
-    pub minute: i32,
+    /// `None` means "use the device's current time" — the Kotlin side falls
+    /// back to `Calendar`. Omitted from the JSON entirely rather than sent
+    /// as `null`, since the Kotlin arg class's `hour`/`minute` are non-null.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hour: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minute: Option<i32>,
     pub snooze_length_minutes: i32,
     #[serde(default = "default_is_24_hour")]
     pub is_24_hour: bool,


### PR DESCRIPTION
## Summary

Part of #205 (typed guest-js bindings and generated TS types) — specifically the two "boundary contracts to tighten" it calls out, unblocked from the rest of that issue since they're independent, low-risk fixes.

- **`PickAlarmSoundOptions`**: `Option<bool>` fields (`show_silent`/`show_default`) serialise as JSON `null` when `None`, which Kotlin's non-null `Boolean = true` arg-class defaults can reject. Only worked so far because TS always passes concrete values. Added `skip_serializing_if = "Option::is_none"` across the struct so an absent option is an absent JSON key, letting Kotlin's own defaults apply as intended.
- **`AlarmRingRequest.hour/minute`**: used a magic `-1` sentinel ("use device time") over non-optional `i32`/`Int` fields on both sides. Changed to `Option<i32>` (Rust) / `Int?` (Kotlin) — an omitted value now means what it says, rather than relying on a value that happens to never be a real hour/minute.

## Test plan

- [x] `cargo build --workspace` / `cargo test --workspace` — clean, all 34 tests pass
- [x] Kotlin compile -- verified locally via `./gradlew testDebugUnitTest` against the real Tauri Android sources in the project's devcontainer image (matching CI's `test-kotlin-plugins` job), both wear-sync and alarm-manager -- `BUILD SUCCESSFUL`

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2
