### PR TITLE
Stop AlarmService.subscribe clobbering earlier subscribers

### DIFF
--- a/apps/threshold/src/services/AlarmService.test.ts
+++ b/apps/threshold/src/services/AlarmService.test.ts
@@ -51,21 +51,25 @@ describe('AlarmService', () => {
             expect(invoke).toHaveBeenCalledWith('get_alarms');
             expect(callback).toHaveBeenCalledWith([mockAlarm]);
         });
-    });
 
-    describe('unsubscribe', () => {
-        it('should call unlisten function if subscribed', async () => {
-            const mockUnlisten = vi.fn();
-            (listen as any).mockResolvedValue(mockUnlisten);
-            await AlarmService.subscribe(vi.fn());
+        it('returns independent cleanup functions for concurrent subscriptions', async () => {
+            const unlistenA = vi.fn();
+            const unlistenB = vi.fn();
+            (listen as any)
+                .mockResolvedValueOnce(unlistenA)
+                .mockResolvedValueOnce(unlistenB);
 
-            await AlarmService.unsubscribe();
+            const cleanupA = await AlarmService.subscribe(vi.fn());
+            const cleanupB = await AlarmService.subscribe(vi.fn());
+            cleanupA();
 
-            expect(mockUnlisten).toHaveBeenCalled();
-        });
+            expect(unlistenA).toHaveBeenCalledTimes(1);
+            expect(unlistenB).not.toHaveBeenCalled();
 
-        it('should do nothing if not subscribed', async () => {
-            await AlarmService.unsubscribe();
+            cleanupB();
+
+            expect(unlistenB).toHaveBeenCalledTimes(1);
+            expect(unlistenA).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/apps/threshold/src/services/AlarmService.ts
+++ b/apps/threshold/src/services/AlarmService.ts
@@ -3,33 +3,15 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import type { AlarmRecord, AlarmInput } from '../types/alarm';
 
 export class AlarmService {
-    private static unlistenFns: UnlistenFn[] = [];
-
     /**
-     * Subscribe to alarm changes
+     * Subscribe to alarm changes. Returns a cleanup function for this
+     * specific subscription -- call it to stop listening.
      */
     static async subscribe(callback: (alarms: AlarmRecord[]) => void): Promise<UnlistenFn> {
-        const unlisten = await listen('alarms:batch:updated', async () => {
+        return await listen('alarms:batch:updated', async () => {
             const alarms = await this.getAll();
             callback(alarms);
         });
-
-        this.unlistenFns = [unlisten];
-
-        return () => {
-            this.unlistenFns.forEach((fn) => fn());
-            this.unlistenFns = [];
-        };
-    }
-
-    /**
-     * Unsubscribe from alarm changes
-     */
-    static async unsubscribe() {
-        if (this.unlistenFns.length > 0) {
-            this.unlistenFns.forEach((fn) => fn());
-            this.unlistenFns = [];
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #201. `AlarmService.subscribe` kept a static `unlistenFns` array shared across all callers and overwrote it (`this.unlistenFns = [unlisten]`) on every call instead of appending. A second `subscribe()` call silently discarded the first subscriber's cleanup handle from tracking, and the returned per-subscription cleanup closure read the shared array at *invocation* time rather than *creation* time — so calling one subscriber's cleanup could tear down a *different* subscriber's listener entirely, if a second `subscribe()` happened in between.

Not theoretical: `main.tsx` wraps the app in `React.StrictMode`, which double-invokes effects in dev, and `AlarmsContext.tsx` (the only production caller) subscribes inside a mount `useEffect` — this fires on every dev session today. Production builds don't use StrictMode, so `subscribe()` likely only runs once per app lifetime there, but the shared static state was a latent bug regardless of caller count.

## Fix

Removed the static bookkeeping entirely and made `subscribe()` return `listen()`'s raw unlisten handle directly — simpler than the code it replaces, not just safer. `AlarmsContext.tsx`'s existing `unlistenPromise.then(unlisten => unlisten())` cleanup pattern needs no changes, since `subscribe()`'s return type (`Promise<UnlistenFn>`) is unchanged. Also removed the dead `unsubscribe()` static method, which had zero production callers (confirmed via grep — only referenced in its own test file).

## Test plan

- [x] `pnpm --filter threshold test` — 48/48 passing, including a new regression test proving two concurrent subscriptions get independent, non-interfering cleanup functions
- [x] `pnpm -r run typecheck` — clean
- [x] Removed the two `unsubscribe()` tests (method no longer exists)
- No Rust/Kotlin changes — pure TS fix

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2