### PR TITLE
Use run_mobile_plugin_async for pick_alarm_sound's open-ended picker wait

### DIFF
--- a/plugins/alarm-manager/src/commands.rs
+++ b/plugins/alarm-manager/src/commands.rs
@@ -19,7 +19,7 @@ pub async fn pick_alarm_sound<R: Runtime>(
     app: AppHandle<R>,
     options: PickAlarmSoundOptions,
 ) -> Result<PickedAlarmSound> {
-    app.alarm_manager().pick_alarm_sound(options)
+    app.alarm_manager().pick_alarm_sound(options).await
 }
 
 #[command]

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -81,7 +81,7 @@ impl<R: Runtime> AlarmManager<R> {
         }
     }
 
-    pub fn pick_alarm_sound(
+    pub async fn pick_alarm_sound(
         &self,
         _options: PickAlarmSoundOptions,
     ) -> crate::Result<PickedAlarmSound> {

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -194,7 +194,18 @@ impl<R: Runtime> AlarmManager<R> {
         self.invoke_cancel(payload)
     }
 
-    pub fn pick_alarm_sound(
+    /// Opens Android's system ringtone/sound picker and waits for the user's choice.
+    ///
+    /// Unlike the other methods on this type, this is an open-ended wait -- the
+    /// picker dialog stays open until the user chooses something or backs out,
+    /// which can take anywhere from under a second to minutes depending on how
+    /// long they browse. `pick_alarm_sound` is called directly from an `async fn`
+    /// Tauri command (`commands::pick_alarm_sound`) that the frontend awaits, so
+    /// using the blocking `run_mobile_plugin` here would tie up a shared tokio
+    /// runtime worker thread for the entire duration the picker is open,
+    /// potentially stalling other concurrent IPC commands. `run_mobile_plugin_async`
+    /// awaits instead of blocking, same rationale as `wear_sync::request_watch_logs`.
+    pub async fn pick_alarm_sound(
         &self,
         #[cfg_attr(not(target_os = "android"), allow(unused_variables))]
         options: PickAlarmSoundOptions,
@@ -202,7 +213,8 @@ impl<R: Runtime> AlarmManager<R> {
         #[cfg(target_os = "android")]
         return self
             .handle
-            .run_mobile_plugin("pickAlarmSound", options)
+            .run_mobile_plugin_async("pickAlarmSound", options)
+            .await
             .map_err(Into::into);
 
         #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
## Summary
Closes #267's standout candidate. `pick_alarm_sound` opens Android's system ringtone picker via `startActivityForResult` and only resolves once the user picks something or backs out (`AlarmManagerPlugin.kt`'s `pickAlarmSoundResult`) -- an open-ended wait, seconds to minutes, unlike every other call in this plugin. It's called directly from `commands::pick_alarm_sound`, an `async fn` Tauri command the frontend `invoke()`s and awaits, so the previous blocking `run_mobile_plugin` tied up a shared tokio runtime worker thread for the whole time the picker dialog was open, which could stall other concurrent IPC commands.

Switches `AlarmManager::pick_alarm_sound` (mobile + desktop) to `run_mobile_plugin_async`, mirroring the same fix already applied to `wear_sync::request_watch_logs` for the identical reason. No Kotlin or frontend changes needed -- the JNI bridge and invoke resolution are identical either way; only how Rust waits on the result changed.

Also spot-checked (per #267's suggested scope) the other "directly-awaited, fast today" call sites (`stopRinging`, `getMaterialYouColours`, `getTimeFormat`, `getAnimatorDurationScale`, `setCanGoBack`, toast `show`, `minimizeApp`) -- all confirmed genuinely fast/in-memory except `minimizeApp`, which was already fixed separately in #268 (unrelated logging-I/O issue, not an async/sync choice). Leaving the rest as-is per the issue's own guidance.

## Test plan
- [x] `cargo test -p tauri-plugin-alarm-manager -p threshold`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --target aarch64-linux-android` for both the plugin and the full `threshold` crate, via the `tauri-dev-mobile` Docker image (no local NDK toolchain) -- clean
- [ ] Kotlin compile verification blocked by the same environment limitation documented in #265/#266/#268 (host-specific cargo-registry paths in the auto-generated `tauri.settings.gradle`); no Kotlin changes in this PR regardless -- `pickAlarmSound`'s Kotlin implementation is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb6fbHiRvaNntsU1aVqF6w