### PR TITLE
Drive native alarm scheduling from Rust events, not the webview

### DIFF
--- a/apps/threshold/src-tauri/src/alarm/events.rs
+++ b/apps/threshold/src-tauri/src/alarm/events.rs
@@ -84,7 +84,7 @@ pub struct AlarmCancelled {
     pub revision: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// Enumerates why a scheduled alarm was cancelled.
 pub enum CancelReason {

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -483,40 +483,20 @@ impl AlarmCoordinator {
         previous: Option<&AlarmRecord>,
         revision: i64,
     ) -> Result<()> {
-        let was_scheduled = previous
-            .map(|p| p.enabled && p.next_trigger.is_some())
-            .unwrap_or(false);
-
-        let should_schedule = alarm.enabled && alarm.next_trigger.is_some();
-
-        match (was_scheduled, should_schedule) {
-            (false, true) => {
-                // Schedule
+        match classify_scheduling_transition(previous, alarm) {
+            SchedulingTransition::Schedule => {
                 self.emit_alarm_scheduled(app, alarm, revision).await?;
             }
-            (true, false) => {
-                // Cancel
-                let reason = if alarm.enabled {
-                    CancelReason::Updated
-                } else {
-                    CancelReason::Disabled
-                };
+            SchedulingTransition::Cancel(reason) => {
                 self.emit_alarm_cancelled(app, alarm.id, reason, revision)
                     .await?;
             }
-            (true, true) => {
-                // Check if trigger changed
-                let trigger_changed = previous
-                    .map(|p| p.next_trigger != alarm.next_trigger)
-                    .unwrap_or(false);
-
-                if trigger_changed {
-                    self.emit_alarm_cancelled(app, alarm.id, CancelReason::Updated, revision)
-                        .await?;
-                    self.emit_alarm_scheduled(app, alarm, revision).await?;
-                }
+            SchedulingTransition::Reschedule => {
+                self.emit_alarm_cancelled(app, alarm.id, CancelReason::Updated, revision)
+                    .await?;
+                self.emit_alarm_scheduled(app, alarm, revision).await?;
             }
-            (false, false) => {}
+            SchedulingTransition::NoOp => {}
         }
 
         Ok(())
@@ -587,5 +567,162 @@ impl AlarmCoordinator {
         };
         app.emit("alarms:batch:updated", &event)?;
         Ok(())
+    }
+}
+
+/// What, if anything, a mutation should do to an alarm's native schedule. Pulled out of
+/// `emit_scheduling_events` as a pure function so it's testable without an `AppHandle`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchedulingTransition {
+    Schedule,
+    Cancel(CancelReason),
+    Reschedule,
+    NoOp,
+}
+
+fn classify_scheduling_transition(
+    previous: Option<&AlarmRecord>,
+    alarm: &AlarmRecord,
+) -> SchedulingTransition {
+    let was_scheduled = previous
+        .map(|p| p.enabled && p.next_trigger.is_some())
+        .unwrap_or(false);
+
+    let should_schedule = alarm.enabled && alarm.next_trigger.is_some();
+
+    match (was_scheduled, should_schedule) {
+        (false, true) => SchedulingTransition::Schedule,
+        (true, false) => {
+            let reason = if alarm.enabled {
+                CancelReason::Updated
+            } else {
+                CancelReason::Disabled
+            };
+            SchedulingTransition::Cancel(reason)
+        }
+        (true, true) => {
+            // Re-schedule on a trigger change, or a sound change alone -- the native
+            // scheduler needs to know about the latter too, or an edited sound won't
+            // take effect until some other change happens to trigger a reschedule.
+            let needs_reschedule = previous
+                .map(|p| p.next_trigger != alarm.next_trigger || p.sound_uri != alarm.sound_uri)
+                .unwrap_or(false);
+
+            if needs_reschedule {
+                SchedulingTransition::Reschedule
+            } else {
+                SchedulingTransition::NoOp
+            }
+        }
+        (false, false) => SchedulingTransition::NoOp,
+    }
+}
+
+#[cfg(test)]
+mod scheduling_transition_tests {
+    use super::*;
+
+    fn alarm(enabled: bool, next_trigger: Option<i64>, sound_uri: Option<&str>) -> AlarmRecord {
+        AlarmRecord {
+            id: 1,
+            label: None,
+            enabled,
+            mode: AlarmMode::Fixed,
+            fixed_time: Some("07:00".into()),
+            window_start: None,
+            window_end: None,
+            active_days: vec![0, 1, 2, 3, 4, 5, 6],
+            next_trigger,
+            sound_uri: sound_uri.map(|s| s.to_string()),
+            sound_title: None,
+            revision: 1,
+        }
+    }
+
+    #[test]
+    fn schedules_a_newly_enabled_alarm() {
+        let previous = alarm(false, None, None);
+        let current = alarm(true, Some(1_000), None);
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::Schedule
+        );
+    }
+
+    #[test]
+    fn schedules_a_brand_new_alarm_with_no_previous_state() {
+        let current = alarm(true, Some(1_000), None);
+
+        assert_eq!(
+            classify_scheduling_transition(None, &current),
+            SchedulingTransition::Schedule
+        );
+    }
+
+    #[test]
+    fn cancels_as_disabled_when_the_user_toggles_off() {
+        let previous = alarm(true, Some(1_000), None);
+        let current = alarm(false, Some(1_000), None);
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::Cancel(CancelReason::Disabled)
+        );
+    }
+
+    #[test]
+    fn cancels_as_updated_when_still_enabled_but_no_longer_has_a_trigger() {
+        let previous = alarm(true, Some(1_000), None);
+        let current = alarm(true, None, None);
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::Cancel(CancelReason::Updated)
+        );
+    }
+
+    #[test]
+    fn reschedules_when_the_trigger_time_changes() {
+        let previous = alarm(true, Some(1_000), None);
+        let current = alarm(true, Some(2_000), None);
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::Reschedule
+        );
+    }
+
+    #[test]
+    fn reschedules_when_only_the_sound_changes() {
+        let previous = alarm(true, Some(1_000), Some("a.mp3"));
+        let current = alarm(true, Some(1_000), Some("b.mp3"));
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::Reschedule
+        );
+    }
+
+    #[test]
+    fn does_nothing_when_neither_trigger_nor_sound_changed() {
+        let previous = alarm(true, Some(1_000), Some("a.mp3"));
+        let current = alarm(true, Some(1_000), Some("a.mp3"));
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::NoOp
+        );
+    }
+
+    #[test]
+    fn does_nothing_for_an_alarm_that_was_never_and_still_is_not_scheduled() {
+        let previous = alarm(false, None, None);
+        let current = alarm(false, None, None);
+
+        assert_eq!(
+            classify_scheduling_transition(Some(&previous), &current),
+            SchedulingTransition::NoOp
+        );
     }
 }

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -725,4 +725,14 @@ mod scheduling_transition_tests {
             SchedulingTransition::NoOp
         );
     }
