### PR TITLE
Add typed guest-js bindings for theme-utils, time-prefs, app-management

### DIFF
--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -36,6 +36,9 @@
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
 		"tauri-plugin-app-events-api": "^0.2.0",
+		"tauri-plugin-app-management-api": "workspace:*",
+		"tauri-plugin-theme-utils-api": "workspace:*",
+		"tauri-plugin-time-prefs-api": "workspace:*",
 		"tauri-plugin-toast-api": "workspace:*"
 	},
 	"devDependencies": {

--- a/apps/threshold/src/contexts/ThemeContext.tsx
+++ b/apps/threshold/src/contexts/ThemeContext.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
 import { CssBaseline, useMediaQuery } from '@mui/material';
-import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { getMaterialYouColours } from 'tauri-plugin-theme-utils-api';
 import { PlatformUtils } from '../utils/PlatformUtils';
 import { SettingsService, Theme as AppTheme } from '../services/SettingsService';
 import { themes, generateSystemTheme, ThemeDefinition, MaterialYouResponse } from '../theme/themes';
@@ -52,9 +52,7 @@ export const ThemeContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
 			if (PlatformUtils.isMobile() && PlatformUtils.getPlatform() === 'android') {
 				try {
 					console.log('Fetching Material You Colours...');
-					const response = await invoke<MaterialYouResponse>(
-						'plugin:theme-utils|get_material_you_colours',
-					);
+					const response = await getMaterialYouColours();
 					console.log('Material You Response:', response);
 					setMaterialYouResponse(response);
 

--- a/apps/threshold/src/services/AppManagementService.ts
+++ b/apps/threshold/src/services/AppManagementService.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { minimizeApp as minimizeAppNative } from 'tauri-plugin-app-management-api';
 
 class AppManagementService {
 	/**
@@ -8,7 +8,7 @@ class AppManagementService {
 	 */
 	async minimizeApp(): Promise<void> {
 		try {
-			await invoke('plugin:app-management|minimize_app');
+			await minimizeAppNative();
 		} catch (error) {
 			console.error('Failed to minimize app:', error);
 		}

--- a/apps/threshold/src/theme/themes.ts
+++ b/apps/threshold/src/theme/themes.ts
@@ -1,21 +1,13 @@
+import type { MaterialYouResponse } from 'tauri-plugin-theme-utils-api';
+
+export type { MaterialYouResponse };
+
 export type ThemeId = 'deep-night' | 'canadian-cottage-winter' | 'georgian-bay-plunge' | 'boring-light' | 'boring-dark' | 'system';
 
 export interface ThemeDefinition {
     id: ThemeId;
     variables: Record<string, string>;
     muiPalette: any; // Using any for flexibility in passing to createTheme
-}
-
-export interface MaterialYouResponse {
-    supported: boolean;
-    apiLevel: number;
-    palettes: {
-        system_accent1?: Record<string, string>;
-        system_accent2?: Record<string, string>;
-        system_accent3?: Record<string, string>;
-        system_neutral1?: Record<string, string>;
-        system_neutral2?: Record<string, string>;
-    };
 }
 
 // Convert Android ARGB hex (#AARRGGBB) to CSS RGBA hex (#RRGGBBAA)

--- a/apps/threshold/src/utils/timePrefs.ts
+++ b/apps/threshold/src/utils/timePrefs.ts
@@ -1,17 +1,11 @@
-import { invoke } from '@tauri-apps/api/core';
+import { getTimeFormat } from 'tauri-plugin-time-prefs-api';
 import { PlatformUtils } from './PlatformUtils';
-
-interface TimeFormatResponse {
-    is24Hour: boolean;
-}
 
 export const TimePrefs = {
     getSystemTimeFormat: async (): Promise<{ is24Hour: boolean; source: 'android' | 'ios' | 'intl' }> => {
         if (PlatformUtils.isMobile()) {
             try {
-                // plugin:time-prefs matches the name in lib.rs Builder::new("time-prefs")
-                // get_time_format matches the function name in commands.rs
-                const response = await invoke<TimeFormatResponse>('plugin:time-prefs|get_time_format');
+                const response = await getTimeFormat();
                 const os = PlatformUtils.getPlatform();
                 return {
                     is24Hour: response.is24Hour,

--- a/plugins/app-management/guest-js/index.ts
+++ b/plugins/app-management/guest-js/index.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Minimises the application to the background.
+ * On Android, this uses moveTaskToBack(true). On iOS, this is currently a no-op.
+ */
+export async function minimizeApp(): Promise<void> {
+	await invoke('plugin:app-management|minimize_app');
+}

--- a/plugins/app-management/package.json
+++ b/plugins/app-management/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "tauri-plugin-app-management-api",
+  "version": "0.1.0",
+  "author": "Threshold",
+  "description": "",
+  "type": "module",
+  "types": "./guest-js/index.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
+  "exports": {
+    "types": "./guest-js/index.ts",
+    "source": "./guest-js/index.ts",
+    "import": "./dist-js/index.js",
+    "require": "./dist-js/index.cjs",
+    "default": "./dist-js/index.js"
+  },
+  "files": [
+    "dist-js",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
+    "rollup": "^4.9.6",
+    "typescript": "^5.3.3",
+    "tslib": "^2.6.2"
+  }
+}

--- a/plugins/app-management/rollup.config.js
+++ b/plugins/app-management/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
+import typescript from '@rollup/plugin-typescript'
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
+
+export default {
+  input: 'guest-js/index.ts',
+  output: [
+    {
+      file: pkg.exports.import,
+      format: 'esm'
+    },
+    {
+      file: pkg.exports.require,
+      format: 'cjs'
+    }
+  ],
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: dirname(pkg.exports.import)
+    })
+  ],
+  external: [
+    /^@tauri-apps\/api/,
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ]
+}

--- a/plugins/app-management/tsconfig.json
+++ b/plugins/app-management/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["guest-js/*.ts"],
+  "exclude": ["dist-js", "node_modules"]
+}

--- a/plugins/theme-utils/.gitignore
+++ b/plugins/theme-utils/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/theme-utils/guest-js/index.ts
+++ b/plugins/theme-utils/guest-js/index.ts
@@ -1,0 +1,21 @@
+import { invoke } from '@tauri-apps/api/core';
+
+// Note: Palettes' keys stay snake_case -- Rust's Palettes struct has no
+// #[serde(rename_all = "camelCase")], unlike the outer MaterialYouResponse.
+export interface Palettes {
+	system_accent1?: Record<string, string>;
+	system_accent2?: Record<string, string>;
+	system_accent3?: Record<string, string>;
+	system_neutral1?: Record<string, string>;
+	system_neutral2?: Record<string, string>;
+}
+
+export interface MaterialYouResponse {
+	supported: boolean;
+	apiLevel: number;
+	palettes: Palettes;
+}
+
+export async function getMaterialYouColours(): Promise<MaterialYouResponse> {
+	return await invoke<MaterialYouResponse>('plugin:theme-utils|get_material_you_colours');
+}

--- a/plugins/theme-utils/package.json
+++ b/plugins/theme-utils/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "tauri-plugin-theme-utils-api",
+  "version": "0.1.0",
+  "author": "Threshold",
+  "description": "",
+  "type": "module",
+  "types": "./guest-js/index.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
+  "exports": {
+    "types": "./guest-js/index.ts",
+    "source": "./guest-js/index.ts",
+    "import": "./dist-js/index.js",
+    "require": "./dist-js/index.cjs",
+    "default": "./dist-js/index.js"
+  },
+  "files": [
+    "dist-js",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
+    "rollup": "^4.9.6",
+    "typescript": "^5.3.3",
+    "tslib": "^2.6.2"
+  }
+}

--- a/plugins/theme-utils/rollup.config.js
+++ b/plugins/theme-utils/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
+import typescript from '@rollup/plugin-typescript'
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
+
+export default {
+  input: 'guest-js/index.ts',
+  output: [
+    {
+      file: pkg.exports.import,
+      format: 'esm'
+    },
+    {
+      file: pkg.exports.require,
+      format: 'cjs'
+    }
+  ],
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: dirname(pkg.exports.import)
+    })
+  ],
+  external: [
+    /^@tauri-apps\/api/,
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ]
+}

--- a/plugins/theme-utils/tsconfig.json
+++ b/plugins/theme-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["guest-js/*.ts"],
+  "exclude": ["dist-js", "node_modules"]
+}

