### PR TITLE
Add typed guest-js bindings for alarm-manager

### DIFF
--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -35,6 +35,7 @@
 		"motion": "^12.27.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
+		"tauri-plugin-alarm-manager-api": "workspace:*",
 		"tauri-plugin-app-events-api": "^0.2.0",
 		"tauri-plugin-app-management-api": "workspace:*",
 		"tauri-plugin-theme-utils-api": "workspace:*",

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -4,8 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 import { APP_NAME } from '../constants';
-import { invoke } from '@tauri-apps/api/core';
 import { listen, emit } from '@tauri-apps/api/event';
+import {
+	schedule as scheduleNative,
+	cancel as cancelNative,
+	getLaunchArgs,
+	stopRinging as stopRingingNative,
+} from 'tauri-plugin-alarm-manager-api';
 import { PlatformUtils } from '../utils/PlatformUtils';
 import { sendNotification } from '@tauri-apps/plugin-notification';
 import { Alarm } from '@threshold/core/types';
@@ -19,14 +24,6 @@ import {
 	type NotificationUpcomingResyncEvent,
 } from './AlarmNotificationService';
 import { notificationToastService } from './NotificationToastService';
-
-// Define the plugin invoke types manually since we can't import from the plugin in this environment
-interface ImportedAlarm {
-	id: number;
-	hour: number;
-	minute: number;
-	label: string;
-}
 
 type NotificationUpcomingResyncPayload = NotificationUpcomingResyncEvent | null | undefined;
 
