### PR TITLE
Pin toolchain versions across Rust, Android, and CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,8 +77,8 @@ RUN yes | sdkmanager --licenses && \
     "build-tools;36.0.0" \
     "ndk;28.2.13676358"
 
-# Install Rust toolchain (stable)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
+# Install Rust toolchain (pinned -- see rust-toolchain.toml at the repo root)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.96.1 \
     && rustup component add clippy rustfmt
 
 # Install experimental Tauri CLI for portable AppImage builds

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -208,7 +208,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.1
 
       - name: Add Rust target
         if: matrix.tauri_target != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
             xvfb
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.1
         with:
           components: clippy, rustfmt
 

--- a/apps/threshold-wear/build.gradle.kts
+++ b/apps/threshold-wear/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "ca.liminalhq.threshold.wear"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "ca.liminalhq.threshold"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1000001009
         versionName = "0.1.9"
     }
@@ -57,7 +57,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.8"
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
 }
 
@@ -90,7 +90,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
 
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
 
     // Debug
     debugImplementation("androidx.compose.ui:ui-tooling:1.5.4")

--- a/apps/threshold-wear/settings.gradle.kts
+++ b/apps/threshold-wear/settings.gradle.kts
@@ -5,8 +5,8 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.2.2"
-        id("org.jetbrains.kotlin.android") version "1.9.22"
+        id("com.android.application") version "8.11.0"
+        id("org.jetbrains.kotlin.android") version "1.9.25"
     }
 }
 

