### PR TITLE
Fix clippy violations and re-enable the CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,8 +132,8 @@ jobs:
       - name: Rust Format Check
         run: cargo fmt --all -- --check
 
-      # - name: Rust Clippy
-      #   run: cargo clippy --all-features -- -D warnings
+      - name: Rust Clippy
+        run: cargo clippy --all-features -- -D warnings
 
   test-kotlin-wear:
     runs-on: ubuntu-24.04

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -88,7 +88,7 @@ impl AlarmCoordinator {
         if is_new {
             self.emit_alarm_created(app, &alarm, revision).await?;
         } else {
-            let snapshot = previous.as_ref().map(|p| AlarmSnapshot::from_alarm(p));
+            let snapshot = previous.as_ref().map(AlarmSnapshot::from_alarm);
             self.emit_alarm_updated(app, &alarm, snapshot, revision)
                 .await?;
         }

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -57,7 +57,7 @@ fn collect_event_logs(app: &AppHandle) -> Result<String, String> {
         entries.push((path, modified));
     }
 
-    entries.sort_by(|a, b| b.1.cmp(&a.1));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     let mut output = String::new();
     output.push_str(&format!("{app_name} event logs\n"));

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -38,11 +38,9 @@ impl<R: Runtime> AlarmManager<R> {
             let enabled = alarm["enabled"].as_bool().unwrap_or(false);
             let next_trigger = alarm["nextTrigger"].as_i64();
 
-            if enabled && next_trigger.is_some() {
-                let trigger = next_trigger.unwrap();
-                self.schedule_internal(id, trigger);
-            } else {
-                self.cancel_internal(id);
+            match next_trigger {
+                Some(trigger) if enabled => self.schedule_internal(id, trigger),
+                _ => self.cancel_internal(id),
             }
         }
     }

--- a/plugins/time-prefs/build.rs
+++ b/plugins/time-prefs/build.rs
@@ -20,5 +20,5 @@ fn inject_android_permissions() -> std::io::Result<()> {
         "manifest",
         permissions.join("\n"),
     )
-    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    .map_err(std::io::Error::other)
 }

--- a/plugins/toast/build.rs
+++ b/plugins/toast/build.rs
@@ -18,5 +18,5 @@ fn inject_android_permissions() -> std::io::Result<()> {
         "manifest",
         permissions.join("\n"),
     )
-    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    .map_err(std::io::Error::other)
 }

--- a/plugins/toast/src/models.rs
+++ b/plugins/toast/src/models.rs
@@ -1,30 +1,20 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ToastDuration {
+    #[default]
     Short,
     Long,
 }
 
-impl Default for ToastDuration {
-    fn default() -> Self {
-        Self::Short
-    }
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ToastPosition {
     Top,
     Centre,
+    #[default]
     Bottom,
-}
-
-impl Default for ToastPosition {
-    fn default() -> Self {
-        Self::Bottom
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/plugins/wear-sync/build.rs
+++ b/plugins/wear-sync/build.rs
@@ -33,5 +33,5 @@ fn inject_android_permissions() -> std::io::Result<()> {
         "manifest",
         permissions.join("\n"),
     )
-    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    .map_err(std::io::Error::other)
 }


### PR DESCRIPTION
## Summary

Part of #206's house-rules hygiene sweep. `cargo clippy --all-features -- -D warnings` was failing on 6 violations across 5 files, found iteratively — clippy couldn't evaluate the rest of the workspace until the first compile blockers were fixed:

- **`time-prefs`/`toast`/`wear-sync` `build.rs`** — `io_other_error`: `std::io::Error::new(ErrorKind::Other, e)` → `std::io::Error::other`
- **`toast/src/models.rs`** — `derivable_impls`: manual `Default` impls for `ToastDuration`/`ToastPosition` replaced with `#[derive(Default)]` + `#[default]` on the appropriate variant
- **`alarm-manager/src/desktop.rs`** — `unnecessary_unwrap`: the `is_some()`-then-`unwrap()` pattern in `update_alarms` replaced with a `match` on `next_trigger`
- **`alarm/mod.rs`** — `redundant_closure`: `|p| AlarmSnapshot::from_alarm(p)` replaced with the bare associated function

All mechanical, no behavioural change. Re-enables the `Rust Clippy` step in `.github/workflows/test.yml` — confirmed the exact CI command (`cargo clippy --all-features -- -D warnings`, no `--workspace` flag) already covers every workspace member since this is a virtual manifest with no root package.

## Test plan

- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo build --workspace` — unaffected
- [x] `cargo nextest run --workspace` — 71/71 passing
- [x] `cargo fmt --all -- --check` — still clean after the manual edits
- No Kotlin/TS changes in this PR

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2