+
+    #[test]
+    fn does_nothing_for_a_brand_new_disabled_alarm_with_no_previous_state() {
+        let current = alarm(false, None, None);
+
+        assert_eq!(
+            classify_scheduling_transition(None, &current),
+            SchedulingTransition::NoOp
+        );
+    }
 }

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -4,10 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::models::*;
-use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use tauri::{plugin::PluginApi, AppHandle, Emitter, Manager, Runtime};
+use tauri::{plugin::PluginApi, Emitter, Runtime};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep_until, Duration, Instant};
 
@@ -35,19 +34,6 @@ impl<R: Runtime> AlarmManager<R> {
     pub fn cancel(&self, payload: CancelRequest) -> crate::Result<()> {
         self.cancel_internal(payload.id);
         Ok(())
-    }
-
-    pub fn update_alarms(&self, alarms: Vec<Value>) {
-        for alarm in alarms {
-            let id = alarm["id"].as_i64().unwrap_or(0) as i32;
-            let enabled = alarm["enabled"].as_bool().unwrap_or(false);
-            let next_trigger = alarm["nextTrigger"].as_i64();
-
-            match next_trigger {
-                Some(trigger) if enabled => self.schedule_internal(id, trigger),
-                _ => self.cancel_internal(id),
-            }
-        }
     }
 
     fn schedule_internal(&self, id: i32, trigger_at: i64) {
@@ -110,9 +96,4 @@ impl<R: Runtime> AlarmManager<R> {
         println!("Desktop: Stop ringing request received");
         Ok(())
     }
-}
-
-pub fn handle_alarms_changed<R: Runtime>(app: &AppHandle<R>, alarms: Vec<Value>) {
-    let manager = app.state::<AlarmManager<R>>();
-    manager.update_alarms(alarms);
 }

--- a/plugins/alarm-manager/src/lib.rs
+++ b/plugins/alarm-manager/src/lib.rs
@@ -57,28 +57,52 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             let alarm_manager = desktop::init(app, api)?;
             app.manage(alarm_manager);
 
-            // Listen to alarms:changed events
-            setup_event_listener(app.clone());
+            // Registered here (the plugin's own setup) rather than the app's setup hook,
+            // so these listeners are guaranteed to exist before AlarmCoordinator's
+            // heal_on_launch re-emits alarm:scheduled -- Tauri runs plugin setup before
+            // the app's own setup closure, and a listener registered after an event
+            // fires never receives it.
+            setup_scheduling_listeners(app.clone());
 
             Ok(())
         })
         .build()
 }
 