@@ -334,8 +331,7 @@ export class AlarmManagerService {
 	// Check for alarms created natively (e.g. via "Set Alarm" intent)
 	private async checkImports() {
 		try {
-			const imports =
-				(await invoke<ImportedAlarm[]>('plugin:alarm-manager|get_launch_args')) ?? [];
+			const imports = await getLaunchArgs();
 			if (imports.length > 0) {
 				console.log(`[AlarmManager] Found ${imports.length} native alarms to import:`, imports);
 				for (const imp of imports) {
@@ -410,9 +406,7 @@ export class AlarmManagerService {
 	): Promise<boolean> {
 		console.log(`Scheduling alarm ${id} for ${new Date(timestamp).toLocaleString()}`);
 		try {
-			await invoke('plugin:alarm-manager|schedule', {
-				payload: { id, triggerAt: timestamp, soundUri },
-			});
+			await scheduleNative({ id, triggerAt: timestamp, soundUri });
 			return true;
 		} catch (e: any) {
 			console.error('Failed to schedule native alarm', e.message || e.toString());
@@ -493,7 +487,7 @@ export class AlarmManagerService {
 	async stopRinging() {
 		try {
 			console.log('[AlarmManager] Stopping ringing...');
-			await invoke('plugin:alarm-manager|stop_ringing');
+			await stopRingingNative();
 		} catch (e) {
 			console.error('Failed to stop ringing', e);
 		}
@@ -501,9 +495,7 @@ export class AlarmManagerService {
 
 	private async cancelNativeAlarm(id: number) {
 		try {
-			await invoke('plugin:alarm-manager|cancel', {
-				payload: { id },
-			});
+			await cancelNative({ id });
 		} catch (e) {
 			console.error('Failed to cancel native alarm', e);
 		}

--- a/apps/threshold/src/services/AlarmSoundPickerService.ts
+++ b/apps/threshold/src/services/AlarmSoundPickerService.ts
@@ -1,5 +1,8 @@
-import { pickAlarmSound as pickAlarmSoundNative } from 'tauri-plugin-alarm-manager-api';
-import type { PickAlarmSoundOptions, PickedAlarmSound } from 'tauri-plugin-alarm-manager-api';
+import {
+	pickAlarmSound as pickAlarmSoundNative,
+	type PickAlarmSoundOptions,
+	type PickedAlarmSound,
+} from 'tauri-plugin-alarm-manager-api';
 import { PlatformUtils } from '../utils/PlatformUtils';
 import { open } from '@tauri-apps/plugin-dialog';
 

--- a/apps/threshold/src/services/AlarmSoundPickerService.ts
+++ b/apps/threshold/src/services/AlarmSoundPickerService.ts
@@ -1,19 +1,9 @@
-import { invoke } from '@tauri-apps/api/core';
+import { pickAlarmSound as pickAlarmSoundNative } from 'tauri-plugin-alarm-manager-api';
+import type { PickAlarmSoundOptions, PickedAlarmSound } from 'tauri-plugin-alarm-manager-api';
 import { PlatformUtils } from '../utils/PlatformUtils';
 import { open } from '@tauri-apps/plugin-dialog';
 
-export interface PickAlarmSoundOptions {
-	existingUri?: string | null;
-	title?: string;
-	showSilent?: boolean;
-	showDefault?: boolean;
-}
-
-export interface PickedAlarmSound {
-	uri: string | null;
-	isSilent: boolean;
-	title: string | null;
-}
+export type { PickAlarmSoundOptions, PickedAlarmSound };
 
 export class AlarmSoundPickerService {
 	/**
@@ -53,13 +43,11 @@ export class AlarmSoundPickerService {
 		}
 
 		try {
-			return await invoke<PickedAlarmSound>('plugin:alarm-manager|pick_alarm_sound', {
-				options: {
-					existingUri: options.existingUri,
-					title: options.title,
-					showSilent: options.showSilent ?? true,
-					showDefault: options.showDefault ?? true,
-				},
+			return await pickAlarmSoundNative({
+				existingUri: options.existingUri,
+				title: options.title,
+				showSilent: options.showSilent ?? true,
+				showDefault: options.showDefault ?? true,
 			});
 		} catch (error: any) {
 			if (typeof error === 'string' && error.includes('cancelled')) {

--- a/plugins/alarm-manager/.gitignore
+++ b/plugins/alarm-manager/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -1,0 +1,53 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface ScheduleRequest {
+	id: number;
+	triggerAt: number;
+	soundUri?: string | null;
+}
+
+export interface CancelRequest {
+	id: number;
+}
+
+export interface ImportedAlarm {
+	id: number;
+	hour: number;
+	minute: number;
+	label: string;
+}
+
+export interface PickAlarmSoundOptions {
+	existingUri?: string | null;
+	title?: string;
+	showSilent?: boolean;
+	showDefault?: boolean;
+}
+
+export interface PickedAlarmSound {
+	uri: string | null;
+	isSilent: boolean;
+	title: string | null;
+}
+
+export async function schedule(payload: ScheduleRequest): Promise<void> {
+	await invoke('plugin:alarm-manager|schedule', { payload });
+}
+
+export async function cancel(payload: CancelRequest): Promise<void> {
+	await invoke('plugin:alarm-manager|cancel', { payload });
+}
+
+/** Native alarms created outside the app (e.g. via a "Set Alarm" intent), pending import. */
+export async function getLaunchArgs(): Promise<ImportedAlarm[]> {
+	return (await invoke<ImportedAlarm[]>('plugin:alarm-manager|get_launch_args')) ?? [];
+}
+
+/** Opens the Android system alarm sound picker. */
+export async function pickAlarmSound(options: PickAlarmSoundOptions): Promise<PickedAlarmSound> {
+	return await invoke<PickedAlarmSound>('plugin:alarm-manager|pick_alarm_sound', { options });
+}
+
+export async function stopRinging(): Promise<void> {
+	await invoke('plugin:alarm-manager|stop_ringing');
+}

--- a/plugins/alarm-manager/package.json
+++ b/plugins/alarm-manager/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "tauri-plugin-alarm-manager-api",
+  "version": "0.1.0",
+  "author": "Threshold",
+  "description": "",
+  "type": "module",
+  "types": "./guest-js/index.ts",
+  "main": "./dist-js/index.cjs",
+  "module": "./dist-js/index.js",
+  "exports": {
+    "types": "./guest-js/index.ts",
+    "source": "./guest-js/index.ts",
+    "import": "./dist-js/index.js",
+    "require": "./dist-js/index.cjs",
+    "default": "./dist-js/index.js"
+  },
+  "files": [
+    "dist-js",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "prepublishOnly": "pnpm build",
+    "pretest": "pnpm build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
+    "rollup": "^4.9.6",
+    "typescript": "^5.3.3",
+    "tslib": "^2.6.2"
+  }
+}

--- a/plugins/alarm-manager/rollup.config.js
+++ b/plugins/alarm-manager/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
+import typescript from '@rollup/plugin-typescript'
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
+
+export default {
+  input: 'guest-js/index.ts',
+  output: [
+    {
+      file: pkg.exports.import,
+      format: 'esm'
+    },
+    {
+      file: pkg.exports.require,
+      format: 'cjs'
+    }
+  ],
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: dirname(pkg.exports.import)
+    })
+  ],
+  external: [
+    /^@tauri-apps\/api/,
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {})
+  ]
+}

--- a/plugins/alarm-manager/tsconfig.json
+++ b/plugins/alarm-manager/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitAny": true,
+    "noEmit": true
+  },
+  "include": ["guest-js/*.ts"],
+  "exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.3(react@19.2.3)
+      tauri-plugin-alarm-manager-api:
+        specifier: workspace:*
+        version: link:../../plugins/alarm-manager
       tauri-plugin-app-events-api:
         specifier: ^0.2.0
         version: 0.2.0
@@ -145,6 +148,25 @@ importers:
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.0.9)(jsdom@27.4.0)
+
+  plugins/alarm-manager:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
 
   plugins/app-management:
     dependencies:


### PR DESCRIPTION
## Summary

The highest-value slice of #205: alarm-manager is the busiest TS↔Rust boundary in the app (5 `invoke()` call sites) and the one the audit specifically called out — `AlarmManagerService.ts:23` hand-redeclared `ImportedAlarm` with the comment *"Define the plugin invoke types manually since we can't import from the plugin in this environment"*. `AlarmSoundPickerService.ts` independently hand-declared `PickAlarmSoundOptions`/`PickedAlarmSound` too.

Adds `plugins/alarm-manager/guest-js/index.ts` (`schedule`, `cancel`, `getLaunchArgs`, `pickAlarmSound`, `stopRinging`), mirroring the exact `package.json`/`rollup.config.js`/`tsconfig.json` shape used for the other plugins in this effort (#221/#223), and migrates all 5 real call sites plus both hand-declared type sites to import from the package instead.

The guest-js layer stays a thin 1:1 wrapper over `invoke()` — no business logic. The `showSilent`/`showDefault` default-filling stays in `AlarmSoundPickerService`, which owns that policy; the binding just exposes the raw command.

## Test plan

- [x] `pnpm -r run typecheck` — clean across all workspace projects
- [x] `pnpm --filter threshold test` — 49/49 passing (including `AlarmManagerService.test.ts` and `AlarmSoundPickerService.test.ts`, both unchanged since they mock the underlying `invoke()` the guest-js wraps)
- [x] `pnpm --filter tauri-plugin-alarm-manager-api build` (rollup) — builds cleanly to `dist-js/`
- [x] `cargo build --workspace` — unaffected (no Rust changes in this slice)
- [x] Kotlin compile-checked locally (`./gradlew testDebugUnitTest` against the real Tauri Android sources, matching CI's `test-kotlin-plugins` job) — `BUILD SUCCESSFUL`
- [x] Confirmed no raw `invoke('plugin:alarm-manager|...')` call sites remain outside tests

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2