### PR TITLE
Fix Home/Settings scroll and alarm-list swipe blocking vertical scroll

### DIFF
--- a/apps/threshold/src/App.tsx
+++ b/apps/threshold/src/App.tsx
@@ -20,8 +20,9 @@ import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notif
 /* Theme variables */
 // import './theme/variables.css'; // Deprecated in favor of Code-First ThemeProvider
 // ringing.css is imported directly by the Ringing screen, scoped to its own
-// .ringing-page root class -- do not import it here (see App.css/router.tsx
-// for why: it used to leak an unscoped body/html overflow:hidden app-wide).
+// .ringing-page root class -- do not import it here (see theme/components.css
+// and router.tsx for why: it used to leak an unscoped body/html overflow:hidden
+// app-wide).
 import './theme/components.css';
 import './theme/transitions.css';
 import { routeTransitions } from './utils/RouteTransitions';

--- a/apps/threshold/src/App.tsx
+++ b/apps/threshold/src/App.tsx
@@ -19,7 +19,9 @@ import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notif
 
 /* Theme variables */
 // import './theme/variables.css'; // Deprecated in favor of Code-First ThemeProvider
-import './theme/ringing.css';
+// ringing.css is imported directly by the Ringing screen, scoped to its own
+// .ringing-page root class -- do not import it here (see App.css/router.tsx
+// for why: it used to leak an unscoped body/html overflow:hidden app-wide).
 import './theme/components.css';
 import './theme/transitions.css';
 import { routeTransitions } from './utils/RouteTransitions';