-fn setup_event_listener<R: Runtime>(app: AppHandle<R>) {
-    use serde_json::Value;
+/// Listens for the AlarmCoordinator's granular scheduling events and drives the native
+/// alarm manager directly, in-process -- no webview round-trip required. `ScheduleRequest`/
+/// `CancelRequest` already deserialize a compatible subset of `alarm:scheduled`'s /
+/// `alarm:cancelled`'s payload fields, so no dedicated event types are needed here.
+fn setup_scheduling_listeners<R: Runtime>(app: AppHandle<R>) {
+    let scheduled_app = app.clone();
+    app.listen("alarm:scheduled", move |event| {
+        match serde_json::from_str::<models::ScheduleRequest>(event.payload()) {
+            Ok(request) => {
+                if let Err(error) = scheduled_app.state::<AlarmManager<R>>().schedule(request) {
+                    log::error!(
+                        "alarm-manager: failed to schedule from alarm:scheduled event: {error}"
+                    );
+                }
+            }
+            Err(error) => {
+                log::error!("alarm-manager: failed to parse alarm:scheduled payload: {error}");
+            }
+        }
+    });
 
-    let app_handle = app.clone();
-    app.listen("alarms:changed", move |event| {
-        let payload = event.payload();
-
-        // Parse AlarmRecord array
-        if let Ok(alarms) = serde_json::from_str::<Vec<Value>>(payload) {
-            #[cfg(mobile)]
-            mobile::handle_alarms_changed(&app_handle, alarms);
-
-            #[cfg(desktop)]
-            desktop::handle_alarms_changed(&app_handle, alarms);
+    let cancelled_app = app.clone();
+    app.listen("alarm:cancelled", move |event| {
+        match serde_json::from_str::<models::CancelRequest>(event.payload()) {
+            Ok(request) => {
+                if let Err(error) = cancelled_app.state::<AlarmManager<R>>().cancel(request) {
+                    log::error!(
+                        "alarm-manager: failed to cancel from alarm:cancelled event: {error}"
+                    );
+                }
+            }
+            Err(error) => {
+                log::error!("alarm-manager: failed to parse alarm:cancelled payload: {error}");
+            }
         }
     });
 }

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -5,13 +5,10 @@
 
 use crate::models::*;
 use serde::Serialize;
-use serde_json::Value;
-use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
 use tauri::{
     ipc::{Channel, InvokeResponseBody},
     plugin::{PluginApi, PluginHandle},
-    AppHandle, Emitter, Manager, Runtime,
+    Emitter, Runtime,
 };
 
 #[derive(Serialize)]
@@ -128,31 +125,21 @@ pub fn init<R: Runtime>(
     #[cfg(not(target_os = "android"))]
     let handle = api.handle().clone();
 
-    Ok(AlarmManager {
-        handle,
-        scheduled_ids: Arc::new(Mutex::new(HashSet::new())),
-    })
+    Ok(AlarmManager { handle })
 }
 
 /// Access to the alarm-manager APIs.
 pub struct AlarmManager<R: Runtime> {
     handle: PluginHandle<R>,
-    scheduled_ids: Arc<Mutex<HashSet<i32>>>,
 }
 
 impl<R: Runtime> AlarmManager<R> {
     pub fn schedule(&self, payload: ScheduleRequest) -> crate::Result<()> {
-        let id = payload.id;
-        self.invoke_schedule(payload)?;
-        self.scheduled_ids.lock().unwrap().insert(id);
-        Ok(())
+        self.invoke_schedule(payload)
     }
 
     pub fn cancel(&self, payload: CancelRequest) -> crate::Result<()> {
-        let id = payload.id;
-        self.invoke_cancel(payload)?;
-        self.scheduled_ids.lock().unwrap().remove(&id);
-        Ok(())
+        self.invoke_cancel(payload)
     }
 
     pub fn get_launch_args(&self) -> crate::Result<Vec<ImportedAlarm>> {
@@ -209,60 +196,6 @@ impl<R: Runtime> AlarmManager<R> {
             .map_err(Into::into)
     }
 
-    pub fn update_alarms(&self, alarms: Vec<Value>) {
-        #[cfg(target_os = "android")]
-        {
-            let previous_ids = self.scheduled_ids.lock().unwrap().clone();
-            let mut desired_ids = HashSet::new();
-
-            for alarm in alarms {
-                let id = alarm["id"].as_i64().unwrap_or(0) as i32;
-                if id <= 0 {
-                    continue;
-                }
-
-                let enabled = alarm["enabled"].as_bool().unwrap_or(false);
-                let next_trigger = alarm["nextTrigger"].as_i64();
-                let sound_uri = alarm["soundUri"].as_str().map(|s| s.to_string());
-
-                if enabled {
-                    if let Some(trigger) = next_trigger {
-                        desired_ids.insert(id);
-                        let payload = ScheduleRequest {
-                            id,
-                            trigger_at: trigger,
-                            sound_uri,
-                        };
-                        if let Err(error) = self.invoke_schedule(payload) {
-                            log::error!("Failed to schedule alarm {}: {}", id, error);
-                        }
-                    } else {
-                        let payload = CancelRequest { id };
-                        if let Err(error) = self.invoke_cancel(payload) {
-                            log::error!("Failed to cancel alarm {}: {}", id, error);
-                        }
-                    }
-                } else {
-                    if previous_ids.contains(&id) {
-                        let payload = CancelRequest { id };
-                        if let Err(error) = self.invoke_cancel(payload) {
-                            log::error!("Failed to cancel alarm {}: {}", id, error);
-                        }
-                    }
-                }
-            }
-
-            for removed_id in previous_ids.difference(&desired_ids) {
-                let payload = CancelRequest { id: *removed_id };
-                if let Err(error) = self.invoke_cancel(payload) {
-                    log::error!("Failed to cancel removed alarm {}: {}", removed_id, error);
-                }
-            }
-
-            *self.scheduled_ids.lock().unwrap() = desired_ids;
-        }
-    }
-
     fn invoke_schedule(&self, payload: ScheduleRequest) -> crate::Result<()> {
         self.handle
             .run_mobile_plugin("schedule", payload)
@@ -274,9 +207,4 @@ impl<R: Runtime> AlarmManager<R> {
             .run_mobile_plugin("cancel", payload)
             .map_err(Into::into)
     }
-}
-
-pub fn handle_alarms_changed<R: Runtime>(app: &AppHandle<R>, alarms: Vec<Value>) {
-    let manager = app.state::<AlarmManager<R>>();
-    manager.update_alarms(alarms);
 }


### PR DESCRIPTION
## Summary
Part 1 of 3 (issue #196) finishing the event-driven native-scheduling migration. See the epic discussion for full context.

- The alarm-manager plugin's granular `alarm:scheduled`/`alarm:cancelled` events (emitted by `AlarmCoordinator` on every real scheduling transition) have had zero listeners since they were introduced — native scheduling has only ever been driven by `AlarmManagerService.ts` polling `alarms:batch:updated` and re-deriving what changed from a full alarm list. The plugin's old `alarms:changed` listener was dead code for the same reason (nothing emits that event either).
- Registers real listeners for `alarm:scheduled`/`alarm:cancelled` inside the plugin's own `setup()` — deliberately not the app's setup hook, since Tauri runs plugin setup before the app's setup closure, and `heal_on_launch`'s re-emission of `alarm:scheduled` on startup needs a listener to already exist to mean anything (verified live — see test plan).
- Deletes the `alarms:changed`-era dead code (`update_alarms`, `scheduled_ids`, `handle_alarms_changed`) on both platforms — this was already unreachable before this change, unrelated to which architecture wins.
- Fixes a real gap this surfaces: `emit_scheduling_events` only checked `next_trigger` for reschedule-worthiness, not `sound_uri`, so a sound-only edit wouldn't reschedule the native alarm. TS's own signature-based dedup happened to catch this independently; now that Rust is becoming the primary driver, it needs to catch it directly. Extracted the transition decision into a pure, directly-testable `classify_scheduling_transition` function.

TS's `alarms:batch:updated`-driven sync is left in place for now, running redundantly alongside the new listeners. Removing it is PR #2 of this series (#242).

## Test plan
- [x] `cargo test --workspace` — all green, 9 unit tests for `classify_scheduling_transition`
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live-verified via the Tauri MCP bridge against a running desktop dev build:
  - Creating an alarm schedules it natively via the new listener
  - Toggling off cancels it
  - Editing **only** the sound (same trigger time) reschedules it — proves the `sound_uri` fix works
  - Restarting the app: `heal_on_launch` re-emits `alarm:scheduled`, and the new listener picks it up **before** any TS code runs — proves the plugin-setup ordering fix works
  - Actually verified the redundant-coexistence claim (not just reasoned about it): temporarily restored the pre-PR TS code on disk and confirmed the dev log shows **two** `Desktop: Schedule alarm N for ...` lines per creation (one from the new Rust listener, one from TS's still-active `syncNativeAlarms`), with no errors — genuinely idempotent, not just assumed to be

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM1S4DNyxhwcbkMcx3hDp2