### PR TITLE
Render desktop toasts and register the toast plugin on desktop

### DIFF
--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -132,12 +132,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_app_management::init());
-
-    #[cfg(target_os = "android")]
-    {
-        builder = builder.plugin(tauri_plugin_toast::init());
-    }
+        .plugin(tauri_plugin_app_management::init())
+        .plugin(tauri_plugin_toast::init());
 
     builder
         .setup(|app| {

--- a/apps/threshold/src/App.tsx
+++ b/apps/threshold/src/App.tsx
@@ -10,6 +10,7 @@ import { ThemeContextProvider } from './contexts/ThemeContext';
 import { AlarmsProvider } from './contexts/AlarmsContext';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { DesktopToastHost } from './components/DesktopToastHost';
 
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -178,6 +179,7 @@ const App: React.FC = () => {
 			<AlarmsProvider>
 				<LocalizationProvider dateAdapter={AdapterDateFns}>
 					<RouterProvider router={router} />
+					<DesktopToastHost />
 				</LocalizationProvider>
 			</AlarmsProvider>
 		</ThemeContextProvider>

--- a/apps/threshold/src/components/DesktopToastHost.tsx
+++ b/apps/threshold/src/components/DesktopToastHost.tsx
@@ -1,0 +1,95 @@
+// Renders desktop toasts as an MUI Snackbar -- there's no native OS toast primitive on
+// desktop, so this is the frontend half of the toast plugin's event-based approach,
+// keeping showToast() a single call path for the UI regardless of platform
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Snackbar } from '@mui/material';
+import { listen } from '@tauri-apps/api/event';
+import { PlatformUtils } from '../utils/PlatformUtils';
+
+type ToastDuration = 'short' | 'long';
+type ToastPosition = 'top' | 'centre' | 'bottom';
+
+interface ToastShowEvent {
+	message: string;
+	duration: ToastDuration;
+	position: ToastPosition;
+}
+
+// Mirrors Android's native Toast durations for rough visual parity across platforms.
+const DURATION_MS: Record<ToastDuration, number> = {
+	short: 2000,
+	long: 3500,
+};
+
+const ANCHOR_ORIGIN: Record<ToastPosition, { vertical: 'top' | 'bottom'; horizontal: 'center' }> = {
+	top: { vertical: 'top', horizontal: 'center' },
+	// MUI Snackbar has no true vertical-centre anchor -- approximated below via sx override.
+	centre: { vertical: 'bottom', horizontal: 'center' },
+	bottom: { vertical: 'bottom', horizontal: 'center' },
+};
+
+export const DesktopToastHost: React.FC = () => {
+	const [current, setCurrent] = useState<ToastShowEvent | null>(null);
+	const [open, setOpen] = useState(false);
+	const queueRef = useRef<ToastShowEvent[]>([]);
+	const showingRef = useRef(false);
+
+	const processQueue = useCallback(() => {
+		if (showingRef.current) return;
+		const next = queueRef.current.shift();
+		if (!next) return;
+		showingRef.current = true;
+		setCurrent(next);
+		setOpen(true);
+	}, []);
+
+	useEffect(() => {
+		if (PlatformUtils.isMobile()) return; // mobile renders a real native Toast instead
+
+		const unlistenPromise = listen<ToastShowEvent>('toast:show', (event) => {
+			queueRef.current.push(event.payload);
+			processQueue();
+		});
+
+		return () => {
+			unlistenPromise.then((unlisten) => unlisten());
+		};
+	}, [processQueue]);
+
+	const handleClose = (_event: unknown, reason?: string) => {
+		if (reason === 'clickaway') return;
+		setOpen(false);
+	};
+
+	const handleExited = () => {
+		showingRef.current = false;
+		setCurrent(null);
+		processQueue();
+	};
+
+	if (PlatformUtils.isMobile() || !current) return null;
+
+	return (
+		<Snackbar
+			open={open}
+			autoHideDuration={DURATION_MS[current.duration]}
+			onClose={handleClose}
+			slotProps={{ transition: { onExited: handleExited } }}
+			anchorOrigin={ANCHOR_ORIGIN[current.position]}
+			message={current.message}
+			sx={
+				current.position === 'centre'
+					? {
+							top: '50% !important',
+							left: '50% !important',
+							transform: 'translate(-50%, -50%)',
+						}
+					: undefined
+			}
+		/>
+	);
+};

--- a/plugins/toast/src/desktop.rs
+++ b/plugins/toast/src/desktop.rs
@@ -1,12 +1,18 @@
-// Desktop stub for the toast command (no-op)
+// Desktop toast implementation -- there's no native OS toast primitive on desktop
+// platforms, so this emits an event for the frontend to render as a Snackbar instead.
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use serde::de::DeserializeOwned;
-use tauri::{plugin::PluginApi, AppHandle, Runtime};
+use tauri::{plugin::PluginApi, AppHandle, Emitter, Runtime};
 
 use crate::models::ShowToastRequest;
+
+/// Emitted to the frontend so it can render the toast itself -- keeps `showToast()`
+/// a single call path for the UI regardless of platform; the plugin is still the
+/// entry point either way.
+const EVENT_SHOW_TOAST: &str = "toast:show";
 
 pub fn init<R: Runtime, C: DeserializeOwned>(
     app: &AppHandle<R>,
@@ -19,8 +25,8 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
 pub struct Toast<R: Runtime>(AppHandle<R>);
 
 impl<R: Runtime> Toast<R> {
-    pub fn show(&self, _payload: ShowToastRequest) -> crate::Result<()> {
-        // Desktop is intentionally a no-op for now.
+    pub fn show(&self, payload: ShowToastRequest) -> crate::Result<()> {
+        self.0.emit(EVENT_SHOW_TOAST, payload)?;
         Ok(())
     }
 }

--- a/plugins/toast/src/error.rs
+++ b/plugins/toast/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     #[cfg(mobile)]
     #[error(transparent)]
     PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+    #[cfg(desktop)]
+    #[error(transparent)]
+    Tauri(#[from] tauri::Error),
 }
 
 impl Serialize for Error {


### PR DESCRIPTION
## Summary
- The toast plugin was only registered `#[cfg(target_os = "android")]` in `lib.rs`, so `invoke('plugin:toast|show', ...)` always failed with `"plugin toast not found"` on desktop, independent of anything else.
- On top of that, `desktop.rs`'s `show()` was a literal no-op stub — so `showToast()` has never actually worked on desktop, including the existing snooze-confirmation toast, silently swallowed by a `try`/`catch` + `console.warn` in `NotificationToastService.ts`.
- Fixes both: registers `tauri_plugin_toast::init()` unconditionally alongside the other desktop plugins, and has `desktop.rs`'s `show()` emit a `toast:show` Tauri event that a new `DesktopToastHost` component renders as an MUI `Snackbar`, with FIFO queueing so multiple toasts don't clobber each other. This keeps `showToast()` a single call path for the UI regardless of platform — the plugin stays the entry point either way, mobile is untouched (compile-time `#[cfg(mobile)]`/`#[cfg(desktop)]` module split, so this code doesn't even exist in mobile builds).

## Test plan
- [x] `cargo test -p tauri-plugin-toast -p threshold` — 36 tests pass
- [x] `cargo check --workspace` clean
- [x] `pnpm --filter threshold exec tsc --noEmit` clean
- [x] Live-verified via the Tauri MCP bridge against a running desktop dev build: single toast show/auto-hide, a 3-item FIFO queue (short/short/long) all advancing correctly in sequence, and all three anchor positions (`top`, `bottom`, `centre`) rendering at the correct screen location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2