--- a/apps/threshold/src/components/SwipeToDeleteRow.tsx
+++ b/apps/threshold/src/components/SwipeToDeleteRow.tsx
@@ -141,7 +141,10 @@ export const SwipeToDeleteRow: React.FC<SwipeToDeleteRowProps> = ({
 				onDrag={handleDrag}
 				onDragEnd={handleDragEnd}
 				animate={controls}
-				style={{ x }}
+				// touchAction must be set on this exact element (not just the outer wrapper) --
+				// Motion needs it here to let the browser handle vertical scroll natively while
+				// still capturing horizontal drag itself, or it captures all touch input.
+				style={{ x, touchAction: 'pan-y' }}
 				onTap={handleTap}
 			>
 				{/* 

--- a/apps/threshold/src/router.tsx
+++ b/apps/threshold/src/router.tsx
@@ -38,6 +38,10 @@ const RootLayout = () => {
 				style={{
 					marginTop: showTitleBar ? '32px' : '0px',
 					height: showTitleBar ? 'calc(100% - 32px)' : '100%',
+					// The single scroll container for every screen -- individual screens should
+					// not manage their own height/overflow. Ringing opts out locally (see
+					// ringing.css) since it's a small fixed-size surface that shouldn't scroll.
+					overflowY: isRingingWindow ? 'hidden' : 'auto',
 					// @ts-ignore - viewTransitionName is not yet in standard React types
 					viewTransitionName: isMobile ? 'wa-route-slot' : undefined,
 				}}

--- a/apps/threshold/src/screens/EditAlarm.tsx
+++ b/apps/threshold/src/screens/EditAlarm.tsx
@@ -179,7 +179,7 @@ const EditAlarm: React.FC = () => {
 	};
 
 	return (
-		<Box sx={{ height: '100%', overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
+		<Box>
 			{/* Mobile Header: Placed OUTSIDE IonContent to avoid scrolling issues and overlay */}
 			{isMobile && (
 				<MobileToolbar
@@ -196,15 +196,12 @@ const EditAlarm: React.FC = () => {
 					}
 				/>
 			)}
-			<Box sx={{ flexGrow: 1 }}>
+			<Box>
 				<Container
 					maxWidth="sm"
 					sx={{
 						py: 3,
 						mt: !isMobile ? 2 : 0,
-						height: '100%',
-						display: 'flex',
-						flexDirection: 'column',
 					}}
 				>
 					{!isMobile && (
@@ -215,7 +212,7 @@ const EditAlarm: React.FC = () => {
 						</Box>
 					)}
 
-					<Stack spacing={3} sx={{ flexGrow: 1, pb: !isMobile ? 10 : 0 }}>
+					<Stack spacing={3} sx={{ pb: !isMobile ? 10 : 0 }}>
 						<Paper elevation={0} sx={{ p: isMobile ? 0 : 3, bgcolor: 'transparent' }}>
 							<ToggleButtonGroup
 								value={mode}

--- a/apps/threshold/src/screens/Home.tsx
+++ b/apps/threshold/src/screens/Home.tsx
@@ -57,7 +57,7 @@ const Home: React.FC = () => {
 	};
 
 	return (
-		<Box sx={{ minHeight: '100vh', overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
+		<Box>
 			{isMobile && (
 				<MobileToolbar
 					title={APP_NAME}
@@ -93,7 +93,6 @@ const Home: React.FC = () => {
 					pt: isMobile ? 2 : 0, // Add top padding on mobile to clear header/prevent blend
 					pb: 10,
 					px: 2, // Always add padding for "inset" bubble look
-					flexGrow: 1,
 				}}
 			>
 				{isMobile ? (

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -70,7 +70,7 @@ const Settings: React.FC = () => {
 	};
 
 	return (
-		<Box sx={{ height: '100%', overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
+		<Box>
 			{/* Mobile Header: Placed OUTSIDE IonContent to avoid scrolling issues and overlay */}
 			{isMobile && (
 				<MobileToolbar
@@ -82,7 +82,7 @@ const Settings: React.FC = () => {
 					title="Settings"
 				/>
 			)}
-			<Box sx={{ flexGrow: 1 }}>
+			<Box>
 				{/* Desktop Spacing Fix: Adjusted mt to 2 to work with RootLayout spacing */}
 				<Container maxWidth="sm" sx={{ py: 3, mt: !isMobile ? 2 : 0 }}>
 					{!isMobile && (

--- a/apps/threshold/src/theme/components.css
+++ b/apps/threshold/src/theme/components.css
@@ -1,3 +1,17 @@
+/* App shell foundation: html/body/#root are pinned to exactly the viewport size
+   and clipped, so .wa-route-slot (the single app-wide scroll container, see
+   router.tsx) is the only place that actually scrolls. Without the overflow
+   clamp here, an overflowing body just grows past the viewport and the whole
+   page scrolls natively instead -- individual screens should not need their
+   own height/overflow rules; this is the one place that owns it. */
+html,
+body,
+#root {
+	height: 100%;
+	overflow: hidden;
+	margin: 0;
+}
+
 /* ... existing day styles ... */
 
 /* Day Selector Pills */

--- a/apps/threshold/src/theme/ringing.css
+++ b/apps/threshold/src/theme/ringing.css
@@ -5,9 +5,11 @@
 	-webkit-tap-highlight-color: transparent;
 }
 
-/* Aggressive reset for body/html - use * selector to ensure it applies */
-body,
-html {
+/* Scoped to the ringing screen's own root element -- must not target body/html
+   directly, since this file is bundled app-wide and would otherwise disable
+   scrolling on every other screen too (see App.css for the shared height
+   foundation every screen actually relies on). */
+.ringing-page {
 	margin: 0 !important;
 	padding: 0 !important;
 	overflow: hidden !important;

--- a/apps/threshold/src/theme/ringing.css
+++ b/apps/threshold/src/theme/ringing.css
@@ -7,8 +7,8 @@
 
 /* Scoped to the ringing screen's own root element -- must not target body/html
    directly, since this file is bundled app-wide and would otherwise disable
-   scrolling on every other screen too (see App.css for the shared height
-   foundation every screen actually relies on). */
+   scrolling on every other screen too (see components.css for the shared
+   height foundation every screen actually relies on). */
 .ringing-page {
 	margin: 0 !important;
 	padding: 0 !important;


### PR DESCRIPTION
## Summary

Home, Settings, and EditAlarm couldn't scroll -- alarms/content beyond the first screenful were completely unreachable, and swiping on any alarm row blocked scroll entirely regardless. Live-verified via the Tauri MCP bridge (direct DOM `scrollTop` checks and simulated scroll interaction, not screenshot diffing -- `html2canvas`-based screenshots don't reliably represent native scroll/clipping behaviour).

## Root cause

`ringing.css` set an unscoped `body, html { overflow: hidden; height: 100% !important }` and was imported unconditionally in `App.tsx`, applying to every screen from app start, not just the Ringing screen it was written for (confirmed intentional for Ringing via git history -- "Prevent scrolling in alarm ringing window" -- just never scoped to only apply there).

On top of that, Home/Settings/EditAlarm each independently hand-rolled their own root-level scroll `Box` (mixing `minHeight` vs `height`, and a `flexDirection: column` wrapping a `flexGrow: 1` child, which structurally can never self-overflow since flex items default to `min-height: auto`), so even without the leak, none of the three were correctly implemented -- and a fourth screen would have been a fourth chance to get it wrong the same way again.

## The fix

Rather than patch three independent, drift-prone implementations, this makes `RootLayout`'s `.wa-route-slot` -- the one wrapper already common to every route -- the single scroll container for the whole app:

- **`components.css`** (`App.css` turned out to be dead/unimported, so the rule lives here instead): `html, body, #root` get an intentional, owned `height: 100%` + `overflow: hidden`, replacing the accidental leak with the same effective foundation, just correctly scoped this time.
- **`router.tsx`**: `.wa-route-slot` gets `overflowY: auto` (`hidden` specifically while on the ringing route, as an extra safeguard alongside Ringing's own opt-out).
- **`ringing.css`**: retargeted from unscoped `body`/`html` to `.ringing-page`, the class Ringing's own root element already carries -- it opts itself out locally instead of clamping the whole app globally.
- **`App.tsx`**: removed the now-redundant `ringing.css` import (`Ringing.tsx` already imports it directly, correctly scoped regardless of load order).
- **Home/Settings/EditAlarm**: deleted their own height/overflow/flex management entirely -- screens no longer need to get this right themselves.

Also fixes **`SwipeToDeleteRow`**: `touchAction: 'pan-y'` was set on the outer wrapper but not the `motion.div` that actually has the `drag="x"` gesture -- Motion needs it on the exact draggable element to let the browser handle vertical scroll natively while it captures horizontal drag itself. Every alarm row is one of these, so this alone was enough to block scrolling on the alarm list regardless of the CSS fix above.

## Test plan

- [x] Live-verified via the Tauri MCP bridge against a running desktop dev build:
  - Home: created 13 test alarms, confirmed `.wa-route-slot`'s `scrollHeight` genuinely exceeds `clientHeight`, confirmed scrolling via both direct `scrollTop` assignment and simulated scroll interaction, confirmed a previously-unreachable alarm becomes visible after scrolling
  - Settings: confirmed the same, including that "Download Event Logs" (previously cut off, matching the reported bug) becomes reachable
  - Ringing: confirmed it still correctly does *not* scroll (`.wa-route-slot` and `.ringing-page` both report `overflow: hidden` while on that route), verified in its own separate window
- [x] `pnpm -r run typecheck` -- clean
- [x] `pnpm --filter threshold test` -- 53/53 passing
- [ ] Mobile-specific verification (the swipe-to-delete touch-action fix) not yet tested live on a device/emulator -- desktop doesn't render `SwipeToDeleteRow` at all, so this fix is code-reviewed but not live-verified yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2