### PR TITLE
Cap event log export size and move its file I/O off the IPC thread

### DIFF
--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -7,7 +7,9 @@ use std::{fs, path::PathBuf, time::SystemTime};
 
 use tauri::{AppHandle, Manager};
 
-const MAX_EVENT_LOG_BYTES: usize = usize::MAX;
+// Caps the assembled export at a reasonable size for a diagnostic dump sent to the
+// developer -- previously `usize::MAX`, which made the truncation logic below a no-op.
+const MAX_EVENT_LOG_BYTES: usize = 2 * 1024 * 1024;
 
 fn truncate_to_limit(value: &str, limit: usize) -> (String, bool) {
     if value.len() <= limit {
@@ -30,14 +32,15 @@ fn truncate_to_limit(value: &str, limit: usize) -> (String, bool) {
     (value[..end].to_string(), true)
 }
 
-fn collect_event_logs(app: &AppHandle) -> Result<String, String> {
-    let log_dir = app
-        .path()
-        .app_log_dir()
-        .map_err(|err| format!("Failed to locate log directory: {err}"))?;
-    let app_name = app.package_info().name.clone();
-    let app_version = app.package_info().version.to_string();
-
+/// Reads and formats the on-disk event logs into a single diagnostic string. Pure aside
+/// from the filesystem reads, so it's directly testable without an `AppHandle` and can be
+/// run on a blocking thread pool from the async commands below without touching `tauri`
+/// types at all.
+fn read_and_format_logs(
+    log_dir: PathBuf,
+    app_name: String,
+    app_version: String,
+) -> Result<String, String> {
     let mut entries: Vec<(PathBuf, SystemTime)> = Vec::new();
     let read_dir =
         fs::read_dir(&log_dir).map_err(|err| format!("Failed to read log directory: {err}"))?;
@@ -121,9 +124,30 @@ fn collect_event_logs(app: &AppHandle) -> Result<String, String> {
     Ok(output)
 }
 
+// A plain (non-async) #[tauri::command] runs its body directly, inline, on whichever
+// thread handles the IPC message -- Tauri does not offload it to a thread pool on its
+// own (confirmed via tauri-macros' body_blocking codegen). For a log directory that
+// could legitimately be a few MB, that blocking `fs` work needs to be moved to
+// spawn_blocking explicitly, which requires the command itself to be async so it can
+// await the spawned task without blocking that thread either.
+async fn collect_event_logs(app: AppHandle) -> Result<String, String> {
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|err| format!("Failed to locate log directory: {err}"))?;
+    let app_name = app.package_info().name.clone();
+    let app_version = app.package_info().version.to_string();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        read_and_format_logs(log_dir, app_name, app_version)
+    })
+    .await
+    .map_err(|err| format!("Failed to spawn blocking task: {err}"))?
+}
+
 #[tauri::command]
-pub fn export_event_logs(app: AppHandle, destination: String) -> Result<String, String> {
-    let content = collect_event_logs(&app)?;
+pub async fn export_event_logs(app: AppHandle, destination: String) -> Result<String, String> {
+    let content = collect_event_logs(app).await?;
     if destination.starts_with("content://") {
         return Err(
             "Android content URIs are not supported for log export. Please choose a file path."
@@ -133,28 +157,35 @@ pub fn export_event_logs(app: AppHandle, destination: String) -> Result<String, 
 
     let normalised_destination = destination
         .strip_prefix("file://")
-        .unwrap_or(destination.as_str());
-    let destination_path = PathBuf::from(normalised_destination);
-    if let Some(parent) = destination_path.parent() {
-        if !parent.exists() {
-            fs::create_dir_all(parent)
-                .map_err(|err| format!("Failed to create log export directory: {err}"))?;
-        }
-    }
+        .unwrap_or(destination.as_str())
+        .to_string();
 
-    fs::write(&destination_path, content)
-        .map_err(|err| format!("Failed to write event logs to {normalised_destination}: {err}"))?;
-    Ok(normalised_destination.to_string())
+    tauri::async_runtime::spawn_blocking(move || {
+        let destination_path = PathBuf::from(&normalised_destination);
+        if let Some(parent) = destination_path.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent)
+                    .map_err(|err| format!("Failed to create log export directory: {err}"))?;
+            }
+        }
+
+        fs::write(&destination_path, content).map_err(|err| {
+            format!("Failed to write event logs to {normalised_destination}: {err}")
+        })?;
+        Ok(normalised_destination)
+    })
+    .await
+    .map_err(|err| format!("Failed to spawn blocking task: {err}"))?
 }
 
 #[tauri::command]
-pub fn get_event_logs(app: AppHandle) -> Result<String, String> {
-    collect_event_logs(&app)
+pub async fn get_event_logs(app: AppHandle) -> Result<String, String> {
+    collect_event_logs(app).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_to_limit;
+    use super::{read_and_format_logs, truncate_to_limit};
 
     #[test]
     fn truncate_to_limit_returns_full_string_when_under_limit() {
@@ -176,5 +207,34 @@ mod tests {
         let (value, truncated) = truncate_to_limit(original, 5);
         assert_eq!(value, "log");
         assert!(truncated);
+    }
+
+    #[test]
+    fn read_and_format_logs_includes_matching_files_and_skips_others() {
+        let dir = std::env::temp_dir().join(format!(
+            "threshold-event-logs-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(dir.join("threshold.log"), "hello from threshold").unwrap();
+        std::fs::write(dir.join("unrelated.log"), "should not appear").unwrap();
+        std::fs::write(dir.join("threshold.txt"), "wrong extension, ignored").unwrap();
+
+        let result =
+            read_and_format_logs(dir.clone(), "threshold".to_string(), "1.2.3".to_string())
+                .unwrap();
+
+        assert!(result.contains("threshold event logs"));
+        assert!(result.contains("Version: 1.2.3"));
+        assert!(result.contains("==== threshold.log ===="));
+        assert!(result.contains("hello from threshold"));
+        assert!(!result.contains("should not appear"));
+        assert!(!result.contains("wrong extension"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- `MAX_EVENT_LOG_BYTES` was `usize::MAX`, making the truncation logic in `read_and_format_logs` (renamed from `collect_event_logs`'s inline body) a complete no-op. Set to a real 2 MiB cap for the diagnostic dump.
- Separately, traced through `tauri-macros`' actual codegen (`body_blocking` in `wrapper.rs`) to confirm a real concern the original issue's "sync I/O in an async command" phrasing gestured at, if imprecisely: a plain (non-async) `#[tauri::command]` runs its body directly, inline, on whichever thread handles the IPC message -- Tauri does not offload it to a thread pool on its own. For a log directory that could legitimately be a few MB, reading/writing it synchronously blocks that thread.
- Extracted the pure formatting logic into `read_and_format_logs` (testable without an `AppHandle`), made `collect_event_logs`/`export_event_logs`/`get_event_logs` `async fn`, and moved the actual `fs` work into `tauri::async_runtime::spawn_blocking`.
- This reimplements the same approach #148 (open since February, since drifted from current `event_logs.rs`) took, fresh against current code, plus the actual byte-limit fix #148 didn't touch. See the comment on #203 for the full verification trail.

Fixes #203

## Test plan

- [x] `cargo test -p threshold` -- all passing, including a new `read_and_format_logs_includes_matching_files_and_skips_others` test
- [x] `cargo clippy -p threshold --all-targets` -- clean
- [x] `cargo fmt -p threshold -- --check` -- clean