--- a/plugins/alarm-manager/android/build.gradle.kts
+++ b/plugins/alarm-manager/android/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
     namespace = "com.plugin.alarmmanager"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
         consumerProguardFiles("proguard-rules.pro")
     }
 
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     compileOnly(project(":tauri-android"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.activity:activity:1.8.0")
 }

--- a/plugins/alarm-manager/permissions/autogenerated/reference.md
+++ b/plugins/alarm-manager/permissions/autogenerated/reference.md
@@ -18,6 +18,7 @@ Default permissions for the alarm-manager plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/alarm-manager/permissions/schemas/schema.json
+++ b/plugins/alarm-manager/permissions/schemas/schema.json
@@ -1,327 +1,366 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the cancel command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-cancel",
-					"markdownDescription": "Enables the cancel command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the cancel command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-cancel",
-					"markdownDescription": "Denies the cancel command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the get_launch_args command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-get-launch-args",
-					"markdownDescription": "Enables the get_launch_args command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the get_launch_args command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-get-launch-args",
-					"markdownDescription": "Denies the get_launch_args command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the pick_alarm_sound command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-pick-alarm-sound",
-					"markdownDescription": "Enables the pick_alarm_sound command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the pick_alarm_sound command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-pick-alarm-sound",
-					"markdownDescription": "Denies the pick_alarm_sound command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the schedule command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-schedule",
-					"markdownDescription": "Enables the schedule command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the schedule command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-schedule",
-					"markdownDescription": "Denies the schedule command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the stop_ringing command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-stop-ringing",
-					"markdownDescription": "Enables the stop_ringing command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the stop_ringing command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-stop-ringing",
-					"markdownDescription": "Denies the stop_ringing command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-schedule`\n- `allow-cancel`\n- `allow-get-launch-args`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-schedule`\n- `allow-cancel`\n- `allow-get-launch-args`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cancel",
+          "markdownDescription": "Enables the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cancel",
+          "markdownDescription": "Denies the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_launch_args command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-launch-args",
+          "markdownDescription": "Enables the get_launch_args command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_launch_args command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-launch-args",
+          "markdownDescription": "Denies the get_launch_args command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the pick_alarm_sound command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-pick-alarm-sound",
+          "markdownDescription": "Enables the pick_alarm_sound command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the pick_alarm_sound command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-pick-alarm-sound",
+          "markdownDescription": "Denies the pick_alarm_sound command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the schedule command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-schedule",
+          "markdownDescription": "Enables the schedule command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the schedule command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-schedule",
+          "markdownDescription": "Denies the schedule command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stop_ringing command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-stop-ringing",
+          "markdownDescription": "Enables the stop_ringing command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stop_ringing command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-stop-ringing",
+          "markdownDescription": "Denies the stop_ringing command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-schedule`\n- `allow-cancel`\n- `allow-get-launch-args`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-schedule`\n- `allow-cancel`\n- `allow-get-launch-args`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/app-management/android/build.gradle.kts
+++ b/plugins/app-management/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/app-management/android/settings.gradle
+++ b/plugins/app-management/android/settings.gradle
@@ -8,10 +8,10 @@ pluginManagement {
         eachPlugin {
             switch (requested.id.id) {
                 case "com.android.library":
-                    useVersion("8.0.2")
+                    useVersion("8.11.0")
                     break
                 case "org.jetbrains.kotlin.android":
-                    useVersion("1.8.20")
+                    useVersion("1.9.25")
                     break
             }
         }

--- a/plugins/app-management/permissions/autogenerated/reference.md
+++ b/plugins/app-management/permissions/autogenerated/reference.md
@@ -14,6 +14,7 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/app-management/permissions/schemas/schema.json
+++ b/plugins/app-management/permissions/schemas/schema.json
@@ -1,279 +1,318 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the minimize_app command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-minimize-app",
-					"markdownDescription": "Enables the minimize_app command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the minimize_app command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-minimize-app",
-					"markdownDescription": "Denies the minimize_app command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-minimize-app`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-minimize-app`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the minimize_app command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-minimize-app",
+          "markdownDescription": "Enables the minimize_app command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the minimize_app command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-minimize-app",
+          "markdownDescription": "Denies the minimize_app command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-minimize-app`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-minimize-app`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/theme-utils/android/build.gradle.kts
+++ b/plugins/theme-utils/android/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
     namespace = "com.plugin.themeutils"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
         consumerProguardFiles("proguard-rules.pro")
     }
 
@@ -29,6 +29,6 @@ android {
 
 dependencies {
     compileOnly(project(":tauri-android"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
     implementation("androidx.core:core-ktx:1.12.0")
 }

--- a/plugins/theme-utils/permissions/autogenerated/reference.md
+++ b/plugins/theme-utils/permissions/autogenerated/reference.md
@@ -14,6 +14,7 @@ Default permissions for the theme-utils plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/theme-utils/permissions/schemas/schema.json
+++ b/plugins/theme-utils/permissions/schemas/schema.json
@@ -1,279 +1,318 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the get_material_you_colours command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-get-material-you-colours",
-					"markdownDescription": "Enables the get_material_you_colours command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the get_material_you_colours command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-get-material-you-colours",
-					"markdownDescription": "Denies the get_material_you_colours command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the theme-utils plugin\n#### This default permission set includes:\n\n- `allow-get-material-you-colours`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the theme-utils plugin\n#### This default permission set includes:\n\n- `allow-get-material-you-colours`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the get_material_you_colours command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-material-you-colours",
+          "markdownDescription": "Enables the get_material_you_colours command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_material_you_colours command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-material-you-colours",
+          "markdownDescription": "Denies the get_material_you_colours command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the theme-utils plugin\n#### This default permission set includes:\n\n- `allow-get-material-you-colours`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the theme-utils plugin\n#### This default permission set includes:\n\n- `allow-get-material-you-colours`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/time-prefs/android/build.gradle.kts
+++ b/plugins/time-prefs/android/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
     namespace = "ca.liminalhq.threshold.timeprefs"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
     }
 
     buildTypes {
@@ -28,5 +28,5 @@ android {
 
 dependencies {
     compileOnly(project(":tauri-android"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
 }

--- a/plugins/time-prefs/permissions/autogenerated/reference.md
+++ b/plugins/time-prefs/permissions/autogenerated/reference.md
@@ -14,6 +14,7 @@ Default permissions for the time-prefs plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/time-prefs/permissions/schemas/schema.json
+++ b/plugins/time-prefs/permissions/schemas/schema.json
@@ -1,291 +1,330 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the android command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-android",
-					"markdownDescription": "Enables the android command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the android command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-android",
-					"markdownDescription": "Denies the android command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the get_time_format command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-get-time-format",
-					"markdownDescription": "Enables the get_time_format command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the get_time_format command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-get-time-format",
-					"markdownDescription": "Denies the get_time_format command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the time-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the time-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the android command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-android",
+          "markdownDescription": "Enables the android command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the android command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-android",
+          "markdownDescription": "Denies the android command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_time_format command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-time-format",
+          "markdownDescription": "Enables the get_time_format command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_time_format command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-time-format",
+          "markdownDescription": "Denies the get_time_format command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the time-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the time-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/toast/android/build.gradle.kts
+++ b/plugins/toast/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/plugins/toast/android/settings.gradle
+++ b/plugins/toast/android/settings.gradle
@@ -8,10 +8,10 @@ pluginManagement {
         eachPlugin {
             switch (requested.id.id) {
                 case "com.android.library":
-                    useVersion("8.0.2")
+                    useVersion("8.11.0")
                     break
                 case "org.jetbrains.kotlin.android":
-                    useVersion("1.8.20")
+                    useVersion("1.9.25")
                     break
             }
         }

--- a/plugins/toast/permissions/autogenerated/reference.md
+++ b/plugins/toast/permissions/autogenerated/reference.md
@@ -14,6 +14,7 @@ Default permissions for the toast plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/toast/permissions/schemas/schema.json
+++ b/plugins/toast/permissions/schemas/schema.json
@@ -1,279 +1,318 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the show command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-show",
-					"markdownDescription": "Enables the show command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the show command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-show",
-					"markdownDescription": "Denies the show command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the toast plugin\n#### This default permission set includes:\n\n- `allow-show`"
+        }
+      ]
+    }
+  }
 }

--- a/plugins/wear-sync/android/build.gradle.kts
+++ b/plugins/wear-sync/android/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 
 android {
     namespace = "ca.liminalhq.threshold.wearsync"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
     }
 
     buildTypes {
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     compileOnly(project(":tauri-android"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
     implementation("com.google.android.gms:play-services-wearable:18.1.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")

--- a/plugins/wear-sync/permissions/autogenerated/reference.md
+++ b/plugins/wear-sync/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@ Default permissions for the wear-sync plugin
 <th>Description</th>
 </tr>
 
+
 <tr>
 <td>
 

--- a/plugins/wear-sync/permissions/schemas/schema.json
+++ b/plugins/wear-sync/permissions/schemas/schema.json
@@ -1,351 +1,390 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "PermissionFile",
-	"description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
-	"type": "object",
-	"properties": {
-		"default": {
-			"description": "The default permission set for the plugin",
-			"anyOf": [
-				{
-					"$ref": "#/definitions/DefaultPermission"
-				},
-				{
-					"type": "null"
-				}
-			]
-		},
-		"set": {
-			"description": "A list of permissions sets defined",
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/PermissionSet"
-			}
-		},
-		"permission": {
-			"description": "A list of inlined permissions",
-			"default": [],
-			"type": "array",
-			"items": {
-				"$ref": "#/definitions/Permission"
-			}
-		}
-	},
-	"definitions": {
-		"DefaultPermission": {
-			"description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-			"type": "object",
-			"required": ["permissions"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"PermissionSet": {
-			"description": "A set of direct permissions grouped together under a new name.",
-			"type": "object",
-			"required": ["description", "identifier", "permissions"],
-			"properties": {
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does.",
-					"type": "string"
-				},
-				"permissions": {
-					"description": "All permissions this set contains.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/PermissionKind"
-					}
-				}
-			}
-		},
-		"Permission": {
-			"description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-			"type": "object",
-			"required": ["identifier"],
-			"properties": {
-				"version": {
-					"description": "The version of the permission.",
-					"type": ["integer", "null"],
-					"format": "uint64",
-					"minimum": 1.0
-				},
-				"identifier": {
-					"description": "A unique identifier for the permission.",
-					"type": "string"
-				},
-				"description": {
-					"description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
-					"type": ["string", "null"]
-				},
-				"commands": {
-					"description": "Allowed or denied commands when using this permission.",
-					"default": {
-						"allow": [],
-						"deny": []
-					},
-					"allOf": [
-						{
-							"$ref": "#/definitions/Commands"
-						}
-					]
-				},
-				"scope": {
-					"description": "Allowed or denied scoped when using this permission.",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Scopes"
-						}
-					]
-				},
-				"platforms": {
-					"description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Target"
-					}
-				}
-			}
-		},
-		"Commands": {
-			"description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Allowed command.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"deny": {
-					"description": "Denied command, which takes priority.",
-					"default": [],
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			}
-		},
-		"Scopes": {
-			"description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
-			"type": "object",
-			"properties": {
-				"allow": {
-					"description": "Data that defines what is allowed by the scope.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				"deny": {
-					"description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
-					"type": ["array", "null"],
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			}
-		},
-		"Value": {
-			"description": "All supported ACL values.",
-			"anyOf": [
-				{
-					"description": "Represents a null JSON value.",
-					"type": "null"
-				},
-				{
-					"description": "Represents a [`bool`].",
-					"type": "boolean"
-				},
-				{
-					"description": "Represents a valid ACL [`Number`].",
-					"allOf": [
-						{
-							"$ref": "#/definitions/Number"
-						}
-					]
-				},
-				{
-					"description": "Represents a [`String`].",
-					"type": "string"
-				},
-				{
-					"description": "Represents a list of other [`Value`]s.",
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Value"
-					}
-				},
-				{
-					"description": "Represents a map of [`String`] keys to [`Value`]s.",
-					"type": "object",
-					"additionalProperties": {
-						"$ref": "#/definitions/Value"
-					}
-				}
-			]
-		},
-		"Number": {
-			"description": "A valid ACL number.",
-			"anyOf": [
-				{
-					"description": "Represents an [`i64`].",
-					"type": "integer",
-					"format": "int64"
-				},
-				{
-					"description": "Represents a [`f64`].",
-					"type": "number",
-					"format": "double"
-				}
-			]
-		},
-		"Target": {
-			"description": "Platform target.",
-			"oneOf": [
-				{
-					"description": "MacOS.",
-					"type": "string",
-					"enum": ["macOS"]
-				},
-				{
-					"description": "Windows.",
-					"type": "string",
-					"enum": ["windows"]
-				},
-				{
-					"description": "Linux.",
-					"type": "string",
-					"enum": ["linux"]
-				},
-				{
-					"description": "Android.",
-					"type": "string",
-					"enum": ["android"]
-				},
-				{
-					"description": "iOS.",
-					"type": "string",
-					"enum": ["iOS"]
-				}
-			]
-		},
-		"PermissionKind": {
-			"type": "string",
-			"oneOf": [
-				{
-					"description": "Enables the mark_watch_pipeline_ready command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-mark-watch-pipeline-ready",
-					"markdownDescription": "Enables the mark_watch_pipeline_ready command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the mark_watch_pipeline_ready command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-mark-watch-pipeline-ready",
-					"markdownDescription": "Denies the mark_watch_pipeline_ready command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the publish_to_watch command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-publish-to-watch",
-					"markdownDescription": "Enables the publish_to_watch command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the publish_to_watch command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-publish-to-watch",
-					"markdownDescription": "Denies the publish_to_watch command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the request_sync_from_watch command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-request-sync-from-watch",
-					"markdownDescription": "Enables the request_sync_from_watch command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the request_sync_from_watch command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-request-sync-from-watch",
-					"markdownDescription": "Denies the request_sync_from_watch command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the send_alarm_dismiss command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-send-alarm-dismiss",
-					"markdownDescription": "Enables the send_alarm_dismiss command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the send_alarm_dismiss command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-send-alarm-dismiss",
-					"markdownDescription": "Denies the send_alarm_dismiss command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the send_alarm_ring command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-send-alarm-ring",
-					"markdownDescription": "Enables the send_alarm_ring command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the send_alarm_ring command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-send-alarm-ring",
-					"markdownDescription": "Denies the send_alarm_ring command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the send_alarm_snooze command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-send-alarm-snooze",
-					"markdownDescription": "Enables the send_alarm_snooze command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the send_alarm_snooze command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-send-alarm-snooze",
-					"markdownDescription": "Denies the send_alarm_snooze command without any pre-configured scope."
-				},
-				{
-					"description": "Enables the set_watch_message_handler command without any pre-configured scope.",
-					"type": "string",
-					"const": "allow-set-watch-message-handler",
-					"markdownDescription": "Enables the set_watch_message_handler command without any pre-configured scope."
-				},
-				{
-					"description": "Denies the set_watch_message_handler command without any pre-configured scope.",
-					"type": "string",
-					"const": "deny-set-watch-message-handler",
-					"markdownDescription": "Denies the set_watch_message_handler command without any pre-configured scope."
-				},
-				{
-					"description": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`",
-					"type": "string",
-					"const": "default",
-					"markdownDescription": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`"
-				}
-			]
-		}
-	}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the mark_watch_pipeline_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-mark-watch-pipeline-ready",
+          "markdownDescription": "Enables the mark_watch_pipeline_ready command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the mark_watch_pipeline_ready command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-mark-watch-pipeline-ready",
+          "markdownDescription": "Denies the mark_watch_pipeline_ready command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the publish_to_watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-publish-to-watch",
+          "markdownDescription": "Enables the publish_to_watch command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the publish_to_watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-publish-to-watch",
+          "markdownDescription": "Denies the publish_to_watch command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the request_sync_from_watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-request-sync-from-watch",
+          "markdownDescription": "Enables the request_sync_from_watch command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the request_sync_from_watch command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-request-sync-from-watch",
+          "markdownDescription": "Denies the request_sync_from_watch command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the send_alarm_dismiss command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-send-alarm-dismiss",
+          "markdownDescription": "Enables the send_alarm_dismiss command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the send_alarm_dismiss command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-send-alarm-dismiss",
+          "markdownDescription": "Denies the send_alarm_dismiss command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the send_alarm_ring command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-send-alarm-ring",
+          "markdownDescription": "Enables the send_alarm_ring command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the send_alarm_ring command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-send-alarm-ring",
+          "markdownDescription": "Denies the send_alarm_ring command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the send_alarm_snooze command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-send-alarm-snooze",
+          "markdownDescription": "Enables the send_alarm_snooze command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the send_alarm_snooze command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-send-alarm-snooze",
+          "markdownDescription": "Denies the send_alarm_snooze command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_watch_message_handler command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-watch-message-handler",
+          "markdownDescription": "Enables the set_watch_message_handler command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_watch_message_handler command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-watch-message-handler",
+          "markdownDescription": "Denies the set_watch_message_handler command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`"
+        }
+      ]
+    }
+  }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Standardizes on a single set of toolchain versions across local dev and CI, closing a gap where Rust and Android toolchains had silently drifted between environments:

