### PR TITLE
Isolate per-import errors in checkImports so one failure doesn't abort the batch

### DIFF
--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -784,5 +784,43 @@ describe('AlarmManagerService', () => {
 			expect(getAllCalls).toBe(2);
 			expect(AlarmService.save).toHaveBeenCalledTimes(1);
 		});
+
+		it('continues processing remaining imports in a batch after one import fails', async () => {
+			const service = new AlarmManagerService();
+			const triggerAt = Date.now() + 60 * 60_000;
+
+			(AlarmService.save as any)
+				.mockRejectedValueOnce(new Error('transient save failure'))
+				.mockResolvedValueOnce({
+					id: 702,
+					label: 'Second alarm',
+					mode: AlarmMode.Fixed,
+					fixedTime: '08:00',
+					activeDays: [3],
+					enabled: true,
+				});
+
+			(invoke as any).mockImplementation((command: string) => {
+				if (command === 'plugin:alarm-manager|get_launch_args') {
+					return Promise.resolve([
+						{ id: 701, hour: 7, minute: 0, label: 'First alarm', activeDays: [2], triggerAt },
+						{ id: 702, hour: 8, minute: 0, label: 'Second alarm', activeDays: [3], triggerAt },
+					]);
+				}
+				return Promise.resolve(null);
+			});
+
+			await service.init();
+
+			// Both imports' temp native alarms get cancelled regardless of the first one's failure.
+			expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|cancel', { payload: { id: 701 } });
+			expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|cancel', { payload: { id: 702 } });
+
+			// The first import's save failed, but the second still went through.
+			expect(AlarmService.save).toHaveBeenCalledTimes(2);
+			expect(AlarmService.save).toHaveBeenCalledWith(
+				expect.objectContaining({ label: 'Second alarm', fixedTime: '08:00' }),
+			);
+		});
 	});
 });

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -334,14 +334,26 @@ export class AlarmManagerService {
 
 	// Check for alarms created natively (e.g. via "Set Alarm" intent)
 	private async checkImports() {
+		let imports: Awaited<ReturnType<typeof getLaunchArgs>>;
+		let knownAlarms: AlarmRecord[];
+
 		try {
-			const imports = await getLaunchArgs();
+			imports = await getLaunchArgs();
 			if (imports.length === 0) return;
 
 			console.log(`[AlarmManager] Found ${imports.length} native alarms to import:`, imports);
-			const knownAlarms = await AlarmService.getAll();
+			knownAlarms = await AlarmService.getAll();
+		} catch (e) {
+			console.error('Failed to check imports', e);
+			return;
+		}
 
-			for (const imp of imports) {
+		// Each import is handled in its own try/catch so one failure (e.g. a transient
+		// save error) doesn't abort the rest of the batch -- otherwise imports after the
+		// failed one would silently go unprocessed (and their temp native alarms
+		// uncancelled) until the next time the app happens to open.
+		for (const imp of imports) {
+			try {
 				// Cancel the 'temporary' native alarm created by the Intent. Safe to call
 				// even if it already fired -- cancellation is idempotent.
 				await this.cancelNativeAlarm(imp.id);
@@ -379,9 +391,13 @@ export class AlarmManagerService {
 
 				const saved = await this.saveAndSchedule(newAlarm);
 				knownAlarms.push(saved);
+			} catch (e) {
+				console.error(
+					'[AlarmManager] Failed to import native alarm, continuing with remaining imports:',
+					imp,
+					e,
+				);
 			}
-		} catch (e) {
-			console.error('Failed to check imports', e);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up from self-review on #235. `checkImports` wrapped its entire per-import loop in one try/catch, so a failure processing one import (e.g. a transient `AlarmService.save` error) aborted the rest of the batch -- imports after the failed one were neither saved nor had their temp native alarms cancelled until the next time the app happened to open.

Split into two phases: an outer try/catch around the initial `getLaunchArgs()`/`AlarmService.getAll()` fetch (genuinely fatal for the whole check if it fails -- there's nothing to iterate without it), and a per-item try/catch inside the loop so one import's failure just gets logged and skipped, leaving the rest of the batch to process normally.

This is pre-existing behaviour, not something #235 introduced -- flagging and fixing it separately since it's a distinct concern from that PR's actual scope (label parsing, `EXTRA_DAYS`, stale imports).

## Test plan

- [x] `pnpm --filter threshold test` -- 53/53 passing, including a new test proving the fix: the first import's `save()` call is mocked to reject, the second import in the same batch still gets processed (both cancelled, both save attempts made) rather than the second one being silently skipped
- [x] `pnpm -r run typecheck` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2