### PR TITLE
Emit ForceSync when a watch-initiated alarm delete fails

### DIFF
--- a/apps/threshold/src-tauri/src/alarm/database.rs
+++ b/apps/threshold/src-tauri/src/alarm/database.rs
@@ -203,10 +203,16 @@ impl AlarmDatabase {
             .execute(&mut *tx)
             .await?;
 
-        // Create tombstone
+        // Create tombstone. Upserts on a repeat delete of the same id (e.g. a retried
+        // watch-originated delete message) rather than erroring on the alarm_id primary key --
+        // refreshing to the retry's revision/timestamp is correct since it may be newer.
         sqlx::query(
             "INSERT INTO alarm_tombstones (alarm_id, deleted_at_revision, deleted_at_timestamp, label)
-             VALUES (?, ?, ?, ?)"
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(alarm_id) DO UPDATE SET
+                deleted_at_revision = excluded.deleted_at_revision,
+                deleted_at_timestamp = excluded.deleted_at_timestamp,
+                label = excluded.label"
         )
         .bind(id)
         .bind(revision)
@@ -954,6 +960,31 @@ mod tests {
 
         let rev2 = db.next_revision().await.unwrap();
         db.delete_with_revision(alarm.id, rev2).await.unwrap();
+
+        let deleted_ids = db.get_deleted_since_revision(rev1).await.unwrap();
+        assert_eq!(deleted_ids.len(), 1);
+        assert_eq!(deleted_ids[0], alarm.id);
+    }
+
+    #[tokio::test]
+    async fn test_delete_with_revision_is_idempotent_on_repeat_delete() {
+        // A retried watch-originated delete for an already-deleted alarm must not error --
+        // alarm_tombstones.alarm_id is a primary key, so re-inserting the same id used to
+        // violate it and surface as a spurious Err from delete_alarm.
+        let db = setup_test_db().await;
+
+        let input = AlarmInput {
+            label: Some("To Delete".into()),
+            ..Default::default()
+        };
+        let rev1 = db.next_revision().await.unwrap();
+        let alarm = db.save(input, None, rev1).await.unwrap();
+
+        let rev2 = db.next_revision().await.unwrap();
+        db.delete_with_revision(alarm.id, rev2).await.unwrap();
+
+        let rev3 = db.next_revision().await.unwrap();
+        db.delete_with_revision(alarm.id, rev3).await.unwrap();
 
         let deleted_ids = db.get_deleted_since_revision(rev1).await.unwrap();
         assert_eq!(deleted_ids.len(), 1);

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -334,7 +334,18 @@ pub fn run() {
                             }
                             match coord.delete_alarm(&handle, cmd.alarm_id).await {
                                 Ok(_) => log::info!("watch: deleted alarm {}", cmd.alarm_id),
-                                Err(e) => log::error!("watch: failed to delete alarm {}: {e}", cmd.alarm_id),
+                                Err(e) => {
+                                    log::error!("watch: failed to delete alarm {}: {e} — requesting resync", cmd.alarm_id);
+                                    if let Err(sync_error) = coord
+                                        .emit_sync_needed(&handle, alarm::events::SyncReason::ForceSync)
+                                        .await
+                                    {
+                                        log::error!(
+                                            "watch: failed to emit ForceSync after delete error for alarm {}: {sync_error}",
+                                            cmd.alarm_id
+                                        );
+                                    }
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
## Summary

- The `wear:alarm:save` and `wear:alarm:delete` listeners in `apps/threshold/src-tauri/src/lib.rs` both correctly reject stale watch revisions and request a `ForceSync` resync in that branch, but only the save listener also requested a resync when the underlying mutation itself failed -- the delete listener just logged the error and returned, leaving the watch believing the delete succeeded while the phone still had the alarm.
- This fix mirrors the save path's failure handling in the delete path: on an `Err` from `coord.delete_alarm`, it now logs the error and calls `coord.emit_sync_needed(&handle, alarm::events::SyncReason::ForceSync).await`, with a secondary error log if that emit itself fails, exactly matching the existing structure directly above it in the same file.
- Code review on this PR found a related edge case: `alarm_tombstones.alarm_id` is a primary key, so a retried watch-originated delete for an already-deleted alarm would hit that constraint on the second tombstone insert, surfacing as a spurious `Err` from `delete_alarm` -- which, after the fix above, now triggers an unnecessary (though harmless) `ForceSync`. Fixed by upserting the tombstone instead of erroring on a repeat delete, so a retry just refreshes the tombstone's revision/timestamp.

## Test plan

- [x] `cargo test -p threshold` -- 46 passed, 0 failed
- [x] `cargo clippy -p threshold --all-targets` -- clean aside from pre-existing, unrelated `bool_assert_comparison` warnings in `alarm/database.rs`
- [x] Added `test_delete_with_revision_is_idempotent_on_repeat_delete`, asserting a repeat `delete_with_revision` call for the same alarm id no longer errors and still reports exactly one tombstoned id
- [ ] No new automated test for the `wear:alarm:delete` listener's failure branch itself -- it's an inline closure registered against a live `app.handle().listen()` inside `setup()`, and there's no existing `tauri::test`/mock-runtime harness in this codebase to drive that event + `AppHandle` + async-spawn path in a unit test; the closest existing coverage (`alarm::scheduling_transition_tests`) tests pure functions, not these listeners

Fixes #157