--- a/plugins/time-prefs/.gitignore
+++ b/plugins/time-prefs/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/time-prefs/guest-js/index.ts
+++ b/plugins/time-prefs/guest-js/index.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface TimeFormatResponse {
+	is24Hour: boolean;
+}
+
+export async function getTimeFormat(): Promise<TimeFormatResponse> {
+	return await invoke<TimeFormatResponse>('plugin:time-prefs|get_time_format');
+}

--- a/plugins/time-prefs/package.json
+++ b/plugins/time-prefs/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "tauri-plugin-time-prefs-api",
+  "version": "0.1.0",
+  "author": "Threshold",
+  "description": "",
+  "type": "module",
+  "types": "./guest-js/index.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
+  "exports": {
+    "types": "./guest-js/index.ts",
+    "source": "./guest-js/index.ts",
+    "import": "./dist-js/index.js",
+    "require": "./dist-js/index.cjs",
+    "default": "./dist-js/index.js"
+  },
+  "files": [
+    "dist-js",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
+    "rollup": "^4.9.6",
+    "typescript": "^5.3.3",
+    "tslib": "^2.6.2"
+  }
+}

--- a/plugins/time-prefs/rollup.config.js
+++ b/plugins/time-prefs/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
+import typescript from '@rollup/plugin-typescript'
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
+
+export default {
+  input: 'guest-js/index.ts',
+  output: [
+    {
+      file: pkg.exports.import,
+      format: 'esm'
+    },
+    {
+      file: pkg.exports.require,
+      format: 'cjs'
+    }
+  ],
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: dirname(pkg.exports.import)
+    })
+  ],
+  external: [
+    /^@tauri-apps\/api/,
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ]
+}

