### PR TITLE
Fall back to jar when zip is missing for native debug symbols

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -575,10 +575,18 @@ jobs:
           if [ -n "${symbols_dir:-}" ] && [ -d "$symbols_dir" ]; then
             sample_lib=$(find "$symbols_dir" -name "libthreshold.so" | head -n1 || true)
             if [ -n "${sample_lib:-}" ] && file "$sample_lib" | grep -q "not stripped"; then
+              symbols_zip="$GITHUB_WORKSPACE/release-assets/android/threshold-phone-native-debug-symbols-v${phone_version_name}-${phone_version_code}.zip"
               (
                 cd "$symbols_dir"
-                zip -r -q "$GITHUB_WORKSPACE/release-assets/android/threshold-phone-native-debug-symbols-v${phone_version_name}-${phone_version_code}.zip" arm64-v8a/ armeabi-v7a/ x86/ x86_64/ || true
-              )
+                if command -v zip >/dev/null 2>&1; then
+                  zip -r -q "$symbols_zip" arm64-v8a/ armeabi-v7a/ x86/ x86_64/
+                else
+                  # `zip` isn't installed in the tauri-ci-mobile image; `jar` (bundled with the
+                  # JDK Gradle already requires) writes a standard PKZIP archive and is a drop-in
+                  # replacement -- Play's deobfuscation upload just needs a real zip file.
+                  jar cf "$symbols_zip" arm64-v8a/ armeabi-v7a/ x86/ x86_64/
+                fi
+              ) || echo "::warning::Could not archive native debug symbols; continuing without them" >&2
             fi
           fi
 


### PR DESCRIPTION
## Summary
Spotted via the Play Console screenshot from tonight's real v0.2.0 release: the uploaded phone bundle only shows a "ReTrace mapping file" attached, no native debug symbols. Confirmed in the `build-android` job logs:

```
/__w/_temp/....sh: line 59: zip: command not found
```

The `tauri-ci-mobile` container doesn't have `zip` installed. The debug-symbols archiving step was wrapped in `|| true` (originally meant to avoid failing the whole Android build over a nice-to-have artefact), which silently swallowed this on every single run -- Cargo's `strip = false` is working fine, the `.so` files really are unstripped and get detected correctly, only the actual zip step was broken.

## Fix
Falls back to `jar cf` (bundled with the JDK Gradle already requires to run, produces a standard PKZIP archive Play's deobfuscation upload accepts) when `zip` isn't on `PATH`, instead of adding a new dependency or touching the shared CI image (which lives in `liminal-hq/.github`, not this repo, per `CLAUDE.md`). Also replaces the blanket `|| true` with a `::warning::` annotation so a genuine future failure is visible in the run instead of silently disappearing again.

## Test plan
- [x] `actionlint .github/workflows/release-build.yml` -- clean
- [ ] Verified on the next release build that `threshold-phone-native-debug-symbols-v*.zip` gets created and uploaded to Play

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w