### PR TITLE
Align toast and app-management on the same androidx versions as everything else

### DIFF
--- a/plugins/app-management/android/build.gradle.kts
+++ b/plugins/app-management/android/build.gradle.kts
@@ -34,8 +34,8 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.7.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/plugins/toast/android/build.gradle.kts
+++ b/plugins/toast/android/build.gradle.kts
@@ -34,8 +34,8 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.7.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
## Summary

- `toast` and `app-management` were the only two plugins still pinned to `androidx.appcompat:1.6.0` and `androidx.core:core-ktx:1.9.0` -- every other plugin (`alarm-manager`, `wear-sync`, `theme-utils`) is already on `1.7.1`/`1.12.0`. Bumped both to match.
- Not the cause of any specific bug on its own -- found while tracing why `scripts/build-android-dev.sh` was re-downloading an older SDK Platform/Build-Tools baseline on every run (see #249): `androidx.appcompat:1.7.1`'s `minCompileSdk=34` metadata is what actually triggers that download, and having two plugins on the older `1.6.0` (`minCompileSdk=33`) just added an unrelated inconsistency to the dependency graph worth closing while it was already in view.

## Test plan

- [x] Confirmed via `aar-metadata.properties` inspection that `1.7.1` is already resolved project-wide today (Gradle picks the highest version across all modules), so this bump doesn't change what actually ships -- it just removes the stale lower pin
- Full Kotlin test suite verification pending real CI (local single-plugin Gradle invocation hit an unrelated `:tauri-android` variant-resolution gap when run in isolation outside the full multi-plugin CI job -- confirmed pre-existing and unaffected by this change, not something this PR introduces)
