### PR TITLE
Stop the back gesture and hardware back button getting stuck enabled on Home

### DIFF
--- a/apps/threshold/src/App.tsx
+++ b/apps/threshold/src/App.tsx
@@ -29,6 +29,7 @@ import './theme/transitions.css';
 import { routeTransitions } from './utils/RouteTransitions';
 import { predictiveBackController } from './utils/PredictiveBackController';
 import { AnimationScale } from './utils/AnimationScale';
+import { screenStack } from './utils/ScreenStack';
 import { SettingsService } from './services/SettingsService';
 import { alarmManagerService } from './services/AlarmManagerService';
 import { ROUTES } from './constants';
@@ -156,9 +157,15 @@ const App: React.FC = () => {
 							return false; // Prevent default (do nothing)
 						}
 
-						// Check if we can go back.
-						// window.history.length > 1 is the standard browser way to check history depth.
-						if (window.history.length > 1) {
+						// Check if we can go back. Deliberately uses screenStack (which tracks
+						// the app's real navigation depth, collapsing back down on a return to
+						// an earlier screen) rather than window.history.length -- that's a
+						// cumulative count of every entry ever pushed this session, so it never
+						// drops back down and stays truthy forever after the first navigation,
+						// wrongly treating Home as "can go back" and swallowing the back
+						// gesture/button instead of minimizing the app (see RouteStage.tsx's
+						// matching canGoBack effect for the same fix).
+						if (screenStack.getPrevious() !== null) {
 							// Signal that this is a backward navigation
 							routeTransitions.setNextDirection('backwards');
 							router.history.back();

--- a/apps/threshold/src/components/RouteStage.tsx
+++ b/apps/threshold/src/components/RouteStage.tsx
@@ -104,13 +104,21 @@ const RouteStage: React.FC = () => {
 	// Desktop's set_can_go_back is a harmless no-op, but there's still nothing for it to do
 	// there -- skip the round-trip entirely, matching how router.tsx already gates
 	// defaultViewTransition on PlatformUtils.isMobile().
+	//
+	// Deliberately checks screenStack.getPrevious() rather than window.history.length: the
+	// latter is a cumulative count of every entry ever pushed this session -- it never goes
+	// back down when you navigate back to an earlier screen (e.g. Home -> Settings -> Home
+	// still leaves history.length at 2+), so it stays truthy forever after the first
+	// navigation, wrongly enabling the gesture on Home. screenStack already tracks the
+	// app's real navigation depth (collapsing back down on a return-to-earlier-screen), so
+	// it's null exactly when there's genuinely nowhere left to go back to in-app.
 	useEffect(() => {
 		if (!PlatformUtils.isMobile()) {
 			return;
 		}
 		const canGoBack =
 			!location.pathname.startsWith(ROUTES.RINGING) &&
-			window.history.length > 1 &&
+			screenStack.getPrevious() !== null &&
 			!window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 		predictiveBackController.setCanGoBack(canGoBack);
 	}, [location.pathname]);


### PR DESCRIPTION
## Summary

- Found by manual on-device testing: the predictive-back gesture (and, it turns out, the hardware back button too) stayed enabled on the Home screen once you'd navigated anywhere at all during the session, instead of letting Android's default behaviour (exit/minimize the app) take over. Swiping back on Home did nothing visible -- no crash, just silence, since the gesture was being consumed into a `router.history.back()` call that had nowhere meaningful to land.
- Root cause: both `RouteStage.tsx`'s `canGoBack` check and `App.tsx`'s hardware back-button handler used `window.history.length > 1` to decide whether there's anywhere to go back to. That's the wrong signal -- `history.length` is a cumulative count of every entry ever pushed to the session history, and it never drops back down when you navigate back to an earlier screen. So once you'd navigated anywhere once, it stayed truthy forever, including back on Home.
- Fix: replaced both checks with `screenStack.getPrevious() !== null`. `ScreenStack` already tracks the app's real in-app navigation depth and correctly collapses back to null once you're at a screen with nothing before it in the actual navigation tree -- the same signal `RouteStage` already uses to decide whether to render a previous screen as the gesture's underlay, so this makes both checks agree with what the gesture is actually capable of showing.

## Test plan

- [x] `pnpm --filter threshold test` -- 56 passed, 0 failed
- [x] `pnpm -r run typecheck` -- clean
- [x] `pnpm format` -- clean
- [ ] Real-device verification pending -- rebuilding to confirm swiping back on Home now exits/minimizes the app on a Pixel 8 Pro
