### PR TITLE
Apply cargo fmt across the workspace and re-enable the CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,8 +129,8 @@ jobs:
           name: rust-test-results
           path: target/nextest/ci/junit.xml
 
-      # - name: Rust Format Check
-      #   run: cargo fmt --all -- --check
+      - name: Rust Format Check
+        run: cargo fmt --all -- --check
 
       # - name: Rust Clippy
       #   run: cargo clippy --all-features -- -D warnings

--- a/apps/threshold/src-tauri/src/alarm/database.rs
+++ b/apps/threshold/src-tauri/src/alarm/database.rs
@@ -1,8 +1,11 @@
-use tauri::{AppHandle, Runtime, Manager};
-use tauri_plugin_sql::{Migration, MigrationKind};
-use crate::alarm::{models::*, error::{Result, Error}};
+use crate::alarm::{
+    error::{Error, Result},
+    models::*,
+};
 use sqlx::sqlite::SqlitePool;
 use sqlx::Row;
+use tauri::{AppHandle, Manager, Runtime};
+use tauri_plugin_sql::{Migration, MigrationKind};
 
 pub struct AlarmDatabase {
     pool: SqlitePool,
@@ -23,7 +26,7 @@ impl AlarmDatabase {
             .connect_with(
                 sqlx::sqlite::SqliteConnectOptions::new()
                     .filename(db_path)
-                    .create_if_missing(true)
+                    .create_if_missing(true),
             )
             .await?;
 
@@ -43,16 +46,17 @@ impl AlarmDatabase {
         let mut tx = self.pool.begin().await?;
 
         // Atomic increment
-        sqlx::query("UPDATE state_revision SET current_revision = current_revision + 1 WHERE id = 1")
-            .execute(&mut *tx)
-            .await?;
+        sqlx::query(
+            "UPDATE state_revision SET current_revision = current_revision + 1 WHERE id = 1",
+        )
+        .execute(&mut *tx)
+        .await?;
 
         // Fetch new value
-        let (rev,): (i64,) = sqlx::query_as(
-            "SELECT current_revision FROM state_revision WHERE id = 1"
-        )
-        .fetch_one(&mut *tx)
-        .await?;
+        let (rev,): (i64,) =
+            sqlx::query_as("SELECT current_revision FROM state_revision WHERE id = 1")
+                .fetch_one(&mut *tx)
+                .await?;
 
         tx.commit().await?;
         Ok(rev)
@@ -60,11 +64,10 @@ impl AlarmDatabase {
 
     /// Get current revision without incrementing
     pub async fn current_revision(&self) -> Result<i64> {
-        let (rev,): (i64,) = sqlx::query_as(
-            "SELECT current_revision FROM state_revision WHERE id = 1"
-        )
-        .fetch_one(&self.pool)
-        .await?;
+        let (rev,): (i64,) =
+            sqlx::query_as("SELECT current_revision FROM state_revision WHERE id = 1")
+                .fetch_one(&self.pool)
+                .await?;
 
         Ok(rev)
     }
@@ -110,7 +113,7 @@ impl AlarmDatabase {
                     label=?, enabled=?, mode=?, fixed_time=?, window_start=?,
                     window_end=?, active_days=?, next_trigger=?, sound_uri=?, sound_title=?,
                     revision=?
-                WHERE id=?"
+                WHERE id=?",
             )
             .bind(input.label)
             .bind(enabled_int)
@@ -134,7 +137,7 @@ impl AlarmDatabase {
                 "INSERT INTO alarms
                     (label, enabled, mode, fixed_time, window_start, window_end,
                      active_days, next_trigger, sound_uri, sound_title, revision)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(input.label)
             .bind(enabled_int)
@@ -168,14 +171,12 @@ impl AlarmDatabase {
         next_trigger: Option<i64>,
         revision: i64,
     ) -> Result<AlarmRecord> {
-        sqlx::query(
-            "UPDATE alarms SET next_trigger = ?, revision = ? WHERE id = ?"
-        )
-        .bind(next_trigger)
-        .bind(revision)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("UPDATE alarms SET next_trigger = ?, revision = ? WHERE id = ?")
+            .bind(next_trigger)
+            .bind(revision)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
 
         self.get_by_id(id).await
     }
@@ -185,12 +186,11 @@ impl AlarmDatabase {
         let mut tx = self.pool.begin().await?;
 
         // Get label before deleting
-        let label: Option<(Option<String>,)> = sqlx::query_as(
-            "SELECT label FROM alarms WHERE id = ?"
-        )
-        .bind(id)
-        .fetch_optional(&mut *tx)
-        .await?;
+        let label: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT label FROM alarms WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&mut *tx)
+                .await?;
 
         // Delete alarm
         sqlx::query("DELETE FROM alarms WHERE id = ?")
@@ -216,24 +216,22 @@ impl AlarmDatabase {
 
     /// Get alarms changed since revision (for incremental sync)
     pub async fn get_alarms_since_revision(&self, since: i64) -> Result<Vec<AlarmRecord>> {
-        let rows = sqlx::query_as::<_, AlarmRow>(
-            "SELECT * FROM alarms WHERE revision > ? ORDER BY id"
-        )
-        .bind(since)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows =
+            sqlx::query_as::<_, AlarmRow>("SELECT * FROM alarms WHERE revision > ? ORDER BY id")
+                .bind(since)
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(rows.into_iter().map(|r| r.into()).collect())
     }
 
     /// Get deleted alarm IDs since revision (for incremental sync)
     pub async fn get_deleted_since_revision(&self, since: i64) -> Result<Vec<i32>> {
-        let rows: Vec<(i32,)> = sqlx::query_as(
-            "SELECT alarm_id FROM alarm_tombstones WHERE deleted_at_revision > ?"
-        )
-        .bind(since)
-        .fetch_all(&self.pool)
-        .await?;
+        let rows: Vec<(i32,)> =
+            sqlx::query_as("SELECT alarm_id FROM alarm_tombstones WHERE deleted_at_revision > ?")
+                .bind(since)
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
@@ -271,7 +269,7 @@ impl AlarmDatabase {
                         sound_uri TEXT,
                         sound_title TEXT
                     )
-                "#
+                "#,
             )
             .execute(pool)
             .await?;
@@ -296,7 +294,7 @@ impl AlarmDatabase {
                         id INTEGER PRIMARY KEY CHECK (id = 1),
                         current_revision INTEGER NOT NULL DEFAULT 0
                     )
-                "#
+                "#,
             )
             .execute(pool)
             .await?;
@@ -315,7 +313,7 @@ impl AlarmDatabase {
                         deleted_at_timestamp INTEGER NOT NULL,
                         label TEXT
                     )
-                "#
+                "#,
             )
             .execute(pool)
             .await?;
@@ -332,12 +330,11 @@ impl AlarmDatabase {
     }
 
     async fn table_exists(pool: &SqlitePool, name: &str) -> Result<bool> {
-        let exists: Option<(i64,)> = sqlx::query_as(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1"
-        )
-        .bind(name)
-        .fetch_optional(pool)
-        .await?;
+        let exists: Option<(i64,)> =
+            sqlx::query_as("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
+                .bind(name)
+                .fetch_optional(pool)
+                .await?;
 
         Ok(exists.is_some())
     }
@@ -378,16 +375,23 @@ impl From<AlarmRow> for AlarmRecord {
             "FIXED" => AlarmMode::Fixed,
             "WINDOW" => AlarmMode::Window,
             _ => {
-                log::warn!("Invalid alarm mode '{}' for alarm {}, defaulting to FIXED", row.mode, row.id);
+                log::warn!(
+                    "Invalid alarm mode '{}' for alarm {}, defaulting to FIXED",
+                    row.mode,
+                    row.id
+                );
                 AlarmMode::Fixed
             }
         };
 
-        let active_days: Vec<i32> = serde_json::from_str(&row.active_days)
-            .unwrap_or_else(|e| {
-                log::warn!("Failed to parse active_days for alarm {}: {}, using empty array", row.id, e);
-                vec![]
-            });
+        let active_days: Vec<i32> = serde_json::from_str(&row.active_days).unwrap_or_else(|e| {
+            log::warn!(
+                "Failed to parse active_days for alarm {}: {}, using empty array",
+                row.id,
+                e
+            );
+            vec![]
+        });
 
         Self {
             id: row.id,
@@ -630,7 +634,7 @@ mod tests {
 
         let result = db.get_by_id(999).await;
         assert!(result.is_err());
-        
+
         if let Err(Error::Database(msg)) = result {
             assert!(msg.contains("not found"));
         } else {
@@ -760,7 +764,7 @@ mod tests {
             sound_title: None,
         };
         let alarm = db.save(input, None, 1).await.unwrap();
-        
+
         assert_eq!(alarm.active_days, vec![0, 2, 4, 6]);
 
         // Verify by fetching
@@ -785,7 +789,7 @@ mod tests {
             sound_title: None,
         };
         let alarm = db.save(input, None, 1).await.unwrap();
-        
+
         assert_eq!(alarm.active_days, Vec::<i32>::new());
 
         let fetched = db.get_by_id(alarm.id).await.unwrap();
@@ -809,7 +813,7 @@ mod tests {
             sound_title: None,
         };
         let alarm = db.save(input, None, 1).await.unwrap();
-        
+
         assert_eq!(alarm.label, None);
         assert_eq!(alarm.sound_uri, None);
         assert_eq!(alarm.sound_title, None);
@@ -909,8 +913,14 @@ mod tests {
     async fn test_incremental_sync() {
         let db = setup_test_db().await;
 
-        let input1 = AlarmInput { label: Some("A".into()), ..Default::default() };
-        let input2 = AlarmInput { label: Some("B".into()), ..Default::default() };
+        let input1 = AlarmInput {
+            label: Some("A".into()),
+            ..Default::default()
+        };
+        let input2 = AlarmInput {
+            label: Some("B".into()),
+            ..Default::default()
+        };
 
         let rev1 = db.next_revision().await.unwrap();
         db.save(input1, None, rev1).await.unwrap();
@@ -930,7 +940,10 @@ mod tests {
     async fn test_delete_with_tombstone() {
         let db = setup_test_db().await;
 
-        let input = AlarmInput { label: Some("To Delete".into()), ..Default::default() };
+        let input = AlarmInput {
+            label: Some("To Delete".into()),
+            ..Default::default()
+        };
         let rev1 = db.next_revision().await.unwrap();
         let alarm = db.save(input, None, rev1).await.unwrap();
 

--- a/apps/threshold/src-tauri/src/alarm/events.rs
+++ b/apps/threshold/src-tauri/src/alarm/events.rs
@@ -3,8 +3,8 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::alarm::models::{AlarmMode, AlarmRecord};
 use serde::{Deserialize, Serialize};
-use crate::alarm::models::{AlarmRecord, AlarmMode};
 
 // =========================================================================
 // CRUD Events
@@ -88,10 +88,10 @@ pub struct AlarmCancelled {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// Enumerates why a scheduled alarm was cancelled.
 pub enum CancelReason {
-    Disabled,   // User toggled off
-    Deleted,    // User deleted alarm
-    Updated,    // Rescheduling with new trigger
-    Expired,    // One-time alarm fired
+    Disabled, // User toggled off
+    Deleted,  // User deleted alarm
+    Updated,  // Rescheduling with new trigger
+    Expired,  // One-time alarm fired
 }
 
 // =========================================================================
@@ -198,8 +198,8 @@ pub struct AlarmsSyncNeeded {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// Enumerates why an explicit sync was requested.
 pub enum SyncReason {
-    BatchComplete,  // Debounce timer expired
-    Initialize,     // App startup
-    Reconnect,      // Watch reconnected
-    ForceSync,      // User requested
+    BatchComplete, // Debounce timer expired
+    Initialize,    // App startup
+    Reconnect,     // Watch reconnected
+    ForceSync,     // User requested
 }

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -4,17 +4,17 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 pub mod database;
+pub mod error;
 pub mod events;
 pub mod models;
 pub mod scheduler;
-pub mod error;
 
-pub use models::*;
 pub use error::{Error, Result};
 use events::*;
+pub use models::*;
 
-use tauri::{AppHandle, Emitter, Manager, Runtime};
 use database::AlarmDatabase;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 /// Central coordinator for all alarm operations
 pub struct AlarmCoordinator {
@@ -48,11 +48,7 @@ impl AlarmCoordinator {
     ///
     /// - `_app`: app handle for event context (unused here).
     /// - `id`: alarm identifier.
-    pub async fn get_alarm<R: Runtime>(
-        &self,
-        _app: &AppHandle<R>,
-        id: i32,
-    ) -> Result<AlarmRecord> {
+    pub async fn get_alarm<R: Runtime>(&self, _app: &AppHandle<R>, id: i32) -> Result<AlarmRecord> {
         self.db.get_by_id(id).await
     }
 
@@ -93,14 +89,17 @@ impl AlarmCoordinator {
             self.emit_alarm_created(app, &alarm, revision).await?;
         } else {
             let snapshot = previous.as_ref().map(|p| AlarmSnapshot::from_alarm(p));
-            self.emit_alarm_updated(app, &alarm, snapshot, revision).await?;
+            self.emit_alarm_updated(app, &alarm, snapshot, revision)
+                .await?;
         }
 
         // 2. Scheduling events
-        self.emit_scheduling_events(app, &alarm, previous.as_ref(), revision).await?;
+        self.emit_scheduling_events(app, &alarm, previous.as_ref(), revision)
+            .await?;
 
         // 3. Batch event
-        self.emit_batch_update(app, vec![alarm.id], revision).await?;
+        self.emit_batch_update(app, vec![alarm.id], revision)
+            .await?;
 
         Ok(alarm)
     }
@@ -138,11 +137,7 @@ impl AlarmCoordinator {
     ///
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
-    pub async fn delete_alarm<R: Runtime>(
-        &self,
-        app: &AppHandle<R>,
-        id: i32,
-    ) -> Result<()> {
+    pub async fn delete_alarm<R: Runtime>(&self, app: &AppHandle<R>, id: i32) -> Result<()> {
         let revision = self.db.next_revision().await?;
 
         // Get alarm info before delete (for label)
@@ -151,8 +146,15 @@ impl AlarmCoordinator {
         self.db.delete_with_revision(id, revision).await?;
 
         // Emit events
-        self.emit_alarm_deleted(app, id, alarm.as_ref().and_then(|a| a.label.clone()), revision).await?;
-        self.emit_alarm_cancelled(app, id, CancelReason::Deleted, revision).await?;
+        self.emit_alarm_deleted(
+            app,
+            id,
+            alarm.as_ref().and_then(|a| a.label.clone()),
+            revision,
+        )
+        .await?;
+        self.emit_alarm_cancelled(app, id, CancelReason::Deleted, revision)
+            .await?;
         self.emit_batch_update(app, vec![id], revision).await?;
 
         Ok(())
@@ -162,11 +164,7 @@ impl AlarmCoordinator {
     ///
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
-    pub async fn dismiss_alarm<R: Runtime>(
-        &self,
-        app: &AppHandle<R>,
-        id: i32,
-    ) -> Result<()> {
+    pub async fn dismiss_alarm<R: Runtime>(&self, app: &AppHandle<R>, id: i32) -> Result<()> {
         let alarm = self.db.get_by_id(id).await?;
 
         // Emit dismissed event
@@ -216,8 +214,10 @@ impl AlarmCoordinator {
             &new_alarm,
             Some(AlarmSnapshot::from_alarm(&alarm)),
             revision,
-        ).await?;
-        self.emit_scheduling_events(app, &new_alarm, Some(&alarm), revision).await?;
+        )
+        .await?;
+        self.emit_scheduling_events(app, &new_alarm, Some(&alarm), revision)
+            .await?;
         self.emit_batch_update(app, vec![id], revision).await?;
 
         // Emit dismissed event
@@ -256,7 +256,10 @@ impl AlarmCoordinator {
         let original_trigger = alarm.next_trigger.unwrap_or(now);
 
         let revision = self.db.next_revision().await?;
-        let updated = self.db.update_next_trigger(id, Some(snoozed_until), revision).await?;
+        let updated = self
+            .db
+            .update_next_trigger(id, Some(snoozed_until), revision)
+            .await?;
 
         let event = AlarmSnoozed {
             id,
@@ -266,7 +269,8 @@ impl AlarmCoordinator {
         };
         app.emit("alarm:snoozed", &event)?;
 
-        self.emit_scheduling_events(app, &updated, Some(&alarm), revision).await?;
+        self.emit_scheduling_events(app, &updated, Some(&alarm), revision)
+            .await?;
         self.emit_batch_update(app, vec![id], revision).await?;
 
         Ok(())
@@ -369,17 +373,22 @@ impl AlarmCoordinator {
         log::info!("🔧 Starting heal-on-launch: syncing alarm-manager cache with DB");
 
         let alarms = self.get_all_alarms(app).await?;
-        let enabled_count = alarms.iter()
+        let enabled_count = alarms
+            .iter()
             .filter(|a| a.enabled && a.next_trigger.is_some())
             .count();
 
-        log::info!("Found {} enabled alarms, re-emitting scheduling events", enabled_count);
+        log::info!(
+            "Found {} enabled alarms, re-emitting scheduling events",
+            enabled_count
+        );
 
         for alarm in alarms {
             if alarm.enabled && alarm.next_trigger.is_some() {
                 // Re-emit scheduling event to heal SharedPreferences cache
                 // We use the alarm's *current* revision because we aren't changing it, just re-syncing
-                self.emit_alarm_scheduled(app, &alarm, alarm.revision).await?;
+                self.emit_alarm_scheduled(app, &alarm, alarm.revision)
+                    .await?;
             }
         }
 
@@ -484,7 +493,7 @@ impl AlarmCoordinator {
             (false, true) => {
                 // Schedule
                 self.emit_alarm_scheduled(app, alarm, revision).await?;
-            },
+            }
             (true, false) => {
                 // Cancel
                 let reason = if alarm.enabled {
@@ -492,8 +501,9 @@ impl AlarmCoordinator {
                 } else {
                     CancelReason::Disabled
                 };
-                self.emit_alarm_cancelled(app, alarm.id, reason, revision).await?;
-            },
+                self.emit_alarm_cancelled(app, alarm.id, reason, revision)
+                    .await?;
+            }
             (true, true) => {
                 // Check if trigger changed
                 let trigger_changed = previous
@@ -501,11 +511,12 @@ impl AlarmCoordinator {
                     .unwrap_or(false);
 
                 if trigger_changed {
-                    self.emit_alarm_cancelled(app, alarm.id, CancelReason::Updated, revision).await?;
+                    self.emit_alarm_cancelled(app, alarm.id, CancelReason::Updated, revision)
+                        .await?;
                     self.emit_alarm_scheduled(app, alarm, revision).await?;
                 }
-            },
-            (false, false) => {},
+            }
+            (false, false) => {}
         }
 
         Ok(())

--- a/apps/threshold/src-tauri/src/alarm/models.rs
+++ b/apps/threshold/src-tauri/src/alarm/models.rs
@@ -10,16 +10,16 @@ pub struct AlarmRecord {
     pub enabled: bool,
     #[cfg_attr(test, ts(type = "AlarmMode"))]
     pub mode: AlarmMode,
-    pub fixed_time: Option<String>,       // "HH:MM"
-    pub window_start: Option<String>,     // "HH:MM"
-    pub window_end: Option<String>,       // "HH:MM"
-    pub active_days: Vec<i32>,             // [0-6] where 0=Sun
+    pub fixed_time: Option<String>,   // "HH:MM"
+    pub window_start: Option<String>, // "HH:MM"
+    pub window_end: Option<String>,   // "HH:MM"
+    pub active_days: Vec<i32>,        // [0-6] where 0=Sun
     // i64 -> bigint by default in ts-rs; these are millisecond timestamps and
     // a revision counter, both safely within JS's Number.MAX_SAFE_INTEGER for
     // the app's realistic lifetime, and all existing call sites already treat
     // them as `number`.
     #[cfg_attr(test, ts(type = "number | null"))]
-    pub next_trigger: Option<i64>,         // Epoch millis
+    pub next_trigger: Option<i64>, // Epoch millis
     pub sound_uri: Option<String>,
     pub sound_title: Option<String>,
     #[cfg_attr(test, ts(type = "number"))]
@@ -127,7 +127,8 @@ export { AlarmMode };
         let path = output_path();
 
         if std::env::var("UPDATE_TS_BINDINGS").is_ok() {
-            fs::write(&path, &generated).expect("failed to write apps/threshold/src/types/alarm.ts");
+            fs::write(&path, &generated)
+                .expect("failed to write apps/threshold/src/types/alarm.ts");
             return;
         }
 

--- a/apps/threshold/src-tauri/src/alarm/scheduler.rs
+++ b/apps/threshold/src-tauri/src/alarm/scheduler.rs
@@ -3,10 +3,10 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use chrono::{Datelike, Local, NaiveTime, Timelike};
+use crate::alarm::{error::Result, models::*};
 use chrono::{DateTime, TimeZone};
+use chrono::{Datelike, Local, NaiveTime, Timelike};
 use rand::Rng;
-use crate::alarm::{models::*, error::Result};
 
 /// Minimum lead time when sampling inside an already-open window, so the
 /// alarm never fires "immediately" the moment it's enabled.
@@ -48,17 +48,23 @@ fn calculate_next_trigger_from(
 
     match alarm.mode {
         AlarmMode::Fixed => {
-            let time = alarm.fixed_time.as_ref()
+            let time = alarm
+                .fixed_time
+                .as_ref()
                 .ok_or("Fixed alarm missing fixedTime")?;
             calculate_fixed_trigger(time, &alarm.active_days, now)
-        },
+        }
         AlarmMode::Window => {
-            let start = alarm.window_start.as_ref()
+            let start = alarm
+                .window_start
+                .as_ref()
                 .ok_or("Window alarm missing windowStart")?;
-            let end = alarm.window_end.as_ref()
+            let end = alarm
+                .window_end
+                .as_ref()
                 .ok_or("Window alarm missing windowEnd")?;
             calculate_window_trigger(start, end, &alarm.active_days, now, kind)
-        },
+        }
     }
 }
 
@@ -133,14 +139,9 @@ fn calculate_window_trigger(
         let weekday = candidate.weekday().num_days_from_sunday() as i32;
 
         if active_days.contains(&weekday) {
-            if let Some(trigger) = sample_window_for_day(
-                candidate,
-                start_time,
-                end_time,
-                crosses_midnight,
-                now,
-                kind,
-            )? {
+            if let Some(trigger) =
+                sample_window_for_day(candidate, start_time, end_time, crosses_midnight, now, kind)?
+            {
                 return Ok(Some(trigger));
             }
         }
@@ -190,7 +191,10 @@ fn sample_window_for_day(
         ReferenceKind::Fresh if window_start <= now => {
             // Already inside the window: sample the remaining time, with a
             // small lead so the alarm never fires "immediately".
-            std::cmp::max(now + chrono::Duration::seconds(MIN_LEAD_SECONDS), window_start)
+            std::cmp::max(
+                now + chrono::Duration::seconds(MIN_LEAD_SECONDS),
+                window_start,
+            )
         }
         _ if window_start > now => window_start,
         // Not eligible for in-progress sampling and the window has already
@@ -238,7 +242,7 @@ fn ceil_to_minute(dt: DateTime<Local>) -> DateTime<Local> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Datelike, DateTime};
+    use chrono::{DateTime, Datelike};
 
     #[test]
     fn test_fixed_alarm_calculation() {
@@ -302,7 +306,9 @@ mod tests {
         };
 
         let trigger_ts = calculate_next_trigger(&input).unwrap().unwrap();
-        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts).unwrap().with_timezone(&Local);
+        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts)
+            .unwrap()
+            .with_timezone(&Local);
 
         assert!(trigger_dt > now);
 
@@ -330,7 +336,9 @@ mod tests {
         };
 
         let trigger_ts = calculate_next_trigger(&input).unwrap().unwrap();
-        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts).unwrap().with_timezone(&Local);
+        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts)
+            .unwrap()
+            .with_timezone(&Local);
 
         assert!(trigger_dt > now);
 
@@ -426,8 +434,12 @@ mod tests {
             .earliest()
             .unwrap();
         let today_idx = now.weekday().num_days_from_sunday() as i32;
-        let start = (now - chrono::Duration::minutes(10)).format("%H:%M").to_string();
-        let end = (now + chrono::Duration::minutes(20)).format("%H:%M").to_string();
+        let start = (now - chrono::Duration::minutes(10))
+            .format("%H:%M")
+            .to_string();
+        let end = (now + chrono::Duration::minutes(20))
+            .format("%H:%M")
+            .to_string();
 
         let input = AlarmInput {
             enabled: true,
@@ -438,13 +450,20 @@ mod tests {
             ..Default::default()
         };
 
-        let trigger_ts = calculate_next_trigger_from(&input, now, ReferenceKind::Fresh).unwrap().unwrap();
-        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts).unwrap().with_timezone(&Local);
+        let trigger_ts = calculate_next_trigger_from(&input, now, ReferenceKind::Fresh)
+            .unwrap()
+            .unwrap();
+        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts)
+            .unwrap()
+            .with_timezone(&Local);
 
         // Should sample from the remaining time of today's window, not skip to next week.
         assert!(trigger_dt > now);
         assert!(trigger_dt.signed_duration_since(now) < chrono::Duration::minutes(21));
-        assert_eq!(trigger_dt.weekday().num_days_from_sunday() as i32, today_idx);
+        assert_eq!(
+            trigger_dt.weekday().num_days_from_sunday() as i32,
+            today_idx
+        );
     }
 
     #[test]
@@ -475,7 +494,9 @@ mod tests {
         let trigger_ts = calculate_next_trigger_from(&input, synthetic_now, ReferenceKind::Fresh)
             .unwrap()
             .unwrap();
-        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts).unwrap().with_timezone(&Local);
+        let trigger_dt = DateTime::from_timestamp_millis(trigger_ts)
+            .unwrap()
+            .with_timezone(&Local);
 
         // Should sample from the remaining ~50 minutes of last night's window.
         assert!(trigger_dt > synthetic_now);
@@ -493,8 +514,12 @@ mod tests {
             .earliest()
             .unwrap();
         let today_idx = now.weekday().num_days_from_sunday() as i32;
-        let start = (now - chrono::Duration::minutes(10)).format("%H:%M").to_string();
-        let end = (now + chrono::Duration::minutes(20)).format("%H:%M").to_string();
+        let start = (now - chrono::Duration::minutes(10))
+            .format("%H:%M")
+            .to_string();
+        let end = (now + chrono::Duration::minutes(20))
+            .format("%H:%M")
+            .to_string();
 
         let input = AlarmInput {
             enabled: true,
@@ -512,7 +537,9 @@ mod tests {
         let after = calculate_next_trigger_after(&input, fired_at + 1_000).unwrap();
 
         if let Some(ts) = after {
-            let dt = DateTime::from_timestamp_millis(ts).unwrap().with_timezone(&Local);
+            let dt = DateTime::from_timestamp_millis(ts)
+                .unwrap()
+                .with_timezone(&Local);
             // Must not resample later today's remaining window time.
             assert!(dt.signed_duration_since(now) > chrono::Duration::days(6));
         }

--- a/apps/threshold/src-tauri/src/commands.rs
+++ b/apps/threshold/src-tauri/src/commands.rs
@@ -3,8 +3,8 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::alarm::{AlarmCoordinator, AlarmInput, AlarmRecord};
 use crate::alarm::events::SyncReason;
+use crate::alarm::{AlarmCoordinator, AlarmInput, AlarmRecord};
 use crate::SnoozeLengthState;
 use crate::TimeFormatKnownState;
 use crate::TimeFormatState;

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -34,8 +34,8 @@ fn collect_event_logs(app: &AppHandle) -> Result<String, String> {
     let app_version = app.package_info().version.to_string();
 
     let mut entries: Vec<(PathBuf, SystemTime)> = Vec::new();
-    let read_dir = fs::read_dir(&log_dir)
-        .map_err(|err| format!("Failed to read log directory: {err}"))?;
+    let read_dir =
+        fs::read_dir(&log_dir).map_err(|err| format!("Failed to read log directory: {err}"))?;
 
     for entry in read_dir {
         let entry = entry.map_err(|err| format!("Failed to read log entry: {err}"))?;
@@ -138,11 +138,7 @@ pub fn export_event_logs(app: AppHandle, destination: String) -> Result<String, 
     }
 
     fs::write(&destination_path, content)
-        .map_err(|err| {
-            format!(
-                "Failed to write event logs to {normalised_destination}: {err}"
-            )
-        })?;
+        .map_err(|err| format!("Failed to write event logs to {normalised_destination}: {err}"))?;
     Ok(normalised_destination.to_string())
 }
 

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -39,7 +39,8 @@ pub fn init<R: Runtime>(
 ) -> crate::Result<AlarmManager<R>> {
     #[cfg(target_os = "android")]
     let handle = {
-        let handle = api.register_android_plugin("com.plugin.alarmmanager", "AlarmManagerPlugin")?;
+        let handle =
+            api.register_android_plugin("com.plugin.alarmmanager", "AlarmManagerPlugin")?;
         let app_handle = app.clone();
 
         handle.run_mobile_plugin::<()>(
@@ -112,7 +113,8 @@ pub fn init<R: Runtime>(
 
                     if let Some(payload) = payload {
                         log::info!("alarm-manager: dismiss requested id={}", payload.id);
-                        let _ = dismiss_app_handle.emit("alarm-manager:dismiss-requested", &payload);
+                        let _ =
+                            dismiss_app_handle.emit("alarm-manager:dismiss-requested", &payload);
                     } else {
                         log::warn!("alarm-manager: failed to parse dismiss requested payload");
                     }
@@ -170,10 +172,11 @@ impl<R: Runtime> AlarmManager<R> {
             _ => serde_json::Value::Array(vec![]),
         };
 
-        serde_json::from_value::<Vec<ImportedAlarm>>(alarms_value)
-            .map_err(|error| crate::Error::MobilePlugin(format!(
+        serde_json::from_value::<Vec<ImportedAlarm>>(alarms_value).map_err(|error| {
+            crate::Error::MobilePlugin(format!(
                 "failed to deserialize launch args payload: {error}"
-            )))
+            ))
+        })
     }
 
     pub fn pick_alarm_sound(

--- a/plugins/app-management/build.rs
+++ b/plugins/app-management/build.rs
@@ -1,11 +1,11 @@
 const COMMANDS: &[&str] = &["minimize_app"];
 
 fn main() {
-  tauri_plugin::Builder::new(COMMANDS)
-    .android_path("android")
-    .build();
-  
-  inject_android_permissions().expect("Failed to inject Android permissions");
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+
+    inject_android_permissions().expect("Failed to inject Android permissions");
 }
 
 fn inject_android_permissions() -> Result<(), Box<dyn std::error::Error>> {

--- a/plugins/app-management/src/commands.rs
+++ b/plugins/app-management/src/commands.rs
@@ -1,11 +1,9 @@
-use tauri::{AppHandle, command, Runtime};
+use tauri::{command, AppHandle, Runtime};
 
-use crate::Result;
 use crate::AppManagementExt;
+use crate::Result;
 
 #[command]
-pub(crate) async fn minimize_app<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<()> {
+pub(crate) async fn minimize_app<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     app.app_management().minimize_app()
 }

--- a/plugins/app-management/src/desktop.rs
+++ b/plugins/app-management/src/desktop.rs
@@ -1,19 +1,18 @@
 use serde::de::DeserializeOwned;
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
-
 pub fn init<R: Runtime, C: DeserializeOwned>(
-  app: &AppHandle<R>,
-  _api: PluginApi<R, C>,
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
 ) -> crate::Result<AppManagement<R>> {
-  Ok(AppManagement(app.clone()))
+    Ok(AppManagement(app.clone()))
 }
 
 /// Access to the app-management APIs.
 pub struct AppManagement<R: Runtime>(AppHandle<R>);
 
 impl<R: Runtime> AppManagement<R> {
-  pub fn minimize_app(&self) -> crate::Result<()> {
-    Ok(())
-  }
+    pub fn minimize_app(&self) -> crate::Result<()> {
+        Ok(())
+    }
 }

--- a/plugins/app-management/src/error.rs
+++ b/plugins/app-management/src/error.rs
@@ -4,20 +4,20 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-  #[error(transparent)]
-  Io(#[from] std::io::Error),
-  #[cfg(mobile)]
-  #[error(transparent)]
-  PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[cfg(mobile)]
+    #[error(transparent)]
+    PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
 }
 
 impl Serialize for Error {
-  fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_str(self.to_string().as_ref())
-  }
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
 }
 
 #[cfg(test)]

--- a/plugins/app-management/src/lib.rs
+++ b/plugins/app-management/src/lib.rs
@@ -1,8 +1,7 @@
 use tauri::{
-  plugin::{Builder, TauriPlugin},
-  Manager, Runtime,
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
 };
-
 
 #[cfg(desktop)]
 mod desktop;
@@ -22,28 +21,28 @@ use mobile::AppManagement;
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the app-management APIs.
 pub trait AppManagementExt<R: Runtime> {
-  fn app_management(&self) -> &AppManagement<R>;
+    fn app_management(&self) -> &AppManagement<R>;
 }
 
 impl<R: Runtime, T: Manager<R>> crate::AppManagementExt<R> for T {
-  fn app_management(&self) -> &AppManagement<R> {
-    self.state::<AppManagement<R>>().inner()
-  }
+    fn app_management(&self) -> &AppManagement<R> {
+        self.state::<AppManagement<R>>().inner()
+    }
 }
 
 /// Initializes the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-  Builder::new("app-management")
-    .invoke_handler(tauri::generate_handler![commands::minimize_app])
-    .setup(|app, api| {
-      #[cfg(mobile)]
-      let app_management = mobile::init(app, api)?;
-      #[cfg(desktop)]
-      let app_management = desktop::init(app, api)?;
-      app.manage(app_management);
-      Ok(())
-    })
-    .build()
+    Builder::new("app-management")
+        .invoke_handler(tauri::generate_handler![commands::minimize_app])
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let app_management = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let app_management = desktop::init(app, api)?;
+            app.manage(app_management);
+            Ok(())
+        })
+        .build()
 }
 
 #[cfg(test)]

--- a/plugins/app-management/src/mobile.rs
+++ b/plugins/app-management/src/mobile.rs
@@ -1,42 +1,42 @@
 use serde::de::DeserializeOwned;
 use tauri::{
-  plugin::{PluginApi, PluginHandle},
-  AppHandle, Runtime,
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
 };
 
 // initializes the Kotlin or Swift plugin classes
 pub fn init<R: Runtime, C: DeserializeOwned>(
-  _app: &AppHandle<R>,
-  api: PluginApi<R, C>,
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
 ) -> crate::Result<AppManagement<R>> {
-  #[cfg(target_os = "android")]
-  let handle = api.register_android_plugin("com.plugin.app_management", "AppManagementPlugin")?;
+    #[cfg(target_os = "android")]
+    let handle = api.register_android_plugin("com.plugin.app_management", "AppManagementPlugin")?;
 
-  // NOTE: iOS implementation is deferred. We intentionally do not register an iOS plugin here.
-  // On iOS we don't register anything because we are providing a Rust-side stub only.
-  #[cfg(not(target_os = "android"))]
-  let handle = api.handle().clone();
+    // NOTE: iOS implementation is deferred. We intentionally do not register an iOS plugin here.
+    // On iOS we don't register anything because we are providing a Rust-side stub only.
+    #[cfg(not(target_os = "android"))]
+    let handle = api.handle().clone();
 
-  Ok(AppManagement(handle))
+    Ok(AppManagement(handle))
 }
 
 /// Access to the app-management APIs.
 pub struct AppManagement<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> AppManagement<R> {
-  pub fn minimize_app(&self) -> crate::Result<()> {
-    #[cfg(target_os = "android")]
-    return self
-      .0
-      .run_mobile_plugin("minimizeApp", ())
-      .map_err(Into::into);
+    pub fn minimize_app(&self) -> crate::Result<()> {
+        #[cfg(target_os = "android")]
+        return self
+            .0
+            .run_mobile_plugin("minimizeApp", ())
+            .map_err(Into::into);
 
-    #[cfg(not(target_os = "android"))]
-    return Err(crate::Error::PluginInvoke(
-      tauri::plugin::mobile::PluginInvokeError::from(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        "Not implemented on iOS",
-      )),
-    ));
-  }
+        #[cfg(not(target_os = "android"))]
+        return Err(crate::Error::PluginInvoke(
+            tauri::plugin::mobile::PluginInvokeError::from(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Not implemented on iOS",
+            )),
+        ));
+    }
 }

--- a/plugins/app-management/src/models.rs
+++ b/plugins/app-management/src/models.rs
@@ -1,2 +1,1 @@
-
 // No models currently needed for minimize_app

--- a/plugins/theme-utils/build.rs
+++ b/plugins/theme-utils/build.rs
@@ -1,7 +1,7 @@
 const COMMANDS: &[&str] = &["get_material_you_colours"];
 
 fn main() {
-  tauri_plugin::Builder::new(COMMANDS)
-    .android_path("android")
-    .build();
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
 }

--- a/plugins/theme-utils/src/commands.rs
+++ b/plugins/theme-utils/src/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, command, Runtime};
+use tauri::{command, AppHandle, Runtime};
 
 use crate::models::MaterialYouResponse;
 use crate::ThemeUtilsExt;
@@ -7,5 +7,7 @@ use crate::ThemeUtilsExt;
 pub(crate) async fn get_material_you_colours<R: Runtime>(
     app: AppHandle<R>,
 ) -> Result<MaterialYouResponse, String> {
-    app.theme_utils().get_material_you_colours().map_err(|e| e.to_string())
+    app.theme_utils()
+        .get_material_you_colours()
+        .map_err(|e| e.to_string())
 }

--- a/plugins/theme-utils/src/lib.rs
+++ b/plugins/theme-utils/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
-  plugin::{Builder, TauriPlugin},
-  Manager, Runtime,
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
 };
 
 pub use models::*;
@@ -23,26 +23,26 @@ use mobile::ThemeUtils;
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the theme-utils APIs.
 pub trait ThemeUtilsExt<R: Runtime> {
-  fn theme_utils(&self) -> &ThemeUtils<R>;
+    fn theme_utils(&self) -> &ThemeUtils<R>;
 }
 
 impl<R: Runtime, T: Manager<R>> ThemeUtilsExt<R> for T {
-  fn theme_utils(&self) -> &ThemeUtils<R> {
-    self.state::<ThemeUtils<R>>().inner()
-  }
+    fn theme_utils(&self) -> &ThemeUtils<R> {
+        self.state::<ThemeUtils<R>>().inner()
+    }
 }
 
 /// Initializes the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-  Builder::new("theme-utils")
-    .invoke_handler(tauri::generate_handler![commands::get_material_you_colours])
-    .setup(|app, api| {
-      #[cfg(target_os = "android")]
-      let theme_utils = mobile::init(api, app)?;
-      #[cfg(not(target_os = "android"))]
-      let theme_utils = desktop::init(api, app)?;
-      app.manage(theme_utils);
-      Ok(())
-    })
-    .build()
+    Builder::new("theme-utils")
+        .invoke_handler(tauri::generate_handler![commands::get_material_you_colours])
+        .setup(|app, api| {
+            #[cfg(target_os = "android")]
+            let theme_utils = mobile::init(api, app)?;
+            #[cfg(not(target_os = "android"))]
+            let theme_utils = desktop::init(api, app)?;
+            app.manage(theme_utils);
+            Ok(())
+        })
+        .build()
 }

--- a/plugins/theme-utils/src/mobile.rs
+++ b/plugins/theme-utils/src/mobile.rs
@@ -1,7 +1,7 @@
 use serde::de::DeserializeOwned;
 use tauri::{
-  plugin::{PluginApi, PluginHandle},
-  AppHandle, Runtime,
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
 };
 
 use crate::models::MaterialYouResponse;
@@ -10,21 +10,20 @@ use crate::models::MaterialYouResponse;
 const PLUGIN_IDENTIFIER: &str = "com.plugin.themeutils";
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
-  _api: PluginApi<R, C>,
-  _app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+    _app: &AppHandle<R>,
 ) -> crate::Result<ThemeUtils<R>> {
-  let handle = _api.register_android_plugin(PLUGIN_IDENTIFIER, "ThemeUtilsPlugin")?;
-  Ok(ThemeUtils(handle))
+    let handle = _api.register_android_plugin(PLUGIN_IDENTIFIER, "ThemeUtilsPlugin")?;
+    Ok(ThemeUtils(handle))
 }
 
 /// Access to the theme-utils APIs.
 pub struct ThemeUtils<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> ThemeUtils<R> {
-  pub fn get_material_you_colours(&self) -> crate::Result<MaterialYouResponse> {
-    self
-      .0
-      .run_mobile_plugin("getMaterialYouColours", ())
-      .map_err(Into::into)
-  }
+    pub fn get_material_you_colours(&self) -> crate::Result<MaterialYouResponse> {
+        self.0
+            .run_mobile_plugin("getMaterialYouColours", ())
+            .map_err(Into::into)
+    }
 }

--- a/plugins/time-prefs/src/commands.rs
+++ b/plugins/time-prefs/src/commands.rs
@@ -1,12 +1,10 @@
 use tauri::{command, AppHandle, Runtime};
 
+use crate::error::Result;
 use crate::models::TimeFormatResponse;
 use crate::TimePrefsExt;
-use crate::error::Result;
 
 #[command]
-pub(crate) async fn get_time_format<R: Runtime>(
-    app: AppHandle<R>,
-) -> Result<TimeFormatResponse> {
+pub(crate) async fn get_time_format<R: Runtime>(app: AppHandle<R>) -> Result<TimeFormatResponse> {
     app.time_prefs().get_time_format()
 }

--- a/plugins/time-prefs/src/desktop.rs
+++ b/plugins/time-prefs/src/desktop.rs
@@ -1,22 +1,22 @@
+use crate::models::TimeFormatResponse;
 use serde::de::DeserializeOwned;
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
-use crate::models::TimeFormatResponse;
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
-  app: &AppHandle<R>,
-  _api: PluginApi<R, C>,
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
 ) -> crate::Result<TimePrefs<R>> {
-  Ok(TimePrefs(app.clone()))
+    Ok(TimePrefs(app.clone()))
 }
 
 /// Access to the TimePrefs APIs
 pub struct TimePrefs<R: Runtime>(AppHandle<R>);
 
 impl<R: Runtime> TimePrefs<R> {
-  pub fn get_time_format(&self) -> crate::Result<TimeFormatResponse> {
-    // Desktop implementation should theoretically not be reached if the frontend
-    // handles the logic using Intl. But if called, we return a default.
-    println!("TimePrefs (Desktop): get_time_format called, returning default false (12h)");
-    Ok(TimeFormatResponse { is24_hour: false })
-  }
+    pub fn get_time_format(&self) -> crate::Result<TimeFormatResponse> {
+        // Desktop implementation should theoretically not be reached if the frontend
+        // handles the logic using Intl. But if called, we return a default.
+        println!("TimePrefs (Desktop): get_time_format called, returning default false (12h)");
+        Ok(TimeFormatResponse { is24_hour: false })
+    }
 }

--- a/plugins/time-prefs/src/error.rs
+++ b/plugins/time-prefs/src/error.rs
@@ -2,20 +2,20 @@ use serde::{Serialize, Serializer};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-  #[error(transparent)]
-  Io(#[from] std::io::Error),
-  #[cfg(mobile)]
-  #[error("Mobile plugin not initialized")]
-  PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[cfg(mobile)]
+    #[error("Mobile plugin not initialized")]
+    PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
 }
 
 impl Serialize for Error {
-  fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_str(self.to_string().as_ref())
-  }
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/plugins/time-prefs/src/lib.rs
+++ b/plugins/time-prefs/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
-  plugin::{Builder, TauriPlugin},
-  Manager, Runtime,
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
 };
 
 pub use models::*;
@@ -23,26 +23,26 @@ use mobile::TimePrefs;
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the time-prefs APIs.
 pub trait TimePrefsExt<R: Runtime> {
-  fn time_prefs(&self) -> &TimePrefs<R>;
+    fn time_prefs(&self) -> &TimePrefs<R>;
 }
 
 impl<R: Runtime, T: Manager<R>> TimePrefsExt<R> for T {
-  fn time_prefs(&self) -> &TimePrefs<R> {
-    self.state::<TimePrefs<R>>().inner()
-  }
+    fn time_prefs(&self) -> &TimePrefs<R> {
+        self.state::<TimePrefs<R>>().inner()
+    }
 }
 
 /// Initialises the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-  Builder::new("time-prefs")
-    .invoke_handler(tauri::generate_handler![commands::get_time_format])
-    .setup(|app, api| {
-      #[cfg(mobile)]
-      let time_prefs = mobile::init(app, api)?;
-      #[cfg(desktop)]
-      let time_prefs = desktop::init(app, api)?;
-      app.manage(time_prefs);
-      Ok(())
-    })
-    .build()
+    Builder::new("time-prefs")
+        .invoke_handler(tauri::generate_handler![commands::get_time_format])
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let time_prefs = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let time_prefs = desktop::init(app, api)?;
+            app.manage(time_prefs);
+            Ok(())
+        })
+        .build()
 }

--- a/plugins/toast/build.rs
+++ b/plugins/toast/build.rs
@@ -5,8 +5,7 @@ fn main() {
         .android_path("android")
         .build();
 
-    inject_android_permissions()
-        .expect("Failed to inject Android manifest permissions for toast");
+    inject_android_permissions().expect("Failed to inject Android manifest permissions for toast");
 }
 
 fn inject_android_permissions() -> std::io::Result<()> {

--- a/plugins/toast/src/error.rs
+++ b/plugins/toast/src/error.rs
@@ -4,18 +4,18 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-  #[error(transparent)]
-  Io(#[from] std::io::Error),
-  #[cfg(mobile)]
-  #[error(transparent)]
-  PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[cfg(mobile)]
+    #[error(transparent)]
+    PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
 }
 
 impl Serialize for Error {
-  fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_str(self.to_string().as_ref())
-  }
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
 }

--- a/plugins/toast/src/mobile.rs
+++ b/plugins/toast/src/mobile.rs
@@ -34,6 +34,8 @@ pub struct Toast<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> Toast<R> {
     pub fn show(&self, payload: ShowToastRequest) -> crate::Result<()> {
-        self.0.run_mobile_plugin("show", payload).map_err(Into::into)
+        self.0
+            .run_mobile_plugin("show", payload)
+            .map_err(Into::into)
     }
 }

--- a/plugins/wear-sync/src/batch_collector.rs
+++ b/plugins/wear-sync/src/batch_collector.rs
@@ -3,11 +3,7 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use std::{
-    collections::HashSet,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use tauri::async_runtime::{JoinHandle, Mutex};
 

--- a/plugins/wear-sync/src/desktop.rs
+++ b/plugins/wear-sync/src/desktop.rs
@@ -12,13 +12,8 @@ use tauri::{plugin::PluginApi, AppHandle, Runtime};
 ///
 /// Desktop does not support Wear OS, so all methods are no-ops that
 /// log the call for development visibility.
-pub fn init<R: Runtime>(
-    app: &AppHandle<R>,
-    _api: PluginApi<R, ()>,
-) -> crate::Result<WearSync<R>> {
-    Ok(WearSync {
-        _app: app.clone(),
-    })
+pub fn init<R: Runtime>(app: &AppHandle<R>, _api: PluginApi<R, ()>) -> crate::Result<WearSync<R>> {
+    Ok(WearSync { _app: app.clone() })
 }
 
 /// Desktop stub for the Wear Data Layer bridge.

--- a/plugins/wear-sync/src/lib.rs
+++ b/plugins/wear-sync/src/lib.rs
@@ -68,12 +68,15 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             spawn_publish_task(app.clone(), rx);
 
             let publisher: Arc<dyn WearSyncPublisher> = Arc::new(ChannelPublisher::new(tx));
-            let batch_collector =
-                Arc::new(BatchCollector::new(BATCH_DEBOUNCE_MS, Arc::clone(&publisher)));
+            let batch_collector = Arc::new(BatchCollector::new(
+                BATCH_DEBOUNCE_MS,
+                Arc::clone(&publisher),
+            ));
 
             let batch_listener = Arc::clone(&batch_collector);
-            app.listen("alarms:batch:updated", move |event| {
-                match serde_json::from_str::<AlarmsBatchUpdated>(event.payload()) {
+            app.listen(
+                "alarms:batch:updated",
+                move |event| match serde_json::from_str::<AlarmsBatchUpdated>(event.payload()) {
                     Ok(payload) => {
                         let batch_listener = Arc::clone(&batch_listener);
                         tauri::async_runtime::spawn(async move {
@@ -87,13 +90,14 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                             "wear-sync: failed to parse alarms:batch:updated payload: {error}"
                         );
                     }
-                }
-            });
+                },
+            );
 
             let sync_listener = Arc::clone(&batch_collector);
             let sync_publisher = Arc::clone(&publisher);
-            app.listen("alarms:sync:needed", move |event| {
-                match serde_json::from_str::<AlarmsSyncNeeded>(event.payload()) {
+            app.listen(
+                "alarms:sync:needed",
+                move |event| match serde_json::from_str::<AlarmsSyncNeeded>(event.payload()) {
                     Ok(payload) => {
                         let sync_listener = Arc::clone(&sync_listener);
                         let sync_publisher = Arc::clone(&sync_publisher);
@@ -106,8 +110,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                             "wear-sync: failed to parse alarms:sync:needed payload: {error}"
                         );
                     }
-                }
-            });
+                },
+            );
 
             // Listen for alarm fired events — notify the watch so it shows
             // the ringing screen in parallel with the phone.
@@ -132,7 +136,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                             };
 
                             if let Err(error) = wear_sync.send_alarm_ring(request) {
-                                log::error!("wear-sync: failed to send alarm ring to watch: {error}");
+                                log::error!(
+                                    "wear-sync: failed to send alarm ring to watch: {error}"
+                                );
                             }
                         });
                     }
@@ -190,8 +196,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                         let app = snooze_app.clone();
                         tauri::async_runtime::spawn(async move {
                             let wear_sync = app.state::<WearSync<R>>();
-                            let duration_ms =
-                                snoozed.snoozed_until.saturating_sub(snoozed.original_trigger);
+                            let duration_ms = snoozed
+                                .snoozed_until
+                                .saturating_sub(snoozed.original_trigger);
                             let snooze_length_minutes = (duration_ms / 60_000).max(0) as i32;
                             let request = AlarmSnoozeRequest {
                                 alarm_id: snoozed.id,
@@ -213,8 +220,9 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             // Listen for messages from the watch (routed by Kotlin WearMessageService
             // through WearSyncPlugin → Channel → app.emit("wear:message:received"))
             let watch_app = app.clone();
-            app.listen("wear:message:received", move |event| {
-                match serde_json::from_str::<WatchMessage>(event.payload()) {
+            app.listen(
+                "wear:message:received",
+                move |event| match serde_json::from_str::<WatchMessage>(event.payload()) {
                     Ok(msg) => {
                         handle_watch_message(&watch_app, msg);
                     }
@@ -223,8 +231,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                             "wear-sync: failed to parse wear:message:received payload: {error}"
                         );
                     }
-                }
-            });
+                },
+            );
 
             Ok(())
         })
@@ -295,7 +303,9 @@ fn spawn_publish_task<R: Runtime>(
                         is_24_hour_known,
                     };
                     if let Err(error) = wear_sync.publish_to_watch(request) {
-                        log::error!("wear-sync: failed to publish immediate sync to watch: {error}");
+                        log::error!(
+                            "wear-sync: failed to publish immediate sync to watch: {error}"
+                        );
                     }
                 }
             }
@@ -327,74 +337,63 @@ fn handle_watch_message<R: Runtime>(app: &AppHandle<R>, msg: WatchMessage) {
                 log::error!("wear-sync: failed to emit wear:sync:request event: {error}");
             }
         }
-        "/threshold/save_alarm" => {
-            match serde_json::from_str::<WatchSaveAlarm>(&msg.data) {
-                Ok(save_cmd) => {
-                    log::info!(
-                        "wear-sync: watch save alarm {} (enabled={}, revision={})",
-                        save_cmd.alarm_id,
-                        save_cmd.enabled,
-                        save_cmd.watch_revision
-                    );
-                    if let Err(error) = app.emit("wear:alarm:save", &save_cmd) {
-                        log::error!("wear-sync: failed to emit wear:alarm:save event: {error}");
-                    }
-                }
-                Err(error) => {
-                    log::warn!("wear-sync: invalid save_alarm payload: {error}");
+        "/threshold/save_alarm" => match serde_json::from_str::<WatchSaveAlarm>(&msg.data) {
+            Ok(save_cmd) => {
+                log::info!(
+                    "wear-sync: watch save alarm {} (enabled={}, revision={})",
+                    save_cmd.alarm_id,
+                    save_cmd.enabled,
+                    save_cmd.watch_revision
+                );
+                if let Err(error) = app.emit("wear:alarm:save", &save_cmd) {
+                    log::error!("wear-sync: failed to emit wear:alarm:save event: {error}");
                 }
             }
-        }
-        "/threshold/delete_alarm" => {
-            match serde_json::from_str::<WatchDeleteAlarm>(&msg.data) {
-                Ok(delete_cmd) => {
-                    log::info!(
-                        "wear-sync: watch delete alarm {} (revision={})",
-                        delete_cmd.alarm_id,
-                        delete_cmd.watch_revision
-                    );
-                    if let Err(error) = app.emit("wear:alarm:delete", &delete_cmd) {
-                        log::error!("wear-sync: failed to emit wear:alarm:delete event: {error}");
-                    }
-                }
-                Err(error) => {
-                    log::warn!("wear-sync: invalid delete_alarm payload: {error}");
+            Err(error) => {
+                log::warn!("wear-sync: invalid save_alarm payload: {error}");
+            }
+        },
+        "/threshold/delete_alarm" => match serde_json::from_str::<WatchDeleteAlarm>(&msg.data) {
+            Ok(delete_cmd) => {
+                log::info!(
+                    "wear-sync: watch delete alarm {} (revision={})",
+                    delete_cmd.alarm_id,
+                    delete_cmd.watch_revision
+                );
+                if let Err(error) = app.emit("wear:alarm:delete", &delete_cmd) {
+                    log::error!("wear-sync: failed to emit wear:alarm:delete event: {error}");
                 }
             }
-        }
-        "/threshold/alarm_dismiss" => {
-            match serde_json::from_str::<WatchDismissAlarm>(&msg.data) {
-                Ok(dismiss_cmd) => {
-                    log::info!(
-                        "wear-sync: watch dismiss alarm {}",
-                        dismiss_cmd.alarm_id
-                    );
-                    if let Err(error) = app.emit("wear:alarm:dismiss", &dismiss_cmd) {
-                        log::error!("wear-sync: failed to emit wear:alarm:dismiss event: {error}");
-                    }
-                }
-                Err(error) => {
-                    log::warn!("wear-sync: invalid alarm_dismiss payload: {error}");
+            Err(error) => {
+                log::warn!("wear-sync: invalid delete_alarm payload: {error}");
+            }
+        },
+        "/threshold/alarm_dismiss" => match serde_json::from_str::<WatchDismissAlarm>(&msg.data) {
+            Ok(dismiss_cmd) => {
+                log::info!("wear-sync: watch dismiss alarm {}", dismiss_cmd.alarm_id);
+                if let Err(error) = app.emit("wear:alarm:dismiss", &dismiss_cmd) {
+                    log::error!("wear-sync: failed to emit wear:alarm:dismiss event: {error}");
                 }
             }
-        }
-        "/threshold/alarm_snooze" => {
-            match serde_json::from_str::<WatchSnoozeAlarm>(&msg.data) {
-                Ok(snooze_cmd) => {
-                    log::info!(
-                        "wear-sync: watch snooze alarm {} for {} min",
-                        snooze_cmd.alarm_id,
-                        snooze_cmd.snooze_length_minutes
-                    );
-                    if let Err(error) = app.emit("wear:alarm:snooze", &snooze_cmd) {
-                        log::error!("wear-sync: failed to emit wear:alarm:snooze event: {error}");
-                    }
-                }
-                Err(error) => {
-                    log::warn!("wear-sync: invalid alarm_snooze payload: {error}");
+            Err(error) => {
+                log::warn!("wear-sync: invalid alarm_dismiss payload: {error}");
+            }
+        },
+        "/threshold/alarm_snooze" => match serde_json::from_str::<WatchSnoozeAlarm>(&msg.data) {
+            Ok(snooze_cmd) => {
+                log::info!(
+                    "wear-sync: watch snooze alarm {} for {} min",
+                    snooze_cmd.alarm_id,
+                    snooze_cmd.snooze_length_minutes
+                );
+                if let Err(error) = app.emit("wear:alarm:snooze", &snooze_cmd) {
+                    log::error!("wear-sync: failed to emit wear:alarm:snooze event: {error}");
                 }
             }
-        }
+            Err(error) => {
+                log::warn!("wear-sync: invalid alarm_snooze payload: {error}");
+            }
+        },
         other => {
             log::warn!("wear-sync: unknown watch message path: {other}");
         }
@@ -578,7 +577,9 @@ mod tests {
 
         let cmd2 = rx.recv().await.unwrap();
         match cmd2 {
-            PublishCommand::Immediate { reason, revision, .. } => {
+            PublishCommand::Immediate {
+                reason, revision, ..
+            } => {
                 assert_eq!(reason, SyncReason::ForceSync);
                 assert_eq!(revision, 6);
             }

--- a/plugins/wear-sync/src/mobile.rs
+++ b/plugins/wear-sync/src/mobile.rs
@@ -9,13 +9,13 @@ use crate::models::{
     AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, PublishRequest, SyncRequest,
     WatchMessage,
 };
+#[cfg(target_os = "android")]
+use tauri::plugin::PluginHandle;
 use tauri::{
     ipc::{Channel, InvokeResponseBody},
     plugin::PluginApi,
     AppHandle, Emitter, Runtime,
 };
-#[cfg(target_os = "android")]
-use tauri::plugin::PluginHandle;
 
 /// Payload sent to the Kotlin side to register the watch message channel.
 #[derive(Serialize)]
@@ -29,16 +29,11 @@ struct WatchMessageHandler {
 /// Registers the Kotlin `WearSyncPlugin` via the Tauri auto-generated bridge
 /// and sets up a [Channel] so Kotlin can send watch messages directly to Rust
 /// without going through the WebView/JS layer.
-pub fn init<R: Runtime>(
-    app: &AppHandle<R>,
-    api: PluginApi<R, ()>,
-) -> crate::Result<WearSync<R>> {
+pub fn init<R: Runtime>(app: &AppHandle<R>, api: PluginApi<R, ()>) -> crate::Result<WearSync<R>> {
     #[cfg(target_os = "android")]
     {
-        let handle = api.register_android_plugin(
-            "ca.liminalhq.threshold.wearsync",
-            "WearSyncPlugin",
-        )?;
+        let handle =
+            api.register_android_plugin("ca.liminalhq.threshold.wearsync", "WearSyncPlugin")?;
 
         // Register a Channel with the Kotlin side so it can send watch messages
         // directly to Rust via JNI, bypassing the WebView/JS layer entirely.
@@ -186,9 +181,7 @@ impl<R: Runtime> WearSync<R> {
     pub fn mark_watch_pipeline_ready(&self) -> crate::Result<()> {
         #[cfg(not(target_os = "android"))]
         {
-            log::debug!(
-                "wear-sync: mark_watch_pipeline_ready no-op on non-Android mobile target"
-            );
+            log::debug!("wear-sync: mark_watch_pipeline_ready no-op on non-Android mobile target");
             return Ok(());
         }
 

--- a/plugins/wear-sync/src/publisher.rs
+++ b/plugins/wear-sync/src/publisher.rs
@@ -124,7 +124,14 @@ mod tests {
 
         let cmd = rx.try_recv().unwrap();
         match cmd {
-            PublishCommand::Immediate { reason, revision, all_alarms_json, snooze_length_minutes, is_24_hour, is_24_hour_known } => {
+            PublishCommand::Immediate {
+                reason,
+                revision,
+                all_alarms_json,
+                snooze_length_minutes,
+                is_24_hour,
+                is_24_hour_known,
+            } => {
                 assert_eq!(reason, SyncReason::ForceSync);
                 assert_eq!(revision, 100);
                 assert_eq!(all_alarms_json, Some("[{\"id\":1}]".into()));

--- a/plugins/wear-sync/src/sync_protocol.rs
+++ b/plugins/wear-sync/src/sync_protocol.rs
@@ -116,7 +116,9 @@ mod tests {
 
     #[test]
     fn sync_response_serialises_up_to_date() {
-        let response = SyncResponse::UpToDate { current_revision: 42 };
+        let response = SyncResponse::UpToDate {
+            current_revision: 42,
+        };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"type\":\"UpToDate\""));
         assert!(json.contains("\"currentRevision\":42"));


### PR DESCRIPTION
## Summary

Part of #206's house-rules hygiene sweep. `cargo fmt --all -- --check` had been failing silently since the gate was commented out in CI — 31 files had accumulated formatting drift (120 diffs). Pure reformatting, no logic changes.

Re-enables the `Rust Format Check` step in `.github/workflows/test.yml` so this can't regrow. Clippy stays commented out for now — it has real violations (`io_other_error` pattern in three plugins' `build.rs`) needing iterative fixes; tracked as a separate follow-up PR in this same sweep.

## Test plan

- [x] `cargo fmt --all -- --check` — clean, 0 diffs
- [x] `cargo build --workspace` — unaffected
- [x] `cargo nextest run --workspace` — 71/71 passing, unaffected
- No Kotlin/TS changes in this PR — only `.rs` files reformatted

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2