| Tool | Standard |
|---|---|
| Rust | 1.96.1 |
| AGP | 8.11.0 |
| Kotlin | 1.9.25 |
| Compose Compiler (threshold-wear only) | 1.5.15 |
| compileSdk | 36 |
| minSdk | 26 (intentionally below 36 — known Tauri bugs on newer minSdk) |
| Gradle wrapper | 8.14.3 (already consistent, no change) |
| JDK | 17 (already consistent, no change) |

**Rust**: adds `rust-toolchain.toml` at the repo root (auto-pins local `cargo`/`rustc` invocations) and updates `dtolnay/rust-toolchain@stable` → `@1.96.1` in both `test.yml` and `release-build.yml` — the action does not read `rust-toolchain.toml`, so the workflow reference itself has to pin the version or the file is a no-op in CI. This is the same class of drift that caused the flaky clippy/prettier CI failures on #228 and #231.

**Android**: brings `threshold-wear` (was AGP 8.2.2 / Kotlin 1.9.22 / compileSdk 34) and all 6 plugins (a mix of compileSdk 34/36, minSdk 21/24/26) up to the same versions already used by the main app's generated Android project and CI's per-plugin build job. Also bumped `threshold-wear`'s Compose Compiler from 1.5.8 to 1.5.15 — required to pair with Kotlin 1.9.25 per the official [Compose-Kotlin compatibility map](https://developer.android.com/jetpack/androidx/releases/compose-kotlin); the old pairing only supports Kotlin up to 1.9.22 and fails to compile otherwise (caught during verification, see Test plan).

