### PR TITLE
Fix SET_ALARM import gaps: label parsing, EXTRA_DAYS, stale imports

### DIFF
--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -707,7 +707,14 @@ describe('AlarmManagerService', () => {
 			(invoke as any).mockImplementation((command: string) => {
 				if (command === 'plugin:alarm-manager|get_launch_args') {
 					return Promise.resolve([
-						{ id: 556, hour: 6, minute: 30, label: 'Already rang', activeDays: [3], triggerAt: pastTriggerAt },
+						{
+							id: 556,
+							hour: 6,
+							minute: 30,
+							label: 'Already rang',
+							activeDays: [3],
+							triggerAt: pastTriggerAt,
+						},
 					]);
 				}
 				return Promise.resolve(null);
@@ -726,7 +733,14 @@ describe('AlarmManagerService', () => {
 			(invoke as any).mockImplementation((command: string) => {
 				if (command === 'plugin:alarm-manager|get_launch_args') {
 					return Promise.resolve([
-						{ id: 557, hour: 7, minute: 0, label: 'No days from native', activeDays: [], triggerAt },
+						{
+							id: 557,
+							hour: 7,
+							minute: 0,
+							label: 'No days from native',
+							activeDays: [],
+							triggerAt,
+						},
 					]);
 				}
 				return Promise.resolve(null);

--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -673,4 +673,102 @@ describe('AlarmManagerService', () => {
 
 		expect(invoke).toHaveBeenCalledWith('set_snooze_length', { minutes: 15 });
 	});
+
+	describe('checkImports', () => {
+		it('imports a native alarm using its resolved activeDays, not a hardcoded daily default', async () => {
+			const service = new AlarmManagerService();
+			const triggerAt = Date.now() + 60 * 60_000;
+
+			(invoke as any).mockImplementation((command: string) => {
+				if (command === 'plugin:alarm-manager|get_launch_args') {
+					return Promise.resolve([
+						{ id: 555, hour: 7, minute: 0, label: 'Gym | Leg day', activeDays: [2], triggerAt },
+					]);
+				}
+				return Promise.resolve(null);
+			});
+
+			await service.init();
+
+			expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|cancel', { payload: { id: 555 } });
+			expect(AlarmService.save).toHaveBeenCalledWith(
+				expect.objectContaining({
+					label: 'Gym | Leg day',
+					fixedTime: '07:00',
+					activeDays: [2],
+				}),
+			);
+		});
+
+		it('skips a stale import whose one-shot occurrence already passed, but still cancels the temp native alarm', async () => {
+			const service = new AlarmManagerService();
+			const pastTriggerAt = Date.now() - 60_000;
+
+			(invoke as any).mockImplementation((command: string) => {
+				if (command === 'plugin:alarm-manager|get_launch_args') {
+					return Promise.resolve([
+						{ id: 556, hour: 6, minute: 30, label: 'Already rang', activeDays: [3], triggerAt: pastTriggerAt },
+					]);
+				}
+				return Promise.resolve(null);
+			});
+
+			await service.init();
+
+			expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|cancel', { payload: { id: 556 } });
+			expect(AlarmService.save).not.toHaveBeenCalled();
+		});
+
+		it('falls back to the triggerAt weekday when activeDays comes back empty', async () => {
+			const service = new AlarmManagerService();
+			const triggerAt = new Date('2026-07-15T07:00:00').getTime(); // a Wednesday
+
+			(invoke as any).mockImplementation((command: string) => {
+				if (command === 'plugin:alarm-manager|get_launch_args') {
+					return Promise.resolve([
+						{ id: 557, hour: 7, minute: 0, label: 'No days from native', activeDays: [], triggerAt },
+					]);
+				}
+				return Promise.resolve(null);
+			});
+
+			await service.init();
+
+			expect(AlarmService.save).toHaveBeenCalledWith(
+				expect.objectContaining({ activeDays: [new Date(triggerAt).getDay()] }),
+			);
+		});
+
+		it('skips a within-batch duplicate without re-querying AlarmService.getAll for every import', async () => {
+			const service = new AlarmManagerService();
+			const triggerAt = Date.now() + 60 * 60_000;
+
+			(AlarmService.save as any).mockResolvedValue({
+				id: 601,
+				label: 'Duplicate label',
+				mode: AlarmMode.Fixed,
+				fixedTime: '07:00',
+				activeDays: [2],
+				enabled: true,
+			});
+
+			(invoke as any).mockImplementation((command: string) => {
+				if (command === 'plugin:alarm-manager|get_launch_args') {
+					return Promise.resolve([
+						{ id: 601, hour: 7, minute: 0, label: 'Duplicate label', activeDays: [2], triggerAt },
+						{ id: 602, hour: 7, minute: 0, label: 'Duplicate label', activeDays: [2], triggerAt },
+					]);
+				}
+				return Promise.resolve(null);
+			});
+
+			await service.init();
+
+			// getAll is called exactly once for the import pass (plus once for the
+			// initial-sync reschedule that follows checkImports in init()).
+			const getAllCalls = (AlarmService.getAll as any).mock.calls.length;
+			expect(getAllCalls).toBe(2);
+			expect(AlarmService.save).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -336,35 +336,49 @@ export class AlarmManagerService {
 	private async checkImports() {
 		try {
 			const imports = await getLaunchArgs();
-			if (imports.length > 0) {
-				console.log(`[AlarmManager] Found ${imports.length} native alarms to import:`, imports);
-				for (const imp of imports) {
-					// Deduplication Check
-					const allAlarms = await AlarmService.getAll();
-					const timeStr = `${imp.hour.toString().padStart(2, '0')}:${imp.minute.toString().padStart(2, '0')}`;
+			if (imports.length === 0) return;
 
-					const duplicate = allAlarms.find(
-						(a) => a.mode === AlarmMode.Fixed && a.fixedTime === timeStr && a.label === imp.label,
-					);
+			console.log(`[AlarmManager] Found ${imports.length} native alarms to import:`, imports);
+			const knownAlarms = await AlarmService.getAll();
 
-					if (duplicate) {
-						console.log('Skipping duplicate import:', imp);
-						continue;
-					}
+			for (const imp of imports) {
+				// Cancel the 'temporary' native alarm created by the Intent. Safe to call
+				// even if it already fired -- cancellation is idempotent.
+				await this.cancelNativeAlarm(imp.id);
 
-					// Cancel the 'temporary' native alarm created by the Intent
-					await this.cancelNativeAlarm(imp.id);
-
-					const newAlarm: AlarmInput = {
-						label: imp.label,
-						mode: AlarmMode.Fixed,
-						fixedTime: timeStr,
-						activeDays: [0, 1, 2, 3, 4, 5, 6],
-						enabled: true,
-					};
-
-					await this.saveAndSchedule(newAlarm);
+				// A stale import means the one-shot occurrence already passed (the temp
+				// native alarm already rang, or was due to). Re-importing it now would
+				// silently turn a single alarm the user never asked to keep into an
+				// ongoing recurring one, so discard it instead.
+				if (imp.triggerAt && Date.now() >= imp.triggerAt) {
+					console.log('[AlarmManager] Skipping stale import (past its occurrence):', imp);
+					continue;
 				}
+
+				const timeStr = `${imp.hour.toString().padStart(2, '0')}:${imp.minute.toString().padStart(2, '0')}`;
+
+				const duplicate = knownAlarms.find(
+					(a) => a.mode === AlarmMode.Fixed && a.fixedTime === timeStr && a.label === imp.label,
+				);
+
+				if (duplicate) {
+					console.log('Skipping duplicate import:', imp);
+					continue;
+				}
+
+				const activeDays =
+					imp.activeDays.length > 0 ? imp.activeDays : [new Date(imp.triggerAt).getDay()];
+
+				const newAlarm: AlarmInput = {
+					label: imp.label,
+					mode: AlarmMode.Fixed,
+					fixedTime: timeStr,
+					activeDays,
+					enabled: true,
+				};
+
+				const saved = await this.saveAndSchedule(newAlarm);
+				knownAlarms.push(saved);
 			}
 		} catch (e) {
 			console.error('Failed to check imports', e);
@@ -375,9 +389,8 @@ export class AlarmManagerService {
 		await AlarmService.toggle(alarm.id, enabled);
 	}
 
-	async saveAndSchedule(alarm: AlarmInput) {
-		const saved = await AlarmService.save(alarm);
-		return saved.id;
+	async saveAndSchedule(alarm: AlarmInput): Promise<AlarmRecord> {
+		return await AlarmService.save(alarm);
 	}
 
 	async deleteAlarm(id: number) {

--- a/plugins/alarm-manager/android/build.gradle.kts
+++ b/plugins/alarm-manager/android/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.activity:activity:1.8.0")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -48,6 +48,8 @@ class ImportedAlarm {
     var hour: Int = 0
     var minute: Int = 0
     var label: String = ""
+    var activeDays: List<Int> = emptyList()
+    var triggerAt: Long = 0
 }
 
 @InvokeArg
@@ -299,27 +301,31 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         for ((key, value) in allImports) {
             if (key.startsWith("import_") && value is String) {
+                // Always remove the entry, whether or not it parses -- a malformed or
+                // unparseable payload must never be retried forever.
                 try {
                     val id = key.removePrefix("import_").toInt()
-                    val parts = value.split("|")
-                    if (parts.size == 2) {
-                        val timeParts = parts[0].split(":")
-                        val hour = timeParts[0].toInt()
-                        val minute = timeParts[1].toInt()
-                        val label = parts[1]
-
-                        val import = ImportedAlarm()
-                        import.id = id
-                        import.hour = hour
-                        import.minute = minute
-                        import.label = label
-                        importsList.add(import)
-
-                        // Clean up
-                        prefs.edit().remove(key).apply()
+                    val json = JSONObject(value)
+                    val daysArray = json.optJSONArray("activeDays")
+                    val activeDays = mutableListOf<Int>()
+                    if (daysArray != null) {
+                        for (i in 0 until daysArray.length()) {
+                            activeDays.add(daysArray.getInt(i))
+                        }
                     }
+
+                    val import = ImportedAlarm()
+                    import.id = id
+                    import.hour = json.getInt("hour")
+                    import.minute = json.getInt("minute")
+                    import.label = json.getString("label")
+                    import.activeDays = activeDays
+                    import.triggerAt = json.optLong("triggerAt", 0)
+                    importsList.add(import)
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to parse import: $value", e)
+                } finally {
+                    prefs.edit().remove(key).apply()
                 }
             }
         }
@@ -333,6 +339,8 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             alarmObj.put("hour", alarm.hour)
             alarmObj.put("minute", alarm.minute)
             alarmObj.put("label", alarm.label)
+            alarmObj.put("activeDays", JSArray(alarm.activeDays))
+            alarmObj.put("triggerAt", alarm.triggerAt)
             array.put(alarmObj)
         }
 

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
@@ -11,6 +11,8 @@ import android.os.Bundle
 import android.provider.AlarmClock
 import android.util.Log
 import java.util.Calendar
+import org.json.JSONArray
+import org.json.JSONObject
 
 class SetAlarmActivity : Activity() {
 
@@ -51,6 +53,17 @@ class SetAlarmActivity : Activity() {
 
         val triggerAt = calendar.timeInMillis
 
+        // EXTRA_DAYS uses Calendar.SUNDAY(1)..SATURDAY(7); Threshold's activeDays uses 0=Sunday..6=Saturday.
+        // Absent EXTRA_DAYS means "one-time, next occurrence only" per the SET_ALARM contract -- Threshold
+        // has no true one-shot concept (every alarm recurs on activeDays), so the honest translation is a
+        // single-day array for whichever weekday this resolved occurrence already falls on.
+        val requestedDays = intent.getIntegerArrayListExtra(AlarmClock.EXTRA_DAYS)
+        val activeDays = if (requestedDays != null && requestedDays.isNotEmpty()) {
+            requestedDays.map { it - 1 }
+        } else {
+            listOf(calendar.get(Calendar.DAY_OF_WEEK) - 1)
+        }
+
         // 3. Generate ID (Random for now, or timestamp based)
         val id = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
 
@@ -60,7 +73,7 @@ class SetAlarmActivity : Activity() {
         // 5. Store "Launch Payload" for React to import later
         // We persist this payload in SharedPrefs distinct from the alarm schedule
         // so that when the app opens, it can read it and sync to SQLite.
-        saveImportPayload(id, hour, minutes, message)
+        saveImportPayload(id, hour, minutes, message, activeDays, triggerAt)
 
         // 6. Launch App if not skipping UI
         if (!skipUi) {
@@ -75,9 +88,22 @@ class SetAlarmActivity : Activity() {
         }
     }
 
-    private fun saveImportPayload(id: Int, hour: Int, minutes: Int, label: String) {
+    private fun saveImportPayload(
+        id: Int,
+        hour: Int,
+        minutes: Int,
+        label: String,
+        activeDays: List<Int>,
+        triggerAt: Long
+    ) {
         val prefs = getSharedPreferences("ThresholdImports", MODE_PRIVATE)
-        val importString = "$hour:$minutes|$label"
-        prefs.edit().putString("import_$id", importString).apply()
+        val payload = JSONObject().apply {
+            put("hour", hour)
+            put("minute", minutes)
+            put("label", label)
+            put("activeDays", JSONArray(activeDays))
+            put("triggerAt", triggerAt)
+        }
+        prefs.edit().putString("import_$id", payload.toString()).apply()
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
@@ -14,6 +14,20 @@ import java.util.Calendar
 import org.json.JSONArray
 import org.json.JSONObject
 
+// EXTRA_DAYS uses Calendar.SUNDAY(1)..SATURDAY(7); Threshold's activeDays uses 0=Sunday..6=Saturday.
+// Absent/empty requestedDays means "one-time, next occurrence only" per the SET_ALARM contract --
+// Threshold has no true one-shot concept (every alarm recurs on activeDays), so the honest
+// translation is a single-day array for whichever weekday the resolved occurrence falls on.
+// A standalone function (not a method) so it's trivially unit-testable without any Android
+// framework dependency -- both parameters are already-resolved Calendar day-of-week values (1-7).
+internal fun resolveActiveDays(requestedDays: List<Int>?, fallbackCalendarDay: Int): List<Int> {
+    return if (requestedDays != null && requestedDays.isNotEmpty()) {
+        requestedDays.map { it - 1 }
+    } else {
+        listOf(fallbackCalendarDay - 1)
+    }
+}
+
 class SetAlarmActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,16 +67,8 @@ class SetAlarmActivity : Activity() {
 
         val triggerAt = calendar.timeInMillis
 
-        // EXTRA_DAYS uses Calendar.SUNDAY(1)..SATURDAY(7); Threshold's activeDays uses 0=Sunday..6=Saturday.
-        // Absent EXTRA_DAYS means "one-time, next occurrence only" per the SET_ALARM contract -- Threshold
-        // has no true one-shot concept (every alarm recurs on activeDays), so the honest translation is a
-        // single-day array for whichever weekday this resolved occurrence already falls on.
         val requestedDays = intent.getIntegerArrayListExtra(AlarmClock.EXTRA_DAYS)
-        val activeDays = if (requestedDays != null && requestedDays.isNotEmpty()) {
-            requestedDays.map { it - 1 }
-        } else {
-            listOf(calendar.get(Calendar.DAY_OF_WEEK) - 1)
-        }
+        val activeDays = resolveActiveDays(requestedDays, calendar.get(Calendar.DAY_OF_WEEK))
 
         // 3. Generate ID (Random for now, or timestamp based)
         val id = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/SetAlarmActivityTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/SetAlarmActivityTest.kt
@@ -1,0 +1,41 @@
+// Tests the SET_ALARM EXTRA_DAYS -> Threshold activeDays conversion
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SetAlarmActivityTest {
+    @Test
+    fun `converts a single requested day from Calendar numbering to Threshold numbering`() {
+        // Calendar.MONDAY = 2 -> Threshold's 1 (0=Sunday..6=Saturday)
+        assertEquals(listOf(1), resolveActiveDays(listOf(2), fallbackCalendarDay = 1))
+    }
+
+    @Test
+    fun `converts multiple requested days preserving order`() {
+        // Calendar.SUNDAY=1, MONDAY=2, SATURDAY=7 -> Threshold 0, 1, 6
+        assertEquals(listOf(0, 1, 6), resolveActiveDays(listOf(1, 2, 7), fallbackCalendarDay = 1))
+    }
+
+    @Test
+    fun `falls back to the resolved occurrence's weekday when requestedDays is null`() {
+        // Calendar.WEDNESDAY = 4 -> Threshold's 3
+        assertEquals(listOf(3), resolveActiveDays(null, fallbackCalendarDay = 4))
+    }
+
+    @Test
+    fun `falls back to the resolved occurrence's weekday when requestedDays is empty`() {
+        assertEquals(listOf(3), resolveActiveDays(emptyList(), fallbackCalendarDay = 4))
+    }
+
+    @Test
+    fun `boundary days convert correctly at both ends of the week`() {
+        // Calendar.SUNDAY(1) -> 0, Calendar.SATURDAY(7) -> 6
+        assertEquals(listOf(0), resolveActiveDays(listOf(1), fallbackCalendarDay = 1))
+        assertEquals(listOf(6), resolveActiveDays(listOf(7), fallbackCalendarDay = 1))
+    }
+}

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -20,6 +20,10 @@ export interface ImportedAlarm {
 	hour: number;
 	minute: number;
 	label: string;
+	/** Days of week this alarm is active on, 0=Sunday..6=Saturday. Always non-empty. */
+	activeDays: number[];
+	/** Epoch millis of the originally-computed one-shot occurrence, for staleness checks. */
+	triggerAt: number;
 }
 
 export interface PickAlarmSoundOptions {


### PR DESCRIPTION
## Summary

Closes #200. The `SET_ALARM` intent import path had three gaps, all in the same flow, plus a related N+1 query issue that replaces the stale #150.

**Label parsing (fixed permanently, not just patched):** `get_launch_args` split the persisted payload on `"|"` and only removed the `SharedPreferences` entry when `parts.size == 2`, so a label like "Gym | Leg day" failed to parse on every launch and was never cleaned up. Since adding `EXTRA_DAYS` support meant extending the payload's shape anyway, I replaced the whole ad hoc pipe/colon-delimited string with JSON (`org.json.JSONObject`, already used elsewhere in this same file) rather than bolting a second delimiter onto a format that had just demonstrated it can't safely carry arbitrary label text. This closes the bug for any label content, not just the reported pipe character, and the entry is now removed in a `try/finally` regardless of parse outcome.

**`EXTRA_DAYS` (recurrence):** was ignored entirely -- `checkImports` hardcoded `activeDays` to all 7 days regardless of what was requested. `EXTRA_DAYS` (`Calendar.SUNDAY=1..SATURDAY=7`) is now converted to Threshold's native `activeDays` (`0=Sunday..6=Saturday`) as early as possible, in `SetAlarmActivity`, using the same `Calendar` instance that already resolves the next occurrence. Threshold has no true one-shot alarm concept -- every alarm recurs on `activeDays` per `scheduler.rs` -- so when `EXTRA_DAYS` is absent the honest translation is a single-day array for whichever weekday that resolved occurrence falls on. The conversion itself is extracted into a standalone `resolveActiveDays` function with its own JUnit test file -- this plugin had no Kotlin unit test infrastructure at all, but the `toast` plugin already demonstrates the minimal setup needed, so the lift was small and worthwhile for logic implementing a documented external contract.

**`EXTRA_SKIP_UI` stale-import window:** if the temp native alarm fired before the app was ever opened, `checkImports` would later import it as a fresh recurring alarm the user never asked to keep. The persisted trigger time now doubles as a staleness check -- `checkImports` skips (but still cancels the temp native alarm for) any import whose one-shot occurrence has already passed. I checked `AlarmUtils`/`BootReceiver` first to confirm there's no reboot-based resurrection risk, so this TS-side check alone is sufficient. As a side effect of reordering the cancel-then-check flow, the pre-existing duplicate-skip path now also correctly cancels the temp native alarm (the original code only cancelled it on the non-duplicate path).

**Also folded in:** hoisted `AlarmService.getAll()` out of the import loop (replaces stale #150), appending each newly-saved alarm to the local list so within-batch duplicate detection still works without a re-query every iteration.

## Known limitation (not fixed here)

`checkImports` wraps its whole per-import loop in one try/catch (pre-existing, not introduced by this PR) -- if `AlarmService.save()` throws partway through a multi-import batch, remaining imports in that batch aren't processed or cancelled until the next app open. Flagged during self-review; left out of scope since it's pre-existing behaviour, not something this PR's changes affect either way.

## Test plan

- [x] `pnpm --filter threshold test` -- 52/52 passing, including 4 new tests covering: correct `activeDays` import (not hardcoded daily), stale-import skip with cancel-still-called, empty-`activeDays` fallback to the `triggerAt` weekday, and within-batch duplicate detection without redundant `getAll()` calls
- [x] `pnpm -r run typecheck` -- clean
- [x] New Kotlin JUnit tests for `resolveActiveDays` (5 tests: single day, multiple days, null/empty fallback, both week boundaries) -- all passing via the devcontainer verification image
- [x] Kotlin (`alarm-manager` plugin) compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2