### PR TITLE
Restore scrolling on screens taller than the viewport

### DIFF
--- a/apps/threshold/src/theme/predictiveBack.css
+++ b/apps/threshold/src/theme/predictiveBack.css
@@ -15,6 +15,14 @@
 	width: 100%;
 	height: 100%;
 	z-index: 2;
+	/* .wa-route-slot (router.tsx) is documented as "the single scroll container for every
+	   screen", but this wrapper -- needed so the gesture has a fixed-size layer to slide --
+	   sits between it and the routed content, so a screen taller than the viewport (e.g.
+	   Settings) no longer reaches that ancestor's scrollbar and gets clipped by
+	   .wa-route-stage's overflow: hidden instead. This layer is the routed content's actual
+	   viewport now, so it needs to be the one that scrolls. */
+	overflow-y: auto;
+	overflow-x: hidden;
 	/* Without an opaque background of its own, translating this layer away reveals the
 	   underlay bleeding through its transparent regions instead of just the area to its side.
 	   `--app-background-colour` is this app's existing theme token for exactly this (see

--- a/scripts/build-android-dev.sh
+++ b/scripts/build-android-dev.sh
@@ -19,6 +19,12 @@
 # without that, each fresh `docker run --rm` would auto-generate a new random debug key,
 # so every build would be signed differently and `adb install -r` over a previous run's
 # install would fail with a signature mismatch instead of updating in place.
+#
+# The Android SDK directory is persisted too -- the image already bakes in the Build-Tools/
+# Platform version this project's compileSdk actually needs, but AGP's dependency metadata
+# checks can still reach for an older Build-Tools/Platform baseline (observed: 35/34) that
+# isn't in the image. Without a persistent volume here, `--rm` throws that away every run,
+# so it re-downloads from Google's servers on every single build instead of once.
 
 set -euo pipefail
 
@@ -73,6 +79,7 @@ docker run --rm \
 	-v threshold-android-gradle-cache:/home/vscode/.gradle \
 	-v threshold-android-cargo-cache:/home/vscode/.cargo/registry \
 	-v threshold-android-keystore:/home/vscode/.android \
+	-v threshold-android-sdk-extras:/home/vscode/Android/Sdk \
 	-w /workspace \
 	"$IMAGE" \
 	bash -c "


### PR DESCRIPTION
## Summary

- Scrolling stopped working on screens taller than the viewport (Settings is the most noticeable, but this affects any overflowing screen) -- a regression from the predictive-back gesture PR. `router.tsx`'s `.wa-route-slot` is documented as "the single scroll container for every screen," but `RouteStage`'s `.wa-route-stage`/`.wa-route-top` wrappers (added so the gesture has a fixed-size layer to slide) sit between it and the routed content, both forcing `height: 100%`, with the outer one clipping via `overflow: hidden`. That capped every screen's visible height at the viewport and hid anything taller instead of letting `.wa-route-slot` scroll it.
- Fix: `.wa-route-top` now scrolls internally (`overflow-y: auto`), since it's effectively the new viewport for routed content. `.wa-route-stage` keeps its `overflow: hidden` so the gesture-slide clipping still works.
- Also includes a small, unrelated dev-tooling fix found while rebuilding to verify this: `scripts/build-android-dev.sh` wasn't persisting the Android SDK directory across runs, so every `docker run --rm` build re-downloaded Build-Tools 35 + Platform 34 from Google's servers from scratch (traced to `androidx.appcompat:1.7.1`'s `minCompileSdk=34` metadata triggering AGP's dependency-metadata verification step, even though the image already bakes in everything this project's own `compileSdk=36` needs). Added a persistent volume for it, matching the existing gradle/cargo/keystore volumes.

## Test plan

- [x] `pnpm --filter threshold test` -- 56 passed, 0 failed
- [x] `pnpm -r run typecheck` -- clean
- [x] `pnpm format` -- clean
- [ ] Real-device verification pending -- rebuilding via `scripts/build-android-dev.sh` to confirm Settings scrolls again on a Pixel 8 Pro (blocked on a fresh Wireless debugging connection)
