### PR TITLE
Add app-management to the Cargo workspace and exclude vendor/ from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 coverage
+vendor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "apps/threshold/src-tauri",
     "plugins/alarm-manager",
+    "plugins/app-management",
     "plugins/wear-sync",
     "plugins/theme-utils",
     "plugins/time-prefs",


### PR DESCRIPTION
## Summary

Part of #206's house-rules hygiene sweep (first of several PRs).

- **`plugins/app-management` was missing from `Cargo.toml`'s workspace `members`** — its Rust code and 2 tests never ran under `cargo build --workspace`/`cargo test --workspace`, so CI's `test-rust` job silently skipped this plugin entirely. Verified adding it compiles clean workspace-wide with no hidden issues, and both its existing tests (`test_plugin_init`, `test_error_serialization`) run and pass.
- **`.prettierignore` was missing a `vendor/` entry** — a workspace-wide `prettier --check` would otherwise falsely flag ~280 third-party files in the vendored `tauri-plugins-workspace` submodule. Needed before `pnpm format:check` can be meaningfully re-enabled in CI (a later PR in this sweep).

## Test plan

- [x] `cargo build --workspace` — clean, `app-management` compiles alongside everything else
- [x] `cargo nextest run --workspace` — 71/71 passing, including `app-management`'s 2 tests (was 0 before this PR)
- [x] `npx prettier --check .` — confirmed `vendor/` no longer appears in the flagged file list

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2