### PR TITLE
Fix release-build.yml being schema-invalid due to secrets in a step if:

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -344,6 +344,10 @@ jobs:
     container:
       image: ghcr.io/liminal-hq/tauri-ci-mobile:latest
       options: --user 0
+    # The `secrets` context isn't readable from a step's `if:` (only from `env:`/`with:`/`run:`),
+    # so the Play deploy steps below gate on this job-level env var instead of secrets directly.
+    env:
+      PLAY_DEPLOY_READY: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -607,7 +611,7 @@ jobs:
       # workflow stays green for anyone who hasn't configured Play Console access yet. See
       # docs/infrastructure/release-build.md#google-play-deployment for full setup.
       - name: Deploy phone release to Google Play (draft)
-        if: ${{ needs.prepare-release.outputs.should_release == 'true' && secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ env.PLAY_DEPLOY_READY == 'true' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -635,7 +639,7 @@ jobs:
       # against this app's own Play Console track list -- if wrong, the action's error message
       # lists the real available track names, which is the fastest way to confirm/correct it.
       - name: Deploy Wear release to Google Play (draft)
-        if: ${{ needs.prepare-release.outputs.should_release == 'true' && secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        if: ${{ env.PLAY_DEPLOY_READY == 'true' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
Found while investigating why pushing the real `v0.2.0` tag tonight produced no workflow run at all. Both Google Play deploy steps (added in #257) reference `secrets.PLAY_SERVICE_ACCOUNT_JSON` directly in their step-level `if:`, e.g.:

```yaml
if: ${{ needs.prepare-release.outputs.should_release == 'true' && secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
```

The `secrets` context is **not** a valid context for a step's `if:` (only `env`, `github`, `inputs`, `job`, `matrix`, `needs`, `runner`, `steps`, `strategy`, `vars` are) -- confirmed with `actionlint`, which flagged this immediately and wasn't previously run against this repo's workflows. This makes the entire workflow file schema-invalid, so GitHub can't parse it at all: every push to `main` since #257 merged has silently produced a run with 0 jobs and no real error beyond "This run likely failed because of a workflow file issue" in the UI, and tag pushes (including tonight's `v0.2.0`) didn't even register a run.

## Fix
Moved the secret check into a job-level `env:` var (the `env` context *is* readable from a step's `if:`), and dropped the now-redundant `should_release` re-check since the job-level `if:` already gates the whole job on it.

## Test plan
- [x] `actionlint .github/workflows/*.yml` -- clean (previously flagged 2 errors on this file)
- [ ] Merge, then re-trigger the `v0.2.0` release via `workflow_dispatch` (tag push won't re-fire for an existing tag) and confirm `prepare-release` actually runs

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w