### PR TITLE
Fix release TUI --no-commit/--no-web-sync no-ops and signed-tag failure

### DIFF
--- a/tools/release-tui/src/cli.tsx
+++ b/tools/release-tui/src/cli.tsx
@@ -37,8 +37,12 @@ interface CommanderCliOptions {
 	bump?: string;
 	redo?: boolean;
 	build?: boolean;
-	noCommit?: boolean;
-	noWebSync?: boolean;
+	// Commander's --no-X shorthand negates the *positive* form: passing --no-commit sets
+	// options.commit to false (true by default), it does not set an options.noCommit property at
+	// all. Reading a noCommit/noWebSync key here (as this used to) is always undefined, so the
+	// flags silently did nothing regardless of whether they were passed.
+	commit?: boolean;
+	webSync?: boolean;
 	dryRun?: boolean;
 }
 
@@ -80,8 +84,8 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
 		bump: options.bump ?? null,
 		redo: Boolean(options.redo),
 		build: Boolean(options.build),
-		noCommit: Boolean(options.noCommit),
-		noWebSync: Boolean(options.noWebSync),
+		noCommit: options.commit === false,
+		noWebSync: options.webSync === false,
 		dryRun: Boolean(options.dryRun),
 	};
 

--- a/tools/release-tui/src/lib/git.ts
+++ b/tools/release-tui/src/lib/git.ts
@@ -28,7 +28,9 @@ export function findLocalTagDate(tagName: string): string | null {
 }
 
 export function findLocalTagCommit(tagName: string): string | null {
-	const result = git('rev-parse', '--short', `refs/tags/${tagName}`);
+	// Peel with ^{commit} -- applyTag() below creates annotated tags, and rev-parse on an
+	// annotated tag ref returns the tag object's own SHA, not the commit it points to.
+	const result = git('rev-parse', '--short', `refs/tags/${tagName}^{commit}`);
 	if (result.status !== 0) return null;
 	return result.stdout.trim() || null;
 }

--- a/tools/release-tui/src/lib/git.ts
+++ b/tools/release-tui/src/lib/git.ts
@@ -96,7 +96,13 @@ export function createRedoCommit(message: string): void {
 }
 
 export function applyTag(tagName: string, force = false): void {
-	const args = force ? ['tag', '-f', tagName] : ['tag', tagName];
+	// Annotated (-a), not lightweight -- this repo has tag.gpgsign=true configured, and a signed
+	// tag must be a real Git object with a message, not just a ref pointing at a commit. Without
+	// -m, git tries to open an editor for the message and fails outright in a non-interactive
+	// shell.
+	const args = force
+		? ['tag', '-f', '-a', tagName, '-m', `Release ${tagName}`]
+		: ['tag', '-a', tagName, '-m', `Release ${tagName}`];
 	const result = git(...args);
 	if (result.status !== 0) throw new Error(`Failed to tag ${tagName}: ${result.stderr.trim()}`);
 }


### PR DESCRIPTION
## Summary
- `--no-commit` and `--no-web-sync` silently did nothing regardless of whether they were passed, because Commander's `--no-X` shorthand sets `options.commit`/`options.webSync` to `false`, not `options.noCommit`/`options.noWebSync` -- reading the latter was always `undefined`.
- `applyTag()` created a lightweight tag with no message, which fails in this repo since `tag.gpgsign=true` requires an annotated tag object to sign.

Found both while dry-running `--ci --bump minor --no-commit` for the first time ahead of the real v0.2.0 release.

## Test plan
- [x] `pnpm --filter @threshold/release-tui run typecheck`
- [x] `pnpm --filter @threshold/release-tui dev --ci --bump minor --dry-run` previews cleanly
- [x] `pnpm --filter @threshold/release-tui dev --ci --bump minor --no-commit` updates version files but creates no commit and no tag (confirmed via `git log`/`git tag --list`)
- [x] `pnpm format` / `bash scripts/check-headers.sh` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w