### PR TITLE
Document wear-sync's guest-js exemption

### DIFF
--- a/docs/plugins/wear-sync.md
+++ b/docs/plugins/wear-sync.md
@@ -192,6 +192,14 @@ For the full flow, see [architecture/wear-os-companion.md](../architecture/wear-
 | `markWatchPipelineReady` | Mark app listener readiness and drain queued messages |
 | `sendAlarmRing` | Send `/threshold/alarm_ring` message to all connected watches |
 
+**No `guest-js`, by design.** Unlike alarm-manager, theme-utils, time-prefs, and
+app-management, this plugin has no TypeScript-facing surface at all — the webview never
+calls `invoke('plugin:wear-sync|...')` directly. Every command above is driven from the
+Rust side (`AlarmCoordinator` events → `run_mobile_plugin(...)`, per the Channels rule in
+`CLAUDE.md`); the app's only interaction with wear-sync is listening for the Tauri events
+it emits (see Events below). Adopting typed `guest-js` bindings here (issue #205) would
+add a package with nothing to bind. This is the accepted variant, not an oversight.
+
 ## Naming Conventions
 
 - Kotlin `@Command` method names use `camelCase` (for example, `publishToWatch`), matching

--- a/docs/plugins/wear-sync.md
+++ b/docs/plugins/wear-sync.md
@@ -196,9 +196,10 @@ For the full flow, see [architecture/wear-os-companion.md](../architecture/wear-
 app-management, this plugin has no TypeScript-facing surface at all — the webview never
 calls `invoke('plugin:wear-sync|...')` directly. Every command above is driven from the
 Rust side (`AlarmCoordinator` events → `run_mobile_plugin(...)`, per the Channels rule in
-`CLAUDE.md`); the app's only interaction with wear-sync is listening for the Tauri events
-it emits (see Events below). Adopting typed `guest-js` bindings here (issue #205) would
-add a package with nothing to bind. This is the accepted variant, not an oversight.
+`CLAUDE.md`), and every event wear-sync itself emits targets the Rust app layer
+(`apps/threshold/src-tauri/src/lib.rs`), not the webview (see Events below) — TS has no
+interaction with this plugin at all. Adopting typed `guest-js` bindings here (issue #205)
+would add a package with nothing to bind. This is the accepted variant, not an oversight.
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Summary

Part of #205. wear-sync has no TypeScript-facing surface — the webview never calls `invoke('plugin:wear-sync|...')`; every command is driven Rust-to-Kotlin from `AlarmCoordinator` events, per the Channels pattern in `CLAUDE.md`. Issue #205 explicitly calls this out as an accepted variant rather than a gap when the other plugins get typed guest-js bindings. Writing it into `docs/plugins/wear-sync.md` so a future audit doesn't re-flag it as a missing binding.

No code changes.

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2