**Generated files**: `plugins/*/permissions/{autogenerated/reference.md,schemas/schema.json}` were regenerated by `build.rs` under the new toolchain and are committed as-is to avoid a drift-check failure in CI.

## Follow-up needed (not in this PR)

The `ci-base` Docker image (`ghcr.io/liminal-hq/threshold/ci-base`) bakes in its own Rust install from `.devcontainer/Dockerfile`, which this PR also updates to 1.96.1 — but the release-build workflow's Android job uses that image's Rust directly (not the `dtolnay` action), so it won't actually get 1.96.1 until someone manually triggers `build-ci-image.yml` (`workflow_dispatch`) to rebuild and republish the image. Flagging this rather than triggering it myself since it publishes to a shared registry.

## Test plan

- [x] `cargo build --workspace`, `cargo nextest run --workspace` (71 passed), `cargo fmt --all -- --check`, `cargo clippy --all-features --workspace -- -D warnings` — all clean under the auto-selected 1.96.1 toolchain (confirmed rustup auto-installs/selects it from `rust-toolchain.toml`, no manual override needed)
- [x] Compiled + ran unit tests for all 6 plugins (alarm-manager, theme-utils, time-prefs, wear-sync, app-management, toast) against AGP 8.11.0 / Kotlin 1.9.25 via the devcontainer image
- [x] Compiled + ran unit tests for `threshold-wear` against AGP 8.11.0 / Kotlin 1.9.25 — initially failed with a Compose Compiler/Kotlin version mismatch error, fixed by bumping `kotlinCompilerExtensionVersion` to 1.5.15
- [x] `pnpm -r run typecheck` and `pnpm --filter threshold test` — clean (unaffected by this change, sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2