--- a/plugins/time-prefs/tsconfig.json
+++ b/plugins/time-prefs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["guest-js/*.ts"],
+  "exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,15 @@ importers:
       tauri-plugin-app-events-api:
         specifier: ^0.2.0
         version: 0.2.0
+      tauri-plugin-app-management-api:
+        specifier: workspace:*
+        version: link:../../plugins/app-management
+      tauri-plugin-theme-utils-api:
+        specifier: workspace:*
+        version: link:../../plugins/theme-utils
+      tauri-plugin-time-prefs-api:
+        specifier: workspace:*
+        version: link:../../plugins/time-prefs
       tauri-plugin-toast-api:
         specifier: workspace:*
         version: link:../../plugins/toast
@@ -136,6 +145,63 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.9)(jsdom@27.4.0)
+
+  plugins/app-management:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  plugins/theme-utils:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  plugins/time-prefs:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
 
   plugins/toast:
     dependencies:


### PR DESCRIPTION
## Summary

Part of #205. Each of these three plugins has exactly one command and no prior JS package, so this slice is mechanical: `package.json`/`rollup.config.js`/`tsconfig.json` mirroring toast's existing template (the only plugin that already had one), plus a `guest-js/index.ts` wrapping the single `invoke()` call.

Migrates the three raw `invoke('plugin:x|cmd')` call sites:
- `ThemeContext.tsx` → `getMaterialYouColours()` (`tauri-plugin-theme-utils-api`)
- `timePrefs.ts` → `getTimeFormat()` (`tauri-plugin-time-prefs-api`)
- `AppManagementService.ts` → `minimizeApp()` (`tauri-plugin-app-management-api`)

`themes.ts`'s hand-mirrored `MaterialYouResponse` is now re-exported from the guest-js package instead of independently declared — preserves an easy-to-miss detail: `Palettes`' own fields stay `snake_case` while the outer struct is `camelCase`, since Rust's `Palettes` struct has no `#[serde(rename_all = "camelCase")]` of its own.

**Side finding, filed separately:** while writing theme-utils' binding, found that `liminal-hq/tauri-plugins-workspace` already has a near-identical `material-you` plugin (same command, same response shape, already published on crates.io/npm). Filed #222 to investigate replacing `plugins/theme-utils` with that shared plugin — out of scope here, this PR just gives the current local plugin proper typed bindings in the meantime.

## Test plan

- [x] `pnpm -r run typecheck` — clean across all 8 workspace projects
- [x] `pnpm --filter threshold test` — 49/49 passing
- [x] `pnpm --filter <pkg> build` (rollup) — all three build cleanly to `dist-js/`
- [x] `cargo build --workspace` — unaffected, clean
- [x] Kotlin compile-checked locally (`./gradlew testDebugUnitTest` against the real Tauri Android sources, matching CI's `test-kotlin-plugins` job) for all three plugins — `BUILD SUCCESSFUL`

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2