### PR TITLE
Format version-bumped JSON files with prettier in the release TUI

### DIFF
--- a/tools/release-tui/src/lib/files.ts
+++ b/tools/release-tui/src/lib/files.ts
@@ -5,6 +5,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { PATHS, REPO_ROOT_MARKER } from './constants.js';
 import { deriveTauriVersionCode } from './version.js';
 
@@ -38,6 +39,9 @@ function readJson(filePath: string): Record<string, unknown> {
 
 function writeJson(filePath: string, data: Record<string, unknown>): void {
 	fs.writeFileSync(filePath, `${JSON.stringify(data, null, '\t')}\n`, 'utf8');
+	// JSON.stringify always expands arrays onto multiple lines; Prettier collapses short ones
+	// (e.g. tauri.conf.json's `"allow": ["**"]`), so a raw stringify fails CI's format:check.
+	spawnSync('pnpm', ['exec', 'prettier', '--write', filePath], { encoding: 'utf8' });
 }
 
 function parseWearVersionName(gradleText: string): string {


### PR DESCRIPTION
## Summary
`writeJson()` in `tools/release-tui/src/lib/files.ts` re-serialised the whole file via a raw `JSON.stringify(data, null, '\t')`, which always expands arrays onto multiple lines. Prettier collapses short arrays onto one line (e.g. `tauri.conf.json`'s `"allow": ["**"]`), so any version bump touching those fields fails CI's `format:check`.

Found merging the v0.2.0 release PR (#259) -- the version-bump commit tripped `test-js`'s prettier check on `tauri.conf.json`. Fixed the immediate failure there with a one-off `prettier --write`; this PR fixes the writer itself so it doesn't recur on the next release.

## Test plan
- [x] `pnpm --filter @threshold/release-tui run typecheck`
- [x] Ran a real (non-dry-run) `--ci --bump patch --no-commit` and confirmed `tauri.conf.json` passes `prettier --check` afterward, with only the version field changed (array formatting preserved)
- [x] Reverted the test bump's file changes before committing
- [x] `pnpm format` / `bash scripts/check-headers.sh` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w