### PR TITLE
Bridge native event logs into the existing export feature

### DIFF
--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/NativeEventLog.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/NativeEventLog.kt
@@ -1,0 +1,58 @@
+// Lightweight native-side event logger for the Wear OS app's own private storage
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wear
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Appends timestamped lines to a file in the watch app's own private storage.
+ *
+ * There's no Tauri/Rust runtime on the Wear OS side (this is a plain native
+ * Kotlin/Compose app), so unlike the phone's copy of this same utility, there's
+ * no shared "app_log_dir()" to write into -- this file is later read and sent
+ * to the phone on request (see [ca.liminalhq.threshold.wear.service.DataLayerListenerService]),
+ * where it's merged into the phone's own event log export.
+ *
+ * Capped much smaller than the phone's copy: this file's content has to fit in
+ * a single Data Layer `MessageClient` payload (~100 KB practical limit) to avoid
+ * needing multi-part transfer for what's meant to be a quick spike.
+ */
+object NativeEventLog {
+	private const val FILE_NAME = "threshold-wear-native.log"
+	private const val MAX_BYTES = 64 * 1024L
+	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+	@Synchronized
+	fun log(context: Context, tag: String, message: String) {
+		try {
+			val file = File(context.filesDir, FILE_NAME)
+			if (file.exists() && file.length() > MAX_BYTES) {
+				file.delete()
+			}
+			val timestamp = formatter.format(Date())
+			file.appendText("[$timestamp][$tag] $message\n")
+		} catch (e: Exception) {
+			Log.w("NativeEventLog", "Failed to write native event log", e)
+		}
+	}
+
+	/** Reads the current log content, or an empty string if nothing's been logged yet. */
+	@Synchronized
+	fun read(context: Context): String {
+		return try {
+			val file = File(context.filesDir, FILE_NAME)
+			if (file.exists()) file.readText() else ""
+		} catch (e: Exception) {
+			Log.w("NativeEventLog", "Failed to read native event log", e)
+			""
+		}
+	}
+}

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/data/WearDataLayerClient.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/data/WearDataLayerClient.kt
@@ -19,6 +19,7 @@ private const val PATH_SAVE_ALARM = "/threshold/save_alarm"
 private const val PATH_DELETE_ALARM = "/threshold/delete_alarm"
 private const val PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
 private const val PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
+private const val PATH_LOG_RESPONSE = "/threshold/log_response"
 
 /**
  * Client for sending messages from the watch to the phone via the Wear
@@ -83,6 +84,16 @@ class WearDataLayerClient(context: Context) {
             put("snoozeLengthMinutes", snoozeLengthMinutes)
         }
         sendToPhone(PATH_ALARM_SNOOZE, json.toString().toByteArray())
+    }
+
+    /**
+     * Send the watch's own native event log content back to the phone, in response
+     * to a `/threshold/log_request` message -- merged into the phone's "Export event
+     * log" feature on arrival. Plain text, not JSON, since it's just the log file's
+     * own content verbatim.
+     */
+    suspend fun sendLogResponse(logContent: String) {
+        sendToPhone(PATH_LOG_RESPONSE, logContent.toByteArray())
     }
 
     /**

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/presentation/RingingActivity.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/presentation/RingingActivity.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.ThresholdWearApp
 import ca.liminalhq.threshold.wear.presentation.theme.ThresholdWearTheme
 import ca.liminalhq.threshold.wear.service.WearRingingService
@@ -46,6 +47,7 @@ class RingingActivity : ComponentActivity() {
 
         if (intent?.action == ACTION_CLOSE_RINGING) {
             Log.d(TAG, "Received close action in onCreate")
+            NativeEventLog.log(applicationContext, TAG, "Received close action in onCreate")
             closeRingingTask()
             return
         }
@@ -68,6 +70,7 @@ class RingingActivity : ComponentActivity() {
         val is24HourSource = if (is24HourKnown) "phone-sync" else "watch-default"
 
         Log.d(TAG, "Ringing activity created for alarm $alarmId ($hour:$minute '$label', is24h=$is24Hour source=$is24HourSource watchDefault=$watchDefaultIs24Hour)")
+        NativeEventLog.log(applicationContext, TAG, "Ringing activity created for alarm id=$alarmId")
 
         val app = application as ThresholdWearApp
         val dataLayerClient = app.dataLayerClient
@@ -83,6 +86,7 @@ class RingingActivity : ComponentActivity() {
                     snoozeLengthMinutes = snoozeLength,
                     onStop = {
                         Log.d(TAG, "Stop pressed for alarm $alarmId")
+                        NativeEventLog.log(applicationContext, TAG, "Stop pressed for alarm id=$alarmId")
                         stopRingingService()
                         scope.launch {
                             dataLayerClient.sendDismissAlarm(alarmId)
@@ -91,6 +95,7 @@ class RingingActivity : ComponentActivity() {
                     },
                     onSnooze = {
                         Log.d(TAG, "Snooze pressed for alarm $alarmId (${snoozeLength}m)")
+                        NativeEventLog.log(applicationContext, TAG, "Snooze pressed for alarm id=$alarmId (${snoozeLength}m)")
                         stopRingingService()
                         scope.launch {
                             // Always schedule a local snooze alarm so the
@@ -116,6 +121,7 @@ class RingingActivity : ComponentActivity() {
 
         if (intent.action == ACTION_CLOSE_RINGING) {
             Log.d(TAG, "Received close action in onNewIntent")
+            NativeEventLog.log(applicationContext, TAG, "Received close action in onNewIntent")
             closeRingingTask()
         }
     }

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/DataLayerListenerService.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/DataLayerListenerService.kt
@@ -21,6 +21,7 @@ import com.google.android.gms.wearable.WearableListenerService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONException
@@ -46,6 +47,15 @@ private const val PATH_LOG_REQUEST = "/threshold/log_request"
 class DataLayerListenerService : WearableListenerService() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Matches WearSyncService's own cleanup -- without this, handleLogRequest's
+        // in-flight coroutine (and the SupervisorJob backing it) outlives this service
+        // instance with nothing left to cancel it if the system tears the service down
+        // mid-request.
+        scope.cancel()
+    }
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         val app = application as? ThresholdWearApp ?: run {

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/DataLayerListenerService.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/DataLayerListenerService.kt
@@ -8,6 +8,7 @@ package ca.liminalhq.threshold.wear.service
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.ThresholdWearApp
 import ca.liminalhq.threshold.wear.data.SyncStatus
 import ca.liminalhq.threshold.wear.data.WatchAlarm
@@ -17,6 +18,10 @@ import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.WearableListenerService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -26,6 +31,7 @@ private const val DATA_PATH_ALARMS = "/threshold/alarms"
 private const val PATH_ALARM_RING = "/threshold/alarm_ring"
 private const val PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
 private const val PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
+private const val PATH_LOG_REQUEST = "/threshold/log_request"
 
 /**
  * Receives data changes and messages from the phone via the Wear Data Layer.
@@ -38,6 +44,8 @@ private const val PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
  * watch UI reflects the latest alarm state.
  */
 class DataLayerListenerService : WearableListenerService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onDataChanged(dataEvents: DataEventBuffer) {
         val app = application as? ThresholdWearApp ?: run {
@@ -99,12 +107,35 @@ class DataLayerListenerService : WearableListenerService() {
     override fun onMessageReceived(messageEvent: MessageEvent) {
         val path = messageEvent.path
         Log.d(TAG, "Message received: $path")
+        NativeEventLog.log(applicationContext, TAG, "Message received path=$path")
 
         when (path) {
             PATH_ALARM_RING -> handleAlarmRing(messageEvent)
             PATH_ALARM_DISMISS -> handleAlarmDismiss(messageEvent)
             PATH_ALARM_SNOOZE -> handleAlarmSnooze(messageEvent)
+            PATH_LOG_REQUEST -> handleLogRequest()
             else -> Log.d(TAG, "Unhandled message path: $path")
+        }
+    }
+
+    /**
+     * Send this watch's own native event log back to the phone, for the phone's
+     * "Export event log" feature to merge in. No Rust/Tauri involved on this side
+     * at all -- just reading a local file and sending it back over the Data Layer.
+     */
+    private fun handleLogRequest() {
+        val app = application as? ThresholdWearApp ?: run {
+            Log.e(TAG, "Application is not ThresholdWearApp — cannot respond to log request")
+            return
+        }
+        scope.launch {
+            try {
+                val content = NativeEventLog.read(applicationContext)
+                app.dataLayerClient.sendLogResponse(content)
+                Log.d(TAG, "Sent watch log (${content.length} chars) to phone")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send watch log to phone", e)
+            }
         }
     }
 
@@ -121,8 +152,14 @@ class DataLayerListenerService : WearableListenerService() {
             // Deduplication: skip if this alarm is already ringing
             if (WearRingingService.ringingAlarmId == alarmId) {
                 Log.d(TAG, "Alarm $alarmId already ringing — ignoring duplicate ring message")
+                NativeEventLog.log(
+                    applicationContext,
+                    TAG,
+                    "Ring message for alarm id=$alarmId dropped -- already ringing this alarm",
+                )
                 return
             }
+            NativeEventLog.log(applicationContext, TAG, "Ring message for alarm id=$alarmId accepted, starting WearRingingService")
             val label = json.optString("label", "")
             val hour = json.optInt("hour", 0)
             val minute = json.optInt("minute", 0)
@@ -197,6 +234,11 @@ class DataLayerListenerService : WearableListenerService() {
     private fun stopRingingOnWatch(action: String, alarmId: Int) {
         if (WearRingingService.ringingAlarmId == -1) {
             Log.d(TAG, "Ignoring $action for alarm $alarmId because no alarm is currently ringing")
+            NativeEventLog.log(
+                applicationContext,
+                TAG,
+                "$action for alarm id=$alarmId dropped -- nothing is currently ringing",
+            )
             return
         }
 
@@ -205,8 +247,14 @@ class DataLayerListenerService : WearableListenerService() {
                 TAG,
                 "Ignoring $action for alarm $alarmId while alarm ${WearRingingService.ringingAlarmId} is ringing",
             )
+            NativeEventLog.log(
+                applicationContext,
+                TAG,
+                "$action for alarm id=$alarmId dropped -- alarm id=${WearRingingService.ringingAlarmId} is ringing instead",
+            )
             return
         }
+        NativeEventLog.log(applicationContext, TAG, "$action accepted for alarm id=$alarmId")
 
         val serviceIntent = Intent(this, WearRingingService::class.java).apply {
             this.action = action

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/PhoneConnectionMonitor.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/PhoneConnectionMonitor.kt
@@ -7,6 +7,7 @@ package ca.liminalhq.threshold.wear.service
 
 import android.content.Context
 import android.util.Log
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.data.AlarmRepository
 import ca.liminalhq.threshold.wear.data.SyncStatus
 import com.google.android.gms.wearable.Node
@@ -125,10 +126,12 @@ class PhoneConnectionMonitor(
         if (connected) {
             repository.setSyncStatus(SyncStatus.CONNECTED)
             Log.i(TAG, "Phone connected — cancelling local fallback alarms")
+            NativeEventLog.log(context, TAG, "Phone connected -- cancelling local fallback alarms")
             scheduler.cancelAll(repository.alarms.value)
         } else {
             repository.setSyncStatus(SyncStatus.OFFLINE)
             Log.i(TAG, "Phone disconnected — scheduling local fallback alarms")
+            NativeEventLog.log(context, TAG, "Phone disconnected -- scheduling local fallback alarms")
             scheduler.reconcile(repository.alarms.value)
         }
     }

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearAlarmReceiver.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearAlarmReceiver.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.ThresholdWearApp
 import java.util.Calendar
 
@@ -40,6 +41,7 @@ class WearAlarmReceiver : BroadcastReceiver() {
         }
 
         Log.d(TAG, "Local alarm fired: id=$alarmId")
+        NativeEventLog.log(context, TAG, "Local (disconnected-fallback) alarm fired id=$alarmId")
 
         // Look up alarm details from the repository
         val app = context.applicationContext as? ThresholdWearApp

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearAlarmScheduler.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearAlarmScheduler.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.data.WatchAlarm
 
 private const val TAG = "WearAlarmScheduler"
@@ -79,6 +80,11 @@ class WearAlarmScheduler(private val context: Context) {
         saveScheduledIds(scheduledIds)
 
         Log.d(TAG, "Reconciled: $scheduled scheduled, $cancelled cancelled (${orphanedIds.size} orphaned)")
+        NativeEventLog.log(
+            context,
+            TAG,
+            "Reconciled fallback schedule: $scheduled scheduled, $cancelled cancelled (${orphanedIds.size} orphaned)",
+        )
     }
 
     /**
@@ -106,6 +112,7 @@ class WearAlarmScheduler(private val context: Context) {
         alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
 
         Log.d(TAG, "Scheduled alarm ${alarm.id} at $triggerAt (${alarm.hour}:${"%02d".format(alarm.minute)} '${alarm.label}')")
+        NativeEventLog.log(context, TAG, "Scheduled fallback alarm id=${alarm.id} at $triggerAt")
     }
 
     /**
@@ -131,6 +138,7 @@ class WearAlarmScheduler(private val context: Context) {
         saveScheduledIds(ids)
 
         Log.d(TAG, "Scheduled snooze for alarm $alarmId in ${delayMinutes}m (trigger at $triggerAt)")
+        NativeEventLog.log(context, TAG, "Scheduled fallback snooze id=$alarmId in ${delayMinutes}m")
     }
 
     /** Cancel a single alarm by its ID. */
@@ -142,6 +150,7 @@ class WearAlarmScheduler(private val context: Context) {
         saveScheduledIds(ids)
 
         Log.d(TAG, "Cancelled alarm $alarmId")
+        NativeEventLog.log(context, TAG, "Cancelled fallback alarm id=$alarmId")
     }
 
     /** Cancel all local alarms for the given list and clear tracked IDs. */

--- a/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearRingingService.kt
+++ b/apps/threshold-wear/src/main/java/ca/liminalhq/threshold/wear/service/WearRingingService.kt
@@ -23,6 +23,7 @@ import android.os.Vibrator
 import android.os.VibratorManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import ca.liminalhq.threshold.wear.NativeEventLog
 import ca.liminalhq.threshold.wear.presentation.RingingActivity
 
 /**
@@ -85,11 +86,13 @@ class WearRingingService : Service() {
         when (intent.action) {
             ACTION_DISMISS -> {
                 Log.d(TAG, "Dismiss action received")
+                NativeEventLog.log(applicationContext, TAG, "Dismiss action received for alarm id=$currentAlarmId")
                 stopSelf()
                 return START_NOT_STICKY
             }
             ACTION_SNOOZE -> {
                 Log.d(TAG, "Snooze action received")
+                NativeEventLog.log(applicationContext, TAG, "Snooze action received for alarm id=$currentAlarmId")
                 stopSelf()
                 return START_NOT_STICKY
             }
@@ -103,10 +106,16 @@ class WearRingingService : Service() {
         val snoozeLength = intent.getIntExtra(EXTRA_SNOOZE_LENGTH, 10)
 
         Log.d(TAG, "Starting ringing for alarm $currentAlarmId ($hour:$minute '$label')")
+        NativeEventLog.log(applicationContext, TAG, "Ringing service starting for alarm id=$currentAlarmId")
 
         val foregroundStarted = startForegroundNotification(hour, minute, label, snoozeLength)
         if (!foregroundStarted) {
             Log.e(TAG, "Failed to enter foreground; stopping ringing service")
+            NativeEventLog.log(
+                applicationContext,
+                TAG,
+                "Failed to enter foreground for alarm id=$currentAlarmId -- stopping",
+            )
             launchRingingActivity(hour, minute, label, snoozeLength)
             stopSelf(startId)
             return START_NOT_STICKY
@@ -121,6 +130,7 @@ class WearRingingService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "Service destroying")
+        NativeEventLog.log(applicationContext, TAG, "Ringing service destroying for alarm id=$currentAlarmId")
         ringingAlarmId = -1
         stopAudio()
         stopVibration()

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -6,6 +6,14 @@
 use std::{fs, path::PathBuf, time::SystemTime};
 
 use tauri::{AppHandle, Manager};
+use tauri_plugin_wear_sync::WearSyncExt;
+
+// Bounded wait for the watch's log response to land on disk before the export reads
+// the log directory -- the Data Layer round trip has no synchronous completion signal,
+// so this just gives it a fixed window rather than blocking indefinitely on an
+// unreachable/asleep watch. If it's too slow or unreachable, the export still proceeds
+// with whatever's already on disk.
+const WATCH_LOG_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
 
 // Caps the assembled export at a reasonable size for a diagnostic dump sent to the
 // developer -- previously `usize::MAX`, which made the truncation logic below a no-op.
@@ -176,6 +184,21 @@ pub async fn export_event_logs(app: AppHandle, destination: String) -> Result<St
     })
     .await
     .map_err(|err| format!("Failed to spawn blocking task: {err}"))?
+}
+
+/// Asks the watch to send its own native event log over, then waits a bounded
+/// amount of time for the response to land on disk before returning -- so a
+/// caller doing `request_watch_logs` then `get_event_logs` gets the watch's
+/// content included when it's reachable, without blocking indefinitely when
+/// it isn't. See `plugins/wear-sync/android/.../WearMessageService.kt`'s
+/// `writeWatchLog` for where the response actually gets written.
+#[tauri::command]
+pub async fn request_watch_logs(app: AppHandle) -> Result<(), String> {
+    if let Err(error) = app.wear_sync().request_watch_logs() {
+        log::warn!("event_logs: failed to request watch logs: {error}");
+    }
+    tokio::time::sleep(WATCH_LOG_WAIT).await;
+    Ok(())
 }
 
 #[tauri::command]

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -305,7 +305,11 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
 
-        std::fs::write(dir.join("Threshold-alarm-manager.log"), "native alarm event").unwrap();
+        std::fs::write(
+            dir.join("Threshold-alarm-manager.log"),
+            "native alarm event",
+        )
+        .unwrap();
         std::fs::write(dir.join("unrelated.log"), "should not appear").unwrap();
 
         let result = read_and_format_logs(

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -12,7 +12,9 @@ use tauri_plugin_wear_sync::WearSyncExt;
 // the log directory -- the Data Layer round trip has no synchronous completion signal,
 // so this just gives it a fixed window rather than blocking indefinitely on an
 // unreachable/asleep watch. If it's too slow or unreachable, the export still proceeds
-// with whatever's already on disk.
+// with whatever's already on disk. Android-only: no watch pairing is possible from
+// desktop at all, so there's nothing to wait for there.
+#[cfg(target_os = "android")]
 const WATCH_LOG_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
 
 // Caps the assembled export at a reasonable size for a diagnostic dump sent to the
@@ -192,11 +194,16 @@ pub async fn export_event_logs(app: AppHandle, destination: String) -> Result<St
 /// content included when it's reachable, without blocking indefinitely when
 /// it isn't. See `plugins/wear-sync/android/.../WearMessageService.kt`'s
 /// `writeWatchLog` for where the response actually gets written.
+///
+/// The wait itself only applies on Android -- wear-sync's `request_watch_logs`
+/// is an unconditional no-op everywhere else (no watch pairing is possible from
+/// desktop at all), so waiting there would just be a fixed delay for nothing.
 #[tauri::command]
 pub async fn request_watch_logs(app: AppHandle) -> Result<(), String> {
     if let Err(error) = app.wear_sync().request_watch_logs() {
         log::warn!("event_logs: failed to request watch logs: {error}");
     }
+    #[cfg(target_os = "android")]
     tokio::time::sleep(WATCH_LOG_WAIT).await;
     Ok(())
 }

--- a/apps/threshold/src-tauri/src/event_logs.rs
+++ b/apps/threshold/src-tauri/src/event_logs.rs
@@ -65,7 +65,16 @@ fn read_and_format_logs(
             Some(name) => name,
             None => continue,
         };
-        if !file_name.starts_with(&app_name) || !file_name.ends_with(".log") {
+        // scripts/build-android-dev.sh overrides productName to "Threshold Dev" for a
+        // side-by-side dev install, which changes app_name here but not the fixed
+        // "Threshold-*.log" filenames the native Kotlin loggers write (those aren't
+        // dynamically derived from productName). Falling back to just the first word
+        // of app_name keeps the dev-build override matching those files without
+        // weakening the filter to accept any unrelated ".log" file in this directory.
+        let app_name_first_word = app_name.split_whitespace().next().unwrap_or(&app_name);
+        let name_matches =
+            file_name.starts_with(&app_name) || file_name.starts_with(app_name_first_word);
+        if !name_matches || !file_name.ends_with(".log") {
             continue;
         }
         let modified = entry
@@ -195,16 +204,28 @@ pub async fn export_event_logs(app: AppHandle, destination: String) -> Result<St
 /// it isn't. See `plugins/wear-sync/android/.../WearMessageService.kt`'s
 /// `writeWatchLog` for where the response actually gets written.
 ///
-/// The wait itself only applies on Android -- wear-sync's `request_watch_logs`
-/// is an unconditional no-op everywhere else (no watch pairing is possible from
-/// desktop at all), so waiting there would just be a fixed delay for nothing.
+/// Only actually waits when Kotlin's own `requestWatchLogs` reports a watch was
+/// reachable at all -- on desktop (no watch pairing possible) and on Android
+/// with no paired watch, that call resolves synchronously with `connected:
+/// false`, so there's nothing worth waiting for and this returns immediately
+/// instead of sleeping out the full window for no reason.
 #[tauri::command]
 pub async fn request_watch_logs(app: AppHandle) -> Result<(), String> {
-    if let Err(error) = app.wear_sync().request_watch_logs() {
-        log::warn!("event_logs: failed to request watch logs: {error}");
-    }
+    let connected = match app.wear_sync().request_watch_logs().await {
+        Ok(connected) => connected,
+        Err(error) => {
+            log::warn!("event_logs: failed to request watch logs: {error}");
+            false
+        }
+    };
+
     #[cfg(target_os = "android")]
-    tokio::time::sleep(WATCH_LOG_WAIT).await;
+    if connected {
+        tokio::time::sleep(WATCH_LOG_WAIT).await;
+    }
+    #[cfg(not(target_os = "android"))]
+    let _ = connected;
+
     Ok(())
 }
 
@@ -264,6 +285,39 @@ mod tests {
         assert!(result.contains("hello from threshold"));
         assert!(!result.contains("should not appear"));
         assert!(!result.contains("wrong extension"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn read_and_format_logs_matches_native_log_files_under_a_dev_product_name_override() {
+        // scripts/build-android-dev.sh overrides productName to "Threshold Dev" for a
+        // side-by-side dev install. The native Kotlin loggers still write fixed
+        // "Threshold-*.log" filenames regardless of that override, so the match needs
+        // to fall back to the first word of app_name rather than requiring an exact
+        // prefix match against the full (possibly multi-word) product name.
+        let dir = std::env::temp_dir().join(format!(
+            "threshold-event-logs-test-devname-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(dir.join("Threshold-alarm-manager.log"), "native alarm event").unwrap();
+        std::fs::write(dir.join("unrelated.log"), "should not appear").unwrap();
+
+        let result = read_and_format_logs(
+            dir.clone(),
+            "Threshold Dev".to_string(),
+            "1.2.3".to_string(),
+        )
+        .unwrap();
+
+        assert!(result.contains("==== Threshold-alarm-manager.log ===="));
+        assert!(result.contains("native alarm event"));
+        assert!(!result.contains("should not appear"));
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
     builder = builder.invoke_handler(tauri::generate_handler![
         event_logs::export_event_logs,
         event_logs::get_event_logs,
+        event_logs::request_watch_logs,
         commands::get_alarms,
         commands::get_alarm,
         commands::save_alarm,
@@ -158,29 +159,26 @@ pub fn run() {
                 log::LevelFilter::Info
             };
 
+            // One explicit format for every platform rather than leaning on the plugin's own
+            // per-platform default (mobile's default omits a timestamp entirely, which made
+            // an earlier on-device incident hard to reconstruct from the exported log; desktop's
+            // default already includes one, but a different format than mobile's -- unified here
+            // so entries from every platform line up the same way in the persisted log file).
             let log_builder = tauri_plugin_log::Builder::default()
                 .level(log_level)
                 .level_for("jni", log::LevelFilter::Warn)
-                .level_for("tao", log::LevelFilter::Info);
-
-            #[cfg(mobile)]
-            {
-                let log_builder = log_builder.format(|out, message, record| {
+                .level_for("tao", log::LevelFilter::Info)
+                .format(|out, message, record| {
                     out.finish(format_args!(
-                        "[{}][{}] {}",
+                        "[{}][{}][{}] {}",
+                        chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
                         record.level(),
                         record.target(),
                         message
                     ))
                 });
 
-                app.handle().plugin(log_builder.build())?;
-            }
-
-            #[cfg(not(mobile))]
-            {
-                app.handle().plugin(log_builder.build())?;
-            }
+            app.handle().plugin(log_builder.build())?;
 
             // Initialise database and coordinator
             let db = tauri::async_runtime::block_on(async {

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -164,6 +164,14 @@ pub fn run() {
             // an earlier on-device incident hard to reconstruct from the exported log; desktop's
             // default already includes one, but a different format than mobile's -- unified here
             // so entries from every platform line up the same way in the persisted log file).
+            //
+            // Local time, not UTC (unlike the rest of the Rust backend's persisted/emitted
+            // timestamps, e.g. alarm/mod.rs, alarm/database.rs) -- deliberately, since this
+            // log exists to be read by a human next to the device correlating against an
+            // alarm's local wall-clock trigger time and the device's own system clock, and
+            // that's exactly what an on-device incident this feature was built for needed.
+            // The numeric UTC offset (%:z) is included so the clock basis is unambiguous
+            // rather than assumed, since it now differs from the rest of the codebase.
             let log_builder = tauri_plugin_log::Builder::default()
                 .level(log_level)
                 .level_for("jni", log::LevelFilter::Warn)
@@ -171,7 +179,7 @@ pub fn run() {
                 .format(|out, message, record| {
                     out.finish(format_args!(
                         "[{}][{}][{}] {}",
-                        chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+                        chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f %:z"),
                         record.level(),
                         record.target(),
                         message

--- a/apps/threshold/src/services/EventLogService.ts
+++ b/apps/threshold/src/services/EventLogService.ts
@@ -17,6 +17,13 @@ const buildDefaultFileName = () => {
 
 export class EventLogService {
 	async downloadEventLogs(): Promise<void> {
+		// Fired before the save dialog rather than after, so its few-second bounded
+		// wait for the watch's response overlaps with the user picking a destination
+		// instead of adding a visible delay once they've already committed to save.
+		const watchLogsRequested = invoke('request_watch_logs').catch((error) => {
+			console.warn('Failed to request watch logs:', error);
+		});
+
 		const destination = await save({
 			title: 'Save Event Logs',
 			defaultPath: buildDefaultFileName(),
@@ -28,6 +35,7 @@ export class EventLogService {
 		}
 
 		try {
+			await watchLogsRequested;
 			const content = await invoke<string>('get_event_logs');
 			await writeTextFile(destination, content);
 			await message('Event logs saved. Send the file to the developer.', {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -166,6 +166,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
                 put("actualFiredAt", actualFiredAt)
             })
             prefs.edit().putString(KEY_PENDING_ALARM_EVENTS, queue.toString()).apply()
+            NativeEventLog.log(context, TAG, "Queued fired event id=$alarmId (queue depth=${queue.length()})")
         }
 
         @Synchronized
@@ -176,6 +177,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
                 put("id", alarmId)
             })
             prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, queue.toString()).apply()
+            NativeEventLog.log(context, TAG, "Queued snooze event id=$alarmId (queue depth=${queue.length()})")
         }
 
         @Synchronized
@@ -186,6 +188,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
                 put("id", alarmId)
             })
             prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, queue.toString()).apply()
+            NativeEventLog.log(context, TAG, "Queued dismiss event id=$alarmId (queue depth=${queue.length()})")
         }
 
         @Synchronized
@@ -209,6 +212,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
                 put("triggerAt", triggerAt)
             })
             prefs.edit().putString(KEY_PENDING_IMPORT_EVENTS, queue.toString()).apply()
+            NativeEventLog.log(context, TAG, "Queued import event id=$id (queue depth=${queue.length()})")
         }
     }
 
@@ -479,6 +483,11 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         prefs.edit().putString(KEY_PENDING_ALARM_EVENTS, remaining.toString()).apply()
         Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued native alarm fired event(s)")
+        NativeEventLog.log(
+            activity,
+            TAG,
+            "Drained fired events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
+        )
     }
 
     @Synchronized
@@ -509,6 +518,11 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, remaining.toString()).apply()
         Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued snooze requested event(s)")
+        NativeEventLog.log(
+            activity,
+            TAG,
+            "Drained snooze events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
+        )
     }
 
     @Synchronized
@@ -539,6 +553,11 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, remaining.toString()).apply()
         Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued dismiss requested event(s)")
+        NativeEventLog.log(
+            activity,
+            TAG,
+            "Drained dismiss events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
+        )
     }
 
     @Synchronized
@@ -574,5 +593,10 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         prefs.edit().putString(KEY_PENDING_IMPORT_EVENTS, remaining.toString()).apply()
         Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued import requested event(s)")
+        NativeEventLog.log(
+            activity,
+            TAG,
+            "Drained import events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
+        )
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
@@ -18,6 +18,7 @@ class AlarmReceiver : BroadcastReceiver() {
         val alarmId = intent.getIntExtra("ALARM_ID", -1)
         val soundUri = intent.getStringExtra("ALARM_SOUND_URI")
         Log.d("AlarmReceiver", "Alarm ID: $alarmId, Sound URI: $soundUri")
+        NativeEventLog.log(context, "AlarmReceiver", "Received alarm id=$alarmId")
 
         // Guard: skip alarms that were cancelled or deleted before this broadcast was processed.
         // cancelAlarm() removes the prefs entry atomically with the AlarmManager cancellation, so
@@ -25,6 +26,7 @@ class AlarmReceiver : BroadcastReceiver() {
         if (!AlarmUtils.isAlarmLive(context, alarmId)) {
             Log.w("AlarmReceiver", "Alarm $alarmId no longer live — skipping fire (deleted/cancelled)")
             Log.d("AlarmReceiver", "========== ALARM RECEIVER END (skipped) ==========")
+            NativeEventLog.log(context, "AlarmReceiver", "Skipped alarm id=$alarmId (no longer live)")
             return
         }
 
@@ -49,5 +51,6 @@ class AlarmReceiver : BroadcastReceiver() {
 
         Log.d("AlarmReceiver", "Service started. Notification will launch app via full-screen intent.")
         Log.d("AlarmReceiver", "========== ALARM RECEIVER END ==========")
+        NativeEventLog.log(context, "AlarmReceiver", "Started AlarmRingingService for alarm id=$alarmId")
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
@@ -62,6 +62,7 @@ class AlarmRingingService : Service() {
         if (intent.action == ACTION_DISMISS) {
             val alarmId = intent.getIntExtra("ALARM_ID", -1)
             Log.d(TAG, "Dismiss action received for alarm $alarmId")
+            NativeEventLog.log(applicationContext, TAG, "Dismiss action received for alarm id=$alarmId")
             AlarmManagerPlugin.notifyAlarmDismissed(applicationContext, alarmId)
             stopSelf()
             return START_NOT_STICKY
@@ -70,6 +71,7 @@ class AlarmRingingService : Service() {
         if (intent.action == ACTION_SNOOZE) {
             val alarmId = intent.getIntExtra("ALARM_ID", -1)
             Log.d(TAG, "Snooze action received for alarm $alarmId")
+            NativeEventLog.log(applicationContext, TAG, "Snooze action received for alarm id=$alarmId")
             AlarmManagerPlugin.notifySnoozeRequested(applicationContext, alarmId)
             stopSelf()
             return START_NOT_STICKY
@@ -79,6 +81,7 @@ class AlarmRingingService : Service() {
         currentAlarmId = intent.getIntExtra("ALARM_ID", -1)
 
         Log.d(TAG, "Starting service for alarm $currentAlarmId with sound $soundUriStr")
+        NativeEventLog.log(applicationContext, TAG, "Ringing service starting for alarm id=$currentAlarmId")
 
         startForegroundNotification(buildLaunchIntent())
         playAudio(soundUriStr)
@@ -90,6 +93,7 @@ class AlarmRingingService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "Service destroying")
+        NativeEventLog.log(applicationContext, TAG, "Ringing service destroying for alarm id=$currentAlarmId")
 
         stopAudio()
         stopVibration()
@@ -175,6 +179,11 @@ class AlarmRingingService : Service() {
             .build()
 
         startForeground(NOTIFICATION_ID, notification)
+        NativeEventLog.log(
+            applicationContext,
+            TAG,
+            "Posted full-screen-intent notification for alarm id=$currentAlarmId",
+        )
     }
 
     private fun playAudio(uriStr: String?) {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/BootReceiver.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/BootReceiver.kt
@@ -10,23 +10,31 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 
+private const val TAG = "BootReceiver"
+
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
-            Log.d("BootReceiver", "Boot completed, rescheduling alarms")
+            Log.d(TAG, "Boot completed, rescheduling alarms")
 
             val alarms = AlarmUtils.loadAllFromPrefs(context)
             val now = System.currentTimeMillis()
+            NativeEventLog.log(context, TAG, "Boot completed, ${alarms.size} alarm(s) to evaluate")
 
+            var rescheduled = 0
+            var expired = 0
             for ((id, trigger, soundUri) in alarms) {
                 if (trigger > now) {
                     AlarmUtils.scheduleAlarm(context, id, trigger, soundUri)
-                    Log.d("BootReceiver", "Rescheduled alarm $id")
+                    Log.d(TAG, "Rescheduled alarm $id")
+                    rescheduled++
                 } else {
-                    Log.d("BootReceiver", "Cleaning up expired alarm $id")
+                    Log.d(TAG, "Cleaning up expired alarm $id")
                     AlarmUtils.cancelAlarm(context, id)
+                    expired++
                 }
             }
+            NativeEventLog.log(context, TAG, "Boot reschedule complete: $rescheduled rescheduled, $expired expired")
         }
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/NativeEventLog.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/NativeEventLog.kt
@@ -1,0 +1,48 @@
+// Lightweight native-side event logger, written into Tauri's own log directory
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Appends timestamped lines to a file in Tauri's own `app_log_dir()`
+ * (`context.filesDir.parentFile/logs`, confirmed against a real device export --
+ * Tauri's Android path resolver has no public Kotlin source available to read
+ * directly), so entries surface in the existing "Export event log" feature's
+ * `read_and_format_logs()` merge without any IPC round-trip to Rust.
+ *
+ * This is deliberately independent of Rust/the webview being booted at all --
+ * the whole point is capturing native events (AlarmReceiver, WearSyncService,
+ * etc.) that can happen before either is alive.
+ */
+object NativeEventLog {
+	private const val FILE_NAME = "Threshold-native.log"
+	private const val MAX_BYTES = 512 * 1024L
+	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+	@Synchronized
+	fun log(context: Context, tag: String, message: String) {
+		try {
+			val logsDir = File(context.filesDir.parentFile, "logs")
+			if (!logsDir.exists()) {
+				logsDir.mkdirs()
+			}
+			val file = File(logsDir, FILE_NAME)
+			if (file.exists() && file.length() > MAX_BYTES) {
+				file.delete()
+			}
+			val timestamp = formatter.format(Date())
+			file.appendText("[$timestamp][$tag] $message\n")
+		} catch (e: Exception) {
+			Log.w("NativeEventLog", "Failed to write native event log", e)
+		}
+	}
+}

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/NativeEventLog.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/NativeEventLog.kt
@@ -22,9 +22,16 @@ import java.util.Locale
  * This is deliberately independent of Rust/the webview being booted at all --
  * the whole point is capturing native events (AlarmReceiver, WearSyncService,
  * etc.) that can happen before either is alive.
+ *
+ * Each plugin's copy of this object writes to its own distinct file (this one:
+ * `Threshold-alarm-manager.log`) rather than sharing one file across plugins --
+ * `read_and_format_logs()` merges every `Threshold*.log` file it finds, so
+ * splitting by plugin needs no Rust-side change and, more importantly, means
+ * there's no file for two independently-`@Synchronized` copies of this object
+ * (one per plugin) to race over in the first place.
  */
 object NativeEventLog {
-	private const val FILE_NAME = "Threshold-native.log"
+	private const val FILE_NAME = "Threshold-alarm-manager.log"
 	private const val MAX_BYTES = 512 * 1024L
 	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
@@ -26,6 +26,8 @@ internal fun resolveActiveDays(requestedDays: List<Int>?, fallbackCalendarDay: I
     }
 }
 
+private const val TAG = "SetAlarmActivity"
+
 class SetAlarmActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,6 +35,7 @@ class SetAlarmActivity : Activity() {
 
         val intent = intent
         if (intent.action == AlarmClock.ACTION_SET_ALARM) {
+            NativeEventLog.log(applicationContext, TAG, "Received SET_ALARM intent")
             handleSetAlarm(intent)
         }
 
@@ -42,7 +45,8 @@ class SetAlarmActivity : Activity() {
     private fun handleSetAlarm(intent: Intent) {
         // 1. Parse Extras
         if (!intent.hasExtra(AlarmClock.EXTRA_HOUR) || !intent.hasExtra(AlarmClock.EXTRA_MINUTES)) {
-            Log.e("SetAlarmActivity", "Missing HOUR or MINUTES extra")
+            Log.e(TAG, "Missing HOUR or MINUTES extra")
+            NativeEventLog.log(applicationContext, TAG, "SET_ALARM intent missing HOUR or MINUTES extra, ignored")
             return
         }
 
@@ -87,6 +91,11 @@ class SetAlarmActivity : Activity() {
             message,
             activeDays,
             triggerAt,
+        )
+        NativeEventLog.log(
+            applicationContext,
+            TAG,
+            "Imported alarm id=$id at $hour:$minutes, skipUi=$skipUi",
         )
 
         // 6. Launch App if not skipping UI

--- a/plugins/app-management/android/src/main/java/com/plugin/app_management/AppManagementPlugin.kt
+++ b/plugins/app-management/android/src/main/java/com/plugin/app_management/AppManagementPlugin.kt
@@ -11,6 +11,8 @@ import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Plugin
 import app.tauri.plugin.Invoke
 
+private const val TAG = "AppManagementPlugin"
+
 @TauriPlugin
 class AppManagementPlugin(private val activity: Activity): Plugin(activity) {
 
@@ -19,6 +21,7 @@ class AppManagementPlugin(private val activity: Activity): Plugin(activity) {
         // moveTaskToBack(true) minimizes the activity without killing it.
         // It effectively behaves like the Home button.
         val success = activity.moveTaskToBack(true)
+        NativeEventLog.log(activity, TAG, "minimizeApp called, moveTaskToBack result=$success")
         if (success) {
             invoke.resolve()
         } else {

--- a/plugins/app-management/android/src/main/java/com/plugin/app_management/NativeEventLog.kt
+++ b/plugins/app-management/android/src/main/java/com/plugin/app_management/NativeEventLog.kt
@@ -1,0 +1,48 @@
+// Lightweight native-side event logger, written into Tauri's own log directory
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.app_management
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Appends timestamped lines to a file in Tauri's own `app_log_dir()`
+ * (`context.filesDir.parentFile/logs`, confirmed against a real device export --
+ * Tauri's Android path resolver has no public Kotlin source available to read
+ * directly), so entries surface in the existing "Export event log" feature's
+ * `read_and_format_logs()` merge without any IPC round-trip to Rust.
+ *
+ * Duplicated from alarm-manager/wear-sync's copies of the same utility rather
+ * than shared -- no shared native module exists yet (see issue #255's Part A
+ * design discussion).
+ */
+object NativeEventLog {
+	private const val FILE_NAME = "Threshold-native.log"
+	private const val MAX_BYTES = 512 * 1024L
+	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+	@Synchronized
+	fun log(context: Context, tag: String, message: String) {
+		try {
+			val logsDir = File(context.filesDir.parentFile, "logs")
+			if (!logsDir.exists()) {
+				logsDir.mkdirs()
+			}
+			val file = File(logsDir, FILE_NAME)
+			if (file.exists() && file.length() > MAX_BYTES) {
+				file.delete()
+			}
+			val timestamp = formatter.format(Date())
+			file.appendText("[$timestamp][$tag] $message\n")
+		} catch (e: Exception) {
+			Log.w("NativeEventLog", "Failed to write native event log", e)
+		}
+	}
+}

--- a/plugins/app-management/android/src/main/java/com/plugin/app_management/NativeEventLog.kt
+++ b/plugins/app-management/android/src/main/java/com/plugin/app_management/NativeEventLog.kt
@@ -22,9 +22,16 @@ import java.util.Locale
  * Duplicated from alarm-manager/wear-sync's copies of the same utility rather
  * than shared -- no shared native module exists yet (see issue #255's Part A
  * design discussion).
+ *
+ * Each plugin's copy writes to its own distinct file (this one:
+ * `Threshold-app-management.log`) rather than sharing one file across plugins --
+ * `read_and_format_logs()` merges every `Threshold*.log` file it finds, so
+ * splitting by plugin needs no Rust-side change and, more importantly, means
+ * there's no file for two independently-`@Synchronized` copies of this object
+ * (one per plugin) to race over in the first place.
  */
 object NativeEventLog {
-	private const val FILE_NAME = "Threshold-native.log"
+	private const val FILE_NAME = "Threshold-app-management.log"
 	private const val MAX_BYTES = 512 * 1024L
 	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeEventLog.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeEventLog.kt
@@ -21,9 +21,16 @@ import java.util.Locale
  *
  * Duplicated from alarm-manager's copy of the same utility rather than shared --
  * no shared native module exists yet (see issue #255's Part A design discussion).
+ *
+ * Each plugin's copy writes to its own distinct file (this one:
+ * `Threshold-wear-sync.log`) rather than sharing one file across plugins --
+ * `read_and_format_logs()` merges every `Threshold*.log` file it finds, so
+ * splitting by plugin needs no Rust-side change and, more importantly, means
+ * there's no file for two independently-`@Synchronized` copies of this object
+ * (one per plugin) to race over in the first place.
  */
 object NativeEventLog {
-	private const val FILE_NAME = "Threshold-native.log"
+	private const val FILE_NAME = "Threshold-wear-sync.log"
 	private const val MAX_BYTES = 512 * 1024L
 	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeEventLog.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeEventLog.kt
@@ -1,0 +1,47 @@
+// Lightweight native-side event logger, written into Tauri's own log directory
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Appends timestamped lines to a file in Tauri's own `app_log_dir()`
+ * (`context.filesDir.parentFile/logs`, confirmed against a real device export --
+ * Tauri's Android path resolver has no public Kotlin source available to read
+ * directly), so entries surface in the existing "Export event log" feature's
+ * `read_and_format_logs()` merge without any IPC round-trip to Rust.
+ *
+ * Duplicated from alarm-manager's copy of the same utility rather than shared --
+ * no shared native module exists yet (see issue #255's Part A design discussion).
+ */
+object NativeEventLog {
+	private const val FILE_NAME = "Threshold-native.log"
+	private const val MAX_BYTES = 512 * 1024L
+	private val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+	@Synchronized
+	fun log(context: Context, tag: String, message: String) {
+		try {
+			val logsDir = File(context.filesDir.parentFile, "logs")
+			if (!logsDir.exists()) {
+				logsDir.mkdirs()
+			}
+			val file = File(logsDir, FILE_NAME)
+			if (file.exists() && file.length() > MAX_BYTES) {
+				file.delete()
+			}
+			val timestamp = formatter.format(Date())
+			file.appendText("[$timestamp][$tag] $message\n")
+		} catch (e: Exception) {
+			Log.w("NativeEventLog", "Failed to write native event log", e)
+		}
+	}
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
@@ -155,8 +155,10 @@ class WearMessageService : WearableListenerService() {
 
                 val dataItem = dataClient.putDataItem(request.asPutDataRequest()).await()
                 Log.d(TAG, "Published cached data to watch: uri=${dataItem.uri}, revision=$revision")
+                NativeEventLog.log(applicationContext, TAG, "Served offline sync from cache at revision $revision")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to publish cached data to watch", e)
+                NativeEventLog.log(applicationContext, TAG, "Failed to publish cached data to watch: ${e.message}")
             }
         }
     }
@@ -170,6 +172,7 @@ class WearMessageService : WearableListenerService() {
      */
     private fun handleOfflineWrite(path: String, data: String) {
         Log.i(TAG, "Watch write received offline ($path), starting WearSyncService")
+        NativeEventLog.log(applicationContext, TAG, "Offline write received path=$path, starting WearSyncService")
         WearSyncQueue.enqueue(this, path, data)
 
         val serviceIntent = Intent(this, WearSyncService::class.java).apply {

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
@@ -8,6 +8,7 @@ package ca.liminalhq.threshold.wearsync
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import java.io.File
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.PutDataMapRequest
@@ -25,7 +26,9 @@ private const val PATH_SAVE_ALARM = "/threshold/save_alarm"
 private const val PATH_DELETE_ALARM = "/threshold/delete_alarm"
 private const val PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
 private const val PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
+private const val PATH_LOG_RESPONSE = "/threshold/log_response"
 private const val DATA_PATH_ALARMS = "/threshold/alarms"
+private const val WATCH_LOG_FILE_NAME = "Threshold-watch.log"
 
 /**
  * Receives messages from the watch via the Wear Data Layer and routes
@@ -53,7 +56,20 @@ class WearMessageService : WearableListenerService() {
         val data = String(messageEvent.data, Charsets.UTF_8)
         Log.d(TAG, "Message received: path=$path, bytes=${messageEvent.data.size}")
 
+        // Handled independent of plugin/Rust state -- this is a plain file write, not
+        // routed through the Tauri event pipeline at all, so it works identically
+        // whether or not Rust/webview happens to be booted right now.
+        if (path == PATH_LOG_RESPONSE) {
+            writeWatchLog(data)
+            return
+        }
+
         val plugin = WearSyncPlugin.instance
+        NativeEventLog.log(
+            applicationContext,
+            TAG,
+            "Message received path=$path, pluginLoaded=${plugin != null}, channelReady=${plugin?.isChannelReady}",
+        )
         if (plugin != null) {
             // Normal path: plugin is loaded, route through Tauri events
             when (path) {
@@ -85,6 +101,26 @@ class WearMessageService : WearableListenerService() {
             else -> {
                 Log.w(TAG, "Unknown message path (offline): $path")
             }
+        }
+    }
+
+    /**
+     * Write the watch's log content into Tauri's own `app_log_dir()`
+     * (`context.filesDir.parentFile/logs`, same directory [NativeEventLog] on this
+     * side writes into), so it merges into the existing "Export event log" feature
+     * automatically -- no Rust involvement needed for the write itself, only for
+     * triggering the original request via [WearSyncPlugin.requestWatchLogs].
+     */
+    private fun writeWatchLog(content: String) {
+        try {
+            val logsDir = File(applicationContext.filesDir.parentFile, "logs")
+            if (!logsDir.exists()) {
+                logsDir.mkdirs()
+            }
+            File(logsDir, WATCH_LOG_FILE_NAME).writeText(content)
+            Log.d(TAG, "Wrote watch log (${content.length} chars) to $logsDir")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write watch log", e)
         }
     }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncCache.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncCache.kt
@@ -55,6 +55,7 @@ object WearSyncCache {
             apply()
         }
         Log.d(TAG, "Cached alarm data at revision $revision (${alarmsJson.length} bytes, snooze=${snoozeLengthMinutes}m, is24h=$is24Hour, is24hKnown=$is24HourKnown)")
+        NativeEventLog.log(context, TAG, "Cached alarm data at revision $revision (${alarmsJson.length} bytes)")
     }
 
     /**
@@ -65,7 +66,10 @@ object WearSyncCache {
      */
     fun read(context: Context): Quintuple<String, Long, Int, Boolean, Boolean>? {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val json = prefs.getString(KEY_ALARMS_JSON, null) ?: return null
+        val json = prefs.getString(KEY_ALARMS_JSON, null) ?: run {
+            NativeEventLog.log(context, TAG, "Cache read requested but empty")
+            return null
+        }
         val revision = prefs.getLong(KEY_REVISION, 0)
         val snoozeLength = prefs.getInt(KEY_SNOOZE_LENGTH, 10)
         val is24Hour = prefs.getBoolean(KEY_IS_24_HOUR, false)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -290,10 +290,16 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
 
     /**
      * Ask connected watch nodes to send their own native event log back, so it
-     * can be merged into the phone's "Export event log" feature. Fire-and-forget:
-     * resolves immediately once the request is sent, doesn't wait for a reply --
-     * the watch's response (if any) arrives later via [WearMessageService] on its
-     * own MSG_PATH_LOG_RESPONSE path and is written straight to the log directory.
+     * can be merged into the phone's "Export event log" feature. Fire-and-forget
+     * as far as the watch's actual reply goes: resolves once the request is sent
+     * (or immediately if there's no node to send it to), doesn't wait for a reply
+     * -- the watch's response (if any) arrives later via [WearMessageService] on
+     * its own MSG_PATH_LOG_RESPONSE path and is written straight to the log
+     * directory.
+     *
+     * Resolves with `{"connected": Boolean}` so the Rust side can tell "no watch
+     * paired at all" apart from "request sent, might still be waiting on a reply"
+     * -- the caller only needs to wait out its bounded window in the latter case.
      */
     @Command
     fun requestWatchLogs(invoke: Invoke) {
@@ -302,7 +308,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                 val nodes = nodeClient.connectedNodes.await()
                 if (nodes.isEmpty()) {
                     Log.d(TAG, "No connected watch nodes — skipping log request")
-                    invoke.resolve()
+                    invoke.resolve(JSObject().apply { put("connected", false) })
                     return@launch
                 }
 
@@ -310,7 +316,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                     messageClient.sendMessage(node.id, MSG_PATH_LOG_REQUEST, ByteArray(0)).await()
                     Log.d(TAG, "Requested watch logs from ${node.displayName}")
                 }
-                invoke.resolve()
+                invoke.resolve(JSObject().apply { put("connected", true) })
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to request watch logs", e)
                 invoke.reject("Failed to request watch logs: ${e.message}")

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -30,6 +30,7 @@ private const val MSG_PATH_SYNC_REQUEST = "/threshold/sync_request"
 private const val MSG_PATH_ALARM_RING = "/threshold/alarm_ring"
 private const val MSG_PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
 private const val MSG_PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
+private const val MSG_PATH_LOG_REQUEST = "/threshold/log_request"
 private const val EXTRA_HEADLESS_BOOT = "wear_sync_headless_boot"
 
 @InvokeArg
@@ -288,6 +289,36 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     /**
+     * Ask connected watch nodes to send their own native event log back, so it
+     * can be merged into the phone's "Export event log" feature. Fire-and-forget:
+     * resolves immediately once the request is sent, doesn't wait for a reply --
+     * the watch's response (if any) arrives later via [WearMessageService] on its
+     * own MSG_PATH_LOG_RESPONSE path and is written straight to the log directory.
+     */
+    @Command
+    fun requestWatchLogs(invoke: Invoke) {
+        scope.launch {
+            try {
+                val nodes = nodeClient.connectedNodes.await()
+                if (nodes.isEmpty()) {
+                    Log.d(TAG, "No connected watch nodes — skipping log request")
+                    invoke.resolve()
+                    return@launch
+                }
+
+                for (node in nodes) {
+                    messageClient.sendMessage(node.id, MSG_PATH_LOG_REQUEST, ByteArray(0)).await()
+                    Log.d(TAG, "Requested watch logs from ${node.displayName}")
+                }
+                invoke.resolve()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to request watch logs", e)
+                invoke.reject("Failed to request watch logs: ${e.message}")
+            }
+        }
+    }
+
+    /**
      * Register a [Channel] for sending watch messages from Kotlin back to Rust.
      *
      * Called by the Rust plugin setup via `run_mobile_plugin("set_watch_message_handler", ...)`.
@@ -327,6 +358,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         activity.runOnUiThread {
             val moved = activity.moveTaskToBack(true)
             Log.d(TAG, "moveTaskToBack result: $moved")
+            NativeEventLog.log(activity, TAG, "moveActivityToBack called, moveTaskToBack result=$moved")
         }
     }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncQueue.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncQueue.kt
@@ -37,6 +37,7 @@ object WearSyncQueue {
 
         prefs.edit().putString(KEY_QUEUE, array.toString()).apply()
         Log.d(TAG, "Enqueued message: path=$path (queue size: ${array.length()})")
+        NativeEventLog.log(context, TAG, "Enqueued message path=$path (queue size: ${array.length()})")
     }
 
     /** Drain all queued messages and clear the queue. Returns list of (path, data) pairs. */
@@ -58,6 +59,7 @@ object WearSyncQueue {
 
         prefs.edit().remove(KEY_QUEUE).apply()
         Log.d(TAG, "Drained ${messages.size} queued message(s)")
+        NativeEventLog.log(context, TAG, "Drained ${messages.size} queued message(s)")
         return messages
     }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncService.kt
@@ -62,6 +62,7 @@ class WearSyncService : Service() {
         }
 
         val path = intent.getStringExtra(EXTRA_PATH) ?: "unknown"
+        NativeEventLog.log(applicationContext, TAG, "Started for trigger path: $path")
 
         startForegroundNotification()
         bootTauriAndReplay(path)
@@ -136,14 +137,25 @@ class WearSyncService : Service() {
                 val plugin = WearSyncPlugin.instance
                 if (plugin != null && plugin.isChannelReady) {
                     Log.i(TAG, "Plugin ready after ${waited}ms, queued messages should replay (trigger path: $path)")
+                    NativeEventLog.log(
+                        applicationContext,
+                        TAG,
+                        "Plugin ready after ${waited}ms for path=$path -- moving activity to back",
+                    )
 
                     // Move the activity to the back so the user doesn't see it.
                     plugin.moveActivityToBack()
                 } else {
                     Log.e(TAG, "Plugin not available after ${waited}ms, giving up on: $path")
+                    NativeEventLog.log(
+                        applicationContext,
+                        TAG,
+                        "Gave up waiting for plugin after ${waited}ms for path=$path",
+                    )
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Error during Tauri boot and replay", e)
+                NativeEventLog.log(applicationContext, TAG, "Error during Tauri boot and replay: ${e.message}")
             } finally {
                 stopSelf()
             }

--- a/plugins/wear-sync/src/desktop.rs
+++ b/plugins/wear-sync/src/desktop.rs
@@ -50,8 +50,8 @@ impl<R: Runtime> WearSync<R> {
         Ok(())
     }
 
-    pub fn request_watch_logs(&self) -> crate::Result<()> {
+    pub async fn request_watch_logs(&self) -> crate::Result<bool> {
         log::debug!("wear-sync: desktop stub — request_watch_logs (no-op)");
-        Ok(())
+        Ok(false)
     }
 }

--- a/plugins/wear-sync/src/desktop.rs
+++ b/plugins/wear-sync/src/desktop.rs
@@ -49,4 +49,9 @@ impl<R: Runtime> WearSync<R> {
         log::debug!("wear-sync: desktop stub — send_alarm_snooze (no-op)");
         Ok(())
     }
+
+    pub fn request_watch_logs(&self) -> crate::Result<()> {
+        log::debug!("wear-sync: desktop stub — request_watch_logs (no-op)");
+        Ok(())
+    }
 }

--- a/plugins/wear-sync/src/lib.rs
+++ b/plugins/wear-sync/src/lib.rs
@@ -135,10 +135,18 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                                 is_24_hour_known: fired.is_24_hour_known,
                             };
 
-                            if let Err(error) = wear_sync.send_alarm_ring(request) {
-                                log::error!(
-                                    "wear-sync: failed to send alarm ring to watch: {error}"
-                                );
+                            let alarm_id = request.alarm_id;
+                            match wear_sync.send_alarm_ring(request) {
+                                Ok(()) => {
+                                    log::info!(
+                                        "wear-sync: sent alarm ring to watch for id={alarm_id}"
+                                    );
+                                }
+                                Err(error) => {
+                                    log::error!(
+                                        "wear-sync: failed to send alarm ring to watch: {error}"
+                                    );
+                                }
                             }
                         });
                     }
@@ -166,10 +174,18 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                             let request = AlarmDismissRequest {
                                 alarm_id: dismissed.id,
                             };
-                            if let Err(error) = wear_sync.send_alarm_dismiss(request) {
-                                log::error!(
-                                    "wear-sync: failed to send alarm dismiss to watch: {error}"
-                                );
+                            let alarm_id = request.alarm_id;
+                            match wear_sync.send_alarm_dismiss(request) {
+                                Ok(()) => {
+                                    log::info!(
+                                        "wear-sync: sent alarm dismiss to watch for id={alarm_id}"
+                                    );
+                                }
+                                Err(error) => {
+                                    log::error!(
+                                        "wear-sync: failed to send alarm dismiss to watch: {error}"
+                                    );
+                                }
                             }
                         });
                     }
@@ -204,10 +220,18 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                                 alarm_id: snoozed.id,
                                 snooze_length_minutes,
                             };
-                            if let Err(error) = wear_sync.send_alarm_snooze(request) {
-                                log::error!(
-                                    "wear-sync: failed to send alarm snooze to watch: {error}"
-                                );
+                            let alarm_id = request.alarm_id;
+                            match wear_sync.send_alarm_snooze(request) {
+                                Ok(()) => {
+                                    log::info!(
+                                        "wear-sync: sent alarm snooze to watch for id={alarm_id}"
+                                    );
+                                }
+                                Err(error) => {
+                                    log::error!(
+                                        "wear-sync: failed to send alarm snooze to watch: {error}"
+                                    );
+                                }
                             }
                         });
                     }

--- a/plugins/wear-sync/src/mobile.rs
+++ b/plugins/wear-sync/src/mobile.rs
@@ -3,7 +3,7 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::models::{
     AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, PublishRequest, SyncRequest,
@@ -22,6 +22,14 @@ use tauri::{
 #[serde(rename_all = "camelCase")]
 struct WatchMessageHandler {
     handler: Channel,
+}
+
+/// Response from Kotlin's `requestWatchLogs`, indicating whether a watch node
+/// was actually reachable to send the request to.
+#[cfg(target_os = "android")]
+#[derive(Deserialize)]
+struct RequestWatchLogsResponse {
+    connected: bool,
 }
 
 /// Initialise the mobile backend for the wear-sync plugin.
@@ -179,17 +187,34 @@ impl<R: Runtime> WearSync<R> {
     /// returns once the request is sent, doesn't wait for the watch's reply
     /// (which arrives later via a separate Data Layer message, handled entirely
     /// on the Kotlin side with no further Rust involvement).
-    pub fn request_watch_logs(&self) -> crate::Result<()> {
+    /// Returns whether a watch was actually reachable to send the request to
+    /// -- the caller uses this to decide whether it's worth waiting at all for
+    /// a reply, rather than blindly sleeping out a fixed window every time.
+    ///
+    /// Uses `run_mobile_plugin_async` rather than the synchronous
+    /// `run_mobile_plugin` other methods on this type use: those are all
+    /// fire-and-forget, invoked from `app.listen(...)` event handlers that are
+    /// themselves wrapped in `tauri::async_runtime::spawn(...)`, so blocking
+    /// whichever worker thread picks up that spawned task is low-impact. This
+    /// one is different -- it's called directly from an `async fn` Tauri
+    /// command (`event_logs::request_watch_logs`) that the frontend awaits, so
+    /// blocking a runtime worker thread here would stall other concurrent IPC
+    /// commands for as long as the Data Layer round trip takes.
+    pub async fn request_watch_logs(&self) -> crate::Result<bool> {
         #[cfg(not(target_os = "android"))]
         {
             log::debug!("wear-sync: request_watch_logs no-op on non-Android mobile target");
-            return Ok(());
+            Ok(false)
         }
 
         #[cfg(target_os = "android")]
-        self.handle
-            .run_mobile_plugin("requestWatchLogs", ())
-            .map_err(Into::into)
+        {
+            let response: RequestWatchLogsResponse = self
+                .handle
+                .run_mobile_plugin_async("requestWatchLogs", ())
+                .await?;
+            Ok(response.connected)
+        }
     }
 
     /// Mark the watch message pipeline as ready on Kotlin side.

--- a/plugins/wear-sync/src/mobile.rs
+++ b/plugins/wear-sync/src/mobile.rs
@@ -174,6 +174,24 @@ impl<R: Runtime> WearSync<R> {
             .map_err(Into::into)
     }
 
+    /// Ask connected watch nodes to send their own native event log back, to be
+    /// merged into the phone's "Export event log" feature. Fire-and-forget --
+    /// returns once the request is sent, doesn't wait for the watch's reply
+    /// (which arrives later via a separate Data Layer message, handled entirely
+    /// on the Kotlin side with no further Rust involvement).
+    pub fn request_watch_logs(&self) -> crate::Result<()> {
+        #[cfg(not(target_os = "android"))]
+        {
+            log::debug!("wear-sync: request_watch_logs no-op on non-Android mobile target");
+            return Ok(());
+        }
+
+        #[cfg(target_os = "android")]
+        self.handle
+            .run_mobile_plugin("requestWatchLogs", ())
+            .map_err(Into::into)
+    }
+
     /// Mark the watch message pipeline as ready on Kotlin side.
     ///
     /// Called after the app has registered its watch event listeners so the


### PR DESCRIPTION
Closes #265.

## Summary
Tonight's on-device incident (alarm fired, watch didn't ring, phone's ringing screen didn't stay visible) turned out to be undiagnosable after the fact -- the phone's `adb logcat` main buffer (256 KiB) had churned out every relevant `Log.d` call within a minute of the incident, the watch's app process had already been recycled by the time it could be inspected, and Threshold's own persisted event log survived but had no timestamps and no success-path logging on the one call that mattered most (`wear-sync`'s `send_alarm_ring`). Full writeup in #265.

- Timestamps every platform's log output with one unified `chrono`-based format, rather than mobile having none and desktop relying on a different plugin-default format.
- Adds `NativeEventLog`, a small Kotlin file-logger writing into Tauri's own `app_log_dir()` on the phone (no Rust IPC needed) and into the watch's own private storage.
- Instruments `AlarmReceiver`, `AlarmRingingService`, `WearSyncService`/`WearSyncPlugin` (especially `moveActivityToBack`), and `WearMessageService` on the phone; `WearAlarmReceiver`, `DataLayerListenerService` (especially the ring-dedup check), and `WearRingingService` on the watch.
- Adds the missing success-path log to `wear-sync`'s `alarm:fired`/`alarm:dismissed`/`alarm:snoozed` listeners.
- Bridges the watch's log into the phone's export via a new `/threshold/log_request` -> `/threshold/log_response` Data Layer message pair, so the existing "Export event log" button gets both devices' logs from one tap -- requested before the save dialog (overlapping its bounded ~3s wait with the user picking a destination), never blocks indefinitely if the watch is unreachable.

## Test plan
- [x] `cargo check --target aarch64-linux-android` for the full `threshold` crate (pulls in `wear-sync`) inside `ghcr.io/liminal-hq/tauri-dev-mobile` -- clean
- [x] `./gradlew compileDebugKotlin` for `apps/threshold-wear` -- clean (only pre-existing, unrelated warnings)
- [x] `pnpm -r run typecheck` -- clean
- [x] `cargo test -p threshold event_logs` -- passing
- [x] `pnpm format` / `bash scripts/check-headers.sh` -- clean
- [ ] The two edited phone-side plugin modules (`tauri-plugin-alarm-manager`, `tauri-plugin-wear-sync`) couldn't be Kotlin-compiled in isolation in this environment -- generated `tauri.settings.gradle` references host-specific cargo registry paths that don't exist in a fresh container. CI's real Android build job is the first full compile of those two files; flagging in case it surfaces something.
- [ ] No physical device retest yet -- this landed same-night as the investigation that motivated it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w