### PR TITLE
Release v0.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,82 @@ This document tracks all releases of the Threshold application.
 
 ---
 
+## Version 0.2.0
+
+**Release Date:** July 15, 2026
+**Status:** Released
+
+> [!NOTE]
+> This release delivers a ground-up screen refresh with entrance and gesture animations, a predictive-back live screen peek on Android, and the move of native alarm scheduling fully off the webview and into Rust. It also lands automatic draft deployment to Google Play for both the phone and Wear apps.
+
+### ✨ New Features
+
+**Screen Refresh Redesign**
+
+- Reworked Home, Edit Alarm, and Settings screens with a consistent accent-rail layout and window management
+- Entrance and reflow animations throughout, respecting the OS animation-speed setting
+- Swipe-to-delete, pull-to-refresh, and drag gesture arbitration rebuilt to coexist correctly on the alarm list
+- Predictive-back gesture support on Android with a live screen peek during the back gesture
+
+**Native Scheduling Fully in Rust**
+
+- Native Android alarm scheduling is now driven entirely by Rust events; TypeScript is no longer in the scheduling path
+- Support for overnight windows and correct sampling inside an open alarm window
+- Typed `guest-js` bindings generated for theme-utils, os-prefs, app-management, and alarm-manager
+- `apps/threshold/src/types/alarm.ts` is now generated from Rust's models via `ts-rs`, keeping frontend and backend alarm types in lockstep
+- Removed the dead, unused `packages/core` scheduler now that scheduling behaviour lives in Rust
+
+**Release Automation**
+
+- Google Play draft deployment: tagged releases now push signed phone and Wear bundles straight to Play's internal tracks as drafts, ready for manual review and publish
+- Every GitHub Release now includes a `SHA256SUMS` file covering all published artefacts
+- Release TUI gained proper CLI flag handling (`--no-commit`, `--no-web-sync`) and signed, annotated tag creation for fully scripted releases
+
+### 🐛 Bug Fixes
+
+- Fixed a ghost notification left behind on alarm delete, and implemented ringing snooze correctly
+- Fixed repeating alarms not re-arming on dismiss
+- Fixed `AlarmService.subscribe` clobbering earlier subscribers
+- Fixed Home and Settings screens losing scroll on viewports taller than the content, and alarm-list swipes blocking vertical scroll
+- Fixed desktop toasts not rendering because the toast plugin wasn't registered on desktop
+- Replaced a blocking `alert()` with inline validation, and added a warning when a Window alarm's next trigger is imminent
+- Fixed the predictive back gesture and hardware back button getting stuck enabled on Home
+- Fixed wear sync status getting stuck, and legacy empty-array sync payloads no longer failing to clear alarms
+- Fixed a live `activeDays`/`triggerAt` data-loss bug in native alarm imports
+- Fixed `SET_ALARM` intent import gaps (label parsing, `EXTRA_DAYS`, stale imports), and isolated per-import errors so one bad import no longer aborts the whole batch
+- Capped event log export size and moved its file I/O off the IPC thread
+
+### 🛠️ Build and Release
+
+- Re-enabled `cargo fmt`, `clippy`, and `prettier` as CI gates after bringing the workspace into compliance
+- Added a TypeScript type-check step, gated in CI
+- Pinned toolchain versions across Rust, Android, and CI, and migrated CI and the devcontainer to the shared Liminal HQ image family
+- Added missing licence headers across the repo
+- Removed barrel files per `AGENTS.md`'s no-barrel-files rule
+
+### 📚 Documentation
+
+- Documented wear-sync's `guest-js` exemption
+- Documented the release build pipeline's Google Play deployment setup and the CLI/agent-friendly end-to-end release runbook
+
+### 📝 Technical Details
+
+**Major PRs Merged (selected):**
+
+- [#190](https://github.com/liminal-hq/threshold/pull/190) - Screen refresh redesign — home, edit, settings, and window management
+- [#244](https://github.com/liminal-hq/threshold/pull/244) - Android predictive-back gesture with a live screen peek
+- [#241](https://github.com/liminal-hq/threshold/pull/241)-[#243](https://github.com/liminal-hq/threshold/pull/243) - Drive native alarm scheduling from Rust events, cutting TS out of the scheduling path entirely
+- [#256](https://github.com/liminal-hq/threshold/pull/256) - Remove the dead `packages/core` scheduler
+- [#257](https://github.com/liminal-hq/threshold/pull/257) - Scaffold draft Google Play deployment and document the CLI release runbook
+
+**Commit/Contributor Summary (`0.1.9` → `0.2.0`):**
+
+- **Commits:** 221
+- **Merged PRs:** 47
+- **Contributors:** Scott Morris
+
+---
+
 ## Version 0.1.9
 
 **Release Date:** March 2, 2026

--- a/apps/threshold-wear/build.gradle.kts
+++ b/apps/threshold-wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ca.liminalhq.threshold"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1000001009
-        versionName = "0.1.9"
+        versionCode = 1000002000
+        versionName = "0.2.0"
     }
 
     signingConfigs {

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "threshold",
 	"private": true,
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/threshold/src-tauri/tauri.conf.json
+++ b/apps/threshold/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Threshold",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"identifier": "ca.liminalhq.threshold",
 	"build": {
 		"beforeDevCommand": "pnpm dev",
@@ -25,7 +25,9 @@
 			"csp": null,
 			"assetProtocol": {
 				"scope": {
-					"allow": ["**"]
+					"allow": [
+						"**"
+					]
 				}
 			}
 		}
@@ -48,11 +50,15 @@
 	"plugins": {
 		"deep-link": {
 			"desktop": {
-				"schemes": ["threshold"]
+				"schemes": [
+					"threshold"
+				]
 			},
 			"mobile": [
 				{
-					"scheme": ["threshold"],
+					"scheme": [
+						"threshold"
+					],
 					"appLink": false
 				}
 			]

--- a/apps/threshold/src-tauri/tauri.conf.json
+++ b/apps/threshold/src-tauri/tauri.conf.json
@@ -25,9 +25,7 @@
 			"csp": null,
 			"assetProtocol": {
 				"scope": {
-					"allow": [
-						"**"
-					]
+					"allow": ["**"]
 				}
 			}
 		}
@@ -50,15 +48,11 @@
 	"plugins": {
 		"deep-link": {
 			"desktop": {
-				"schemes": [
-					"threshold"
-				]
+				"schemes": ["threshold"]
 			},
 			"mobile": [
 				{
-					"scheme": [
-						"threshold"
-					],
+					"scheme": ["threshold"],
 					"appLink": false
 				}
 			]

--- a/distribution/whatsnew-wear/whatsnew-en-CA
+++ b/distribution/whatsnew-wear/whatsnew-en-CA
@@ -1,1 +1,1 @@
-Bug fixes and improvements.
+Alarm scheduling now runs natively for better reliability, and sync with your phone is more consistent. Fixed sync status getting stuck and a data-loss bug affecting active days on repeating alarms.

--- a/distribution/whatsnew-wear/whatsnew-en-CA
+++ b/distribution/whatsnew-wear/whatsnew-en-CA
@@ -1,1 +1,6 @@
-Alarm scheduling now runs natively for better reliability, and sync with your phone is more consistent. Fixed sync status getting stuck and a data-loss bug affecting active days on repeating alarms.
+🔔 What's New
+• Alarm scheduling now runs fully natively for better reliability
+
+🦿 Fixes
+• Fixed sync status getting stuck
+• Fixed a data-loss bug affecting active days on repeating alarms

--- a/distribution/whatsnew-wear/whatsnew-en-CA
+++ b/distribution/whatsnew-wear/whatsnew-en-CA
@@ -1,6 +1,6 @@
 🔔 What's New
 • Alarm scheduling now runs fully natively for better reliability
 
-🦿 Fixes
+🐛 Fixes
 • Fixed sync status getting stuck
 • Fixed a data-loss bug affecting active days on repeating alarms

--- a/distribution/whatsnew/whatsnew-en-CA
+++ b/distribution/whatsnew/whatsnew-en-CA
@@ -3,7 +3,7 @@
 • Predictive-back gesture support with a live screen peek
 • Alarm scheduling now runs fully natively for better reliability
 
-🦿 Fixes
+🐛 Fixes
 • Fixed a ghost notification left behind on alarm delete
 • Fixed scrolling getting stuck on some screens
 • Fixed sync issues with the Wear companion app

--- a/distribution/whatsnew/whatsnew-en-CA
+++ b/distribution/whatsnew/whatsnew-en-CA
@@ -1,1 +1,9 @@
-Refreshed Home, Edit Alarm, and Settings screens with smoother entrance animations and gesture handling, plus predictive-back support with a live screen peek. Alarm scheduling now runs natively for better reliability. Fixed a ghost notification on delete, stuck scrolling on some screens, and several sync issues with the Wear companion app.
+🔔 What's New
+• Refreshed Home, Edit Alarm, and Settings screens with smoother animations
+• Predictive-back gesture support with a live screen peek
+• Alarm scheduling now runs fully natively for better reliability
+
+🦿 Fixes
+• Fixed a ghost notification left behind on alarm delete
+• Fixed scrolling getting stuck on some screens
+• Fixed sync issues with the Wear companion app

--- a/distribution/whatsnew/whatsnew-en-CA
+++ b/distribution/whatsnew/whatsnew-en-CA
@@ -1,1 +1,1 @@
-Bug fixes and improvements.
+Refreshed Home, Edit Alarm, and Settings screens with smoother entrance animations and gesture handling, plus predictive-back support with a live screen peek. Alarm scheduling now runs natively for better reliability. Fixed a ghost notification on delete, stuck scrolling on some screens, and several sync issues with the Wear companion app.


### PR DESCRIPTION
## Summary
- Bumps app/Wear versions to 0.2.0 (`apps/threshold/src-tauri/tauri.conf.json`, `apps/threshold-wear/build.gradle.kts`, `apps/threshold/package.json`)
- Adds the real `RELEASE_NOTES.md` entry for this release
- Replaces the placeholder Play "what's new" text in `distribution/whatsnew/whatsnew-en-CA` and `distribution/whatsnew-wear/whatsnew-en-CA` with real content for this release

Please review the release notes and What's New copy -- once this merges, tagging the merge commit `v0.2.0` and pushing the tag triggers the real release build, including the first real draft push to Google Play's internal tracks for both phone and Wear.

## Test plan
- [x] Version bump previously validated via `pnpm --filter @threshold/release-tui dev --ci --bump minor --dry-run`
- [ ] Review release notes / What's New copy
- [ ] Merge, then tag and push to trigger `release-build.yml`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w