### PR TITLE
Add home screen widget SVG mockups for next-alarm and history widgets

### DIFF
--- a/docs/ui/widgets/README.md
+++ b/docs/ui/widgets/README.md
@@ -5,10 +5,10 @@ webview (React/MUI) — launchers render widgets via RemoteViews, a fixed whitel
 native views — so each mockup carries a numbered "RemoteViews build sheet" mapping
 every visual element to the native view and drawable that implements it.
 
-| Mockup | Issue | Contents |
-| --- | --- | --- |
+| Mockup                         | Issue                                                      | Contents                                       |
+| ------------------------------ | ---------------------------------------------------------- | ---------------------------------------------- |
 | `widget-next-alarm-mockup.svg` | [#156](https://github.com/liminal-hq/threshold/issues/156) | 4×2 hero, 2×1 narrow, light theme, empty state |
-| `widget-history-mockup.svg` | [#279](https://github.com/liminal-hq/threshold/issues/279) | 2×2 streak, 4×1 week strip, empty state |
+| `widget-history-mockup.svg`    | [#279](https://github.com/liminal-hq/threshold/issues/279) | 2×2 streak, 4×1 week strip, empty state        |
 
 Visual language follows the screen-refresh-2026 v4 mockups
 (`docs/ui/redesigns/screen-refresh-2026/mockups/v4/`): dark navy cards, the

--- a/docs/ui/widgets/README.md
+++ b/docs/ui/widgets/README.md
@@ -1,0 +1,17 @@
+# Home screen widget mockups
+
+Design mockups for the Android home screen widget family. Widget UI cannot use the
+webview (React/MUI) — launchers render widgets via RemoteViews, a fixed whitelist of
+native views — so each mockup carries a numbered "RemoteViews build sheet" mapping
+every visual element to the native view and drawable that implements it.
+
+| Mockup | Issue | Contents |
+| --- | --- | --- |
+| `widget-next-alarm-mockup.svg` | [#156](https://github.com/liminal-hq/threshold/issues/156) | 4×2 hero, 2×1 narrow, light theme, empty state |
+| `widget-history-mockup.svg` | [#279](https://github.com/liminal-hq/threshold/issues/279) | 2×2 streak, 4×1 week strip, empty state |
+
+Visual language follows the screen-refresh-2026 v4 mockups
+(`docs/ui/redesigns/screen-refresh-2026/mockups/v4/`): dark navy cards, the
+alarm-card accent rail as the family signature, brand orange eyebrows, and the
+`#4c8dff` accent. Mechanism decisions (SharedPreferences snapshot, `threshold://`
+tap deep links, no Rust at render time) are documented in #156's comments.

--- a/docs/ui/widgets/widget-history-mockup.svg
+++ b/docs/ui/widgets/widget-history-mockup.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 860" width="1240" height="860">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#111b2e"/>
+    </linearGradient>
+    <linearGradient id="wall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e1526"/>
+      <stop offset="100%" stop-color="#0a101d"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a364b"/>
+      <stop offset="100%" stop-color="#22304a"/>
+    </linearGradient>
+    <linearGradient id="cardMuted" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#202b3d"/>
+      <stop offset="100%" stop-color="#1a2436"/>
+    </linearGradient>
+    <pattern id="dots" x="0" y="0" width="34" height="34" patternUnits="userSpaceOnUse">
+      <circle cx="17" cy="17" r="1.3" fill="#24344f" opacity="0.55"/>
+    </pattern>
+    <filter id="widgetShadow">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+    <style><![CDATA[
+      .t { font-family: "Avenir Next", "Nunito Sans", "Segoe UI", sans-serif; }
+      .eyebrow { font-size: 15px; letter-spacing: 2px; fill: #ff8f5d; font-weight: 700; }
+      .caption { font-size: 14px; fill: #6f88a9; }
+      .noteTitle { font-size: 17px; fill: #dbe8fb; font-weight: 700; }
+      .noteBody { font-size: 14px; fill: #a7bad5; }
+      .chipText { font-size: 13px; fill: #ffffff; font-weight: 700; }
+      .dayLetter { font-size: 15px; fill: #6f88a9; }
+    ]]></style>
+  </defs>
+
+  <rect width="1240" height="860" fill="url(#bg)"/>
+  <text class="t eyebrow" x="48" y="56">THRESHOLD WIDGETS — ALARM HISTORY (#279) · STREAK / WEEK STRIP · REMOTEVIEWS</text>
+
+  <!-- ==================== Launcher backdrop ==================== -->
+  <rect x="48" y="92" width="600" height="718" rx="24" fill="url(#wall)" stroke="#1b2940"/>
+  <rect x="48" y="92" width="600" height="718" rx="24" fill="url(#dots)"/>
+
+  <!-- ========== A · Streak 2x2 — widget_streak.xml ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="118" y="140" width="250" height="250" rx="28" fill="url(#card)" stroke="#3e5272"/>
+  </g>
+  <rect x="118" y="168" width="7" height="194" rx="3.5" fill="#ff8f5d"/>
+  <text class="t" x="150" y="200" style="font-size:26px;">🔥</text>
+  <text class="t" x="190" y="196" style="font-size:15px;letter-spacing:2px;fill:#ff8f5d;font-weight:700;">STREAK</text>
+  <text class="t" x="148" y="300" style="font-size:92px;fill:#f5f8ff;font-weight:700;letter-spacing:-2px;">6</text>
+  <text class="t" x="212" y="300" style="font-size:26px;fill:#a9bad1;">days</text>
+  <text class="t" x="150" y="334" style="font-size:17px;fill:#a9bad1;">no-snooze streak</text>
+  <!-- mini week dots -->
+  <g>
+    <circle cx="156" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="182" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="208" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="234" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="260" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="286" cy="364" r="7" fill="#4c8dff"/>
+    <circle cx="312" cy="364" r="7" fill="none" stroke="#3b4c66" stroke-width="2"/>
+  </g>
+  <text class="t caption" x="118" y="418">A · 2×2 streak — widget_streak.xml</text>
+
+  <!-- numbered chips on A -->
+  <circle cx="344" cy="164" r="11" fill="#4c8dff"/><text class="t chipText" x="344" y="169" text-anchor="middle">1</text>
+  <circle cx="252" cy="266" r="11" fill="#4c8dff"/><text class="t chipText" x="252" y="271" text-anchor="middle">2</text>
+  <circle cx="344" cy="364" r="11" fill="#4c8dff"/><text class="t chipText" x="344" y="369" text-anchor="middle">5</text>
+
+  <!-- ========== B · Week strip 4x1 — widget_week.xml ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="88" y="460" width="520" height="140" rx="24" fill="url(#card)" stroke="#3e5272"/>
+  </g>
+  <rect x="88" y="482" width="7" height="96" rx="3.5" fill="#4c8dff"/>
+  <text class="t" x="124" y="504" style="font-size:15px;letter-spacing:2px;fill:#ff8f5d;font-weight:700;">THIS WEEK</text>
+  <text class="t" x="584" y="504" text-anchor="end" style="font-size:17px;fill:#a9bad1;">avg wake 7:24</text>
+  <!-- dots: filled = snooze-free · orange ring = snoozed · hollow = no alarm · white ring = today -->
+  <g>
+    <circle cx="146" cy="546" r="12" fill="#4c8dff"/>
+    <circle cx="205" cy="546" r="12" fill="none" stroke="#ff8f5d" stroke-width="3"/>
+    <circle cx="264" cy="546" r="12" fill="#4c8dff"/>
+    <circle cx="323" cy="546" r="12" fill="#4c8dff"/>
+    <circle cx="382" cy="546" r="12" fill="none" stroke="#3b4c66" stroke-width="2"/>
+    <circle cx="441" cy="546" r="12" fill="#4c8dff"/>
+    <circle cx="500" cy="546" r="12" fill="#4c8dff"/>
+    <circle cx="500" cy="546" r="17" fill="none" stroke="#f5f8ff" stroke-width="1.5" opacity="0.8"/>
+  </g>
+  <text class="t dayLetter" x="146" y="586" text-anchor="middle">S</text>
+  <text class="t dayLetter" x="205" y="586" text-anchor="middle">S</text>
+  <text class="t dayLetter" x="264" y="586" text-anchor="middle">M</text>
+  <text class="t dayLetter" x="323" y="586" text-anchor="middle">T</text>
+  <text class="t dayLetter" x="382" y="586" text-anchor="middle">W</text>
+  <text class="t dayLetter" x="441" y="586" text-anchor="middle">T</text>
+  <text class="t" x="500" y="586" text-anchor="middle" style="font-size:15px;fill:#f5f8ff;font-weight:700;">F</text>
+  <text class="t caption" x="88" y="628">B · 4×1 week strip — widget_week.xml</text>
+
+  <!-- numbered chips on B -->
+  <circle cx="584" cy="546" r="11" fill="#4c8dff"/><text class="t chipText" x="584" y="551" text-anchor="middle">3</text>
+  <circle cx="382" cy="510" r="11" fill="#4c8dff"/><text class="t chipText" x="382" y="515" text-anchor="middle">4</text>
+
+  <!-- ========== C · Streak empty state ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="88" y="662" width="250" height="130" rx="24" fill="url(#cardMuted)" stroke="#2e3c54"/>
+  </g>
+  <rect x="88" y="682" width="6" height="90" rx="3" fill="#3b4c66"/>
+  <text class="t" x="116" y="716" style="font-size:22px;opacity:0.4;">🔥</text>
+  <text class="t" x="150" y="712" style="font-size:21px;fill:#7f90a8;font-weight:700;">Start a streak</text>
+  <text class="t" x="116" y="748" style="font-size:14px;fill:#5d6f89;">Wake snooze-free tomorrow</text>
+  <text class="t caption" x="358" y="716">C · empty = invitation,</text>
+  <text class="t caption" x="358" y="736">never a zero</text>
+
+  <!-- ==================== Build sheet ==================== -->
+  <text class="t eyebrow" x="690" y="140">REMOTEVIEWS BUILD SHEET</text>
+
+  <g transform="translate(690 176)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">1</text>
+    <text class="t noteTitle" x="34" y="13">Same family shell as the #156 widget</text>
+    <text class="t noteBody" x="34" y="36">Identical rounded background + rail drawables; the rail tint flips to</text>
+    <text class="t noteBody" x="34" y="55">streak orange so the two widgets read as siblings, not twins.</text>
+  </g>
+
+  <g transform="translate(690 262)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">2</text>
+    <text class="t noteTitle" x="34" y="13">Streak count — TextView 56sp bold (+ emoji TextView)</text>
+    <text class="t noteBody" x="34" y="36">Derived from alarm_history at digest time, never stored — no second</text>
+    <text class="t noteBody" x="34" y="55">source of truth. Count = consecutive days with a snooze-free wake.</text>
+  </g>
+
+  <g transform="translate(690 348)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">3</text>
+    <text class="t noteTitle" x="34" y="13">Day dots — 7 ImageViews, tinted oval drawables</text>
+    <text class="t noteBody" x="34" y="36">No runtime drawing. Fallback if RemoteViews spacing fights back:</text>
+    <text class="t noteBody" x="34" y="55">pre-render the strip as one Bitmap via setImageViewBitmap.</text>
+  </g>
+
+  <g transform="translate(690 434)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">4</text>
+    <text class="t noteTitle" x="34" y="13">Dot states</text>
+    <text class="t noteBody" x="34" y="36">Filled blue = snooze-free wake · orange ring = snoozed ·</text>
+    <text class="t noteBody" x="34" y="55">hollow grey = no alarm that day · outer white ring = today.</text>
+  </g>
+
+  <g transform="translate(690 520)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">5</text>
+    <text class="t noteTitle" x="34" y="13">Tap — PendingIntent → threshold://history</text>
+    <text class="t noteBody" x="34" y="36">Lands on the stats screen (#274) through the existing deep-link</text>
+    <text class="t noteBody" x="34" y="55">path; cold-starts Rust exactly like the #156 widget taps.</text>
+  </g>
+
+  <g transform="translate(690 606)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">6</text>
+    <text class="t noteTitle" x="34" y="13">Data path</text>
+    <text class="t noteBody" x="34" y="36">Stats digest (streak count, week dots, avg wake) recomputed after each</text>
+    <text class="t noteBody" x="34" y="55">history insert (#273), pushed through the alarm-manager channel to</text>
+    <text class="t noteBody" x="34" y="74">SharedPreferences; emit only on change, render with the process dead.</text>
+  </g>
+
+  <rect x="690" y="712" width="502" height="88" rx="14" fill="#151f33" stroke="#24344f"/>
+  <text class="t noteTitle" x="712" y="744">Sequencing</text>
+  <text class="t noteBody" x="712" y="768">Blocked by #156 (widget foundation) and #273 (history capture).</text>
+  <text class="t noteBody" x="712" y="787">Streak widget (A) is the recommended v1; the week strip can follow.</text>
+</svg>

--- a/docs/ui/widgets/widget-next-alarm-mockup.svg
+++ b/docs/ui/widgets/widget-next-alarm-mockup.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 860" width="1240" height="860">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1220"/>
+      <stop offset="100%" stop-color="#111b2e"/>
+    </linearGradient>
+    <linearGradient id="wall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e1526"/>
+      <stop offset="100%" stop-color="#0a101d"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a364b"/>
+      <stop offset="100%" stop-color="#22304a"/>
+    </linearGradient>
+    <linearGradient id="cardMuted" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#202b3d"/>
+      <stop offset="100%" stop-color="#1a2436"/>
+    </linearGradient>
+    <pattern id="dots" x="0" y="0" width="34" height="34" patternUnits="userSpaceOnUse">
+      <circle cx="17" cy="17" r="1.3" fill="#24344f" opacity="0.55"/>
+    </pattern>
+    <filter id="widgetShadow">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+    <style><![CDATA[
+      .t { font-family: "Avenir Next", "Nunito Sans", "Segoe UI", sans-serif; }
+      .eyebrow { font-size: 15px; letter-spacing: 2px; fill: #ff8f5d; font-weight: 700; }
+      .caption { font-size: 14px; fill: #6f88a9; }
+      .noteTitle { font-size: 17px; fill: #dbe8fb; font-weight: 700; }
+      .noteBody { font-size: 14px; fill: #a7bad5; }
+      .chipText { font-size: 13px; fill: #ffffff; font-weight: 700; }
+    ]]></style>
+  </defs>
+
+  <rect width="1240" height="860" fill="url(#bg)"/>
+  <text class="t eyebrow" x="48" y="56">THRESHOLD WIDGETS — NEXT ALARM (#156) · ANDROID · REMOTEVIEWS</text>
+
+  <!-- ==================== Launcher backdrop ==================== -->
+  <rect x="48" y="92" width="600" height="718" rx="24" fill="url(#wall)" stroke="#1b2940"/>
+  <rect x="48" y="92" width="600" height="718" rx="24" fill="url(#dots)"/>
+
+  <!-- ========== A · Hero 4x2 — widget_alarm.xml ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="88" y="140" width="520" height="240" rx="32" fill="url(#card)" stroke="#3e5272"/>
+  </g>
+  <rect x="88" y="170" width="7" height="180" rx="3.5" fill="#4c8dff"/>
+  <text class="t" x="124" y="212" style="font-size:20px;letter-spacing:2.5px;fill:#ff8f5d;font-weight:700;">NEXT ALARM</text>
+  <text class="t" x="124" y="294" style="font-size:72px;fill:#f5f8ff;font-weight:700;letter-spacing:-1px;">7:14 AM</text>
+  <text class="t" x="124" y="338" style="font-size:26px;fill:#a9bad1;">Weekday Alarm</text>
+  <text class="t caption" x="88" y="408">A · 4×2 default — widget_alarm.xml</text>
+
+  <!-- numbered chips on A -->
+  <g>
+    <circle cx="584" cy="164" r="11" fill="#4c8dff"/><text class="t chipText" x="584" y="169" text-anchor="middle">1</text>
+    <circle cx="91.5" cy="260" r="11" fill="#4c8dff"/><text class="t chipText" x="91.5" y="265" text-anchor="middle">2</text>
+    <circle cx="330" cy="205" r="11" fill="#4c8dff"/><text class="t chipText" x="330" y="210" text-anchor="middle">3</text>
+    <circle cx="425" cy="270" r="11" fill="#4c8dff"/><text class="t chipText" x="425" y="275" text-anchor="middle">4</text>
+    <circle cx="330" cy="331" r="11" fill="#4c8dff"/><text class="t chipText" x="330" y="336" text-anchor="middle">5</text>
+    <circle cx="584" cy="356" r="11" fill="#4c8dff"/><text class="t chipText" x="584" y="361" text-anchor="middle">6</text>
+  </g>
+
+  <!-- ========== B · Narrow 2x1 — widget_alarm_narrow.xml ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="88" y="440" width="250" height="130" rx="24" fill="url(#card)" stroke="#3e5272"/>
+  </g>
+  <rect x="88" y="460" width="6" height="90" rx="3" fill="#4c8dff"/>
+  <text class="t" x="116" y="482" style="font-size:13px;letter-spacing:2px;fill:#ff8f5d;font-weight:700;">NEXT</text>
+  <text class="t" x="116" y="527" style="font-size:40px;fill:#f5f8ff;font-weight:700;letter-spacing:-0.5px;">7:14 AM</text>
+  <text class="t" x="116" y="554" style="font-size:16px;fill:#a9bad1;">Weekday Alarm</text>
+  <text class="t caption" x="88" y="598">B · 2×1 narrow — widget_alarm_narrow.xml</text>
+
+  <!-- ========== C · Light theme (values/ resources) ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="378" y="440" width="230" height="130" rx="24" fill="#ffffff" stroke="#dfe5ee"/>
+  </g>
+  <rect x="378" y="460" width="6" height="90" rx="3" fill="#002244"/>
+  <text class="t" x="404" y="482" style="font-size:12px;letter-spacing:2px;fill:#e2703d;font-weight:700;">NEXT ALARM</text>
+  <text class="t" x="404" y="524" style="font-size:36px;fill:#1a1a1a;font-weight:700;letter-spacing:-0.5px;">7:14 AM</text>
+  <text class="t" x="404" y="550" style="font-size:15px;fill:#5a6a80;">Weekday Alarm</text>
+  <text class="t caption" x="378" y="598">C · light — values/ vs values-night/</text>
+
+  <!-- ========== D · Empty state ========== -->
+  <g filter="url(#widgetShadow)">
+    <rect x="88" y="630" width="520" height="130" rx="24" fill="url(#cardMuted)" stroke="#2e3c54"/>
+  </g>
+  <rect x="88" y="650" width="7" height="90" rx="3.5" fill="#3b4c66"/>
+  <text class="t" x="124" y="690" style="font-size:30px;fill:#7f90a8;font-weight:700;">No alarm set</text>
+  <text class="t" x="124" y="722" style="font-size:18px;fill:#5d6f89;">Tap to open Threshold</text>
+  <text class="t caption" x="88" y="788">D · empty state — tap deep-links to threshold://home</text>
+
+  <!-- ==================== Build sheet ==================== -->
+  <text class="t eyebrow" x="690" y="140">REMOTEVIEWS BUILD SHEET</text>
+
+  <g transform="translate(690 176)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">1</text>
+    <text class="t noteTitle" x="34" y="13">Root — LinearLayout (vertical)</text>
+    <text class="t noteBody" x="34" y="36">Background = rounded-rect shape drawable. Android 12+ applies the</text>
+    <text class="t noteBody" x="34" y="55">system widget corner radius; pre-12 fallback 16dp. No WebView, no MUI.</text>
+  </g>
+
+  <g transform="translate(690 262)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">2</text>
+    <text class="t noteTitle" x="34" y="13">Accent rail — ImageView + 3dp shape drawable</text>
+    <text class="t noteBody" x="34" y="36">Carries the alarm-card rail into the widget family — the one visual</text>
+    <text class="t noteBody" x="34" y="55">signature shared with the in-app list. Muted tint in the empty state.</text>
+  </g>
+
+  <g transform="translate(690 348)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">3</text>
+    <text class="t noteTitle" x="34" y="13">Eyebrow — TextView, 12sp, letterSpacing 0.15</text>
+    <text class="t noteBody" x="34" y="36">Brand orange (#ff8f5d dark / #e2703d light). Optionally swap to</text>
+    <text class="t noteBody" x="34" y="55">system accent (Material You dynamic colour) in a follow-up.</text>
+  </g>
+
+  <g transform="translate(690 434)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">4</text>
+    <text class="t noteTitle" x="34" y="13">Time — TextView, 40sp bold, static text</text>
+    <text class="t noteBody" x="34" y="36">Resolved next_trigger from the SharedPreferences snapshot. Window</text>
+    <text class="t noteBody" x="34" y="55">alarms are already resolved at schedule time (scheduler.rs), so one</text>
+    <text class="t noteBody" x="34" y="74">precise time — never a range. No countdown: widgets can't tick.</text>
+  </g>
+
+  <g transform="translate(690 538)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">5</text>
+    <text class="t noteTitle" x="34" y="13">Label — TextView, 14sp, single line</text>
+    <text class="t noteBody" x="34" y="36">ellipsize="end"; hidden when the alarm has no label.</text>
+  </g>
+
+  <g transform="translate(690 606)">
+    <circle cx="11" cy="8" r="11" fill="#4c8dff"/><text class="t chipText" x="11" y="13" text-anchor="middle">6</text>
+    <text class="t noteTitle" x="34" y="13">Tap — PendingIntent.getActivity</text>
+    <text class="t noteBody" x="34" y="36">Whole widget → threshold://edit/&lt;id&gt; (empty → threshold://home).</text>
+    <text class="t noteBody" x="34" y="55">Cold-starts the app, Rust included, via the existing deep-link path.</text>
+  </g>
+
+  <rect x="690" y="694" width="502" height="106" rx="14" fill="#151f33" stroke="#24344f"/>
+  <text class="t noteTitle" x="712" y="726">Data path (no Rust at render time)</text>
+  <text class="t noteBody" x="712" y="750">alarm-manager writes the snapshot to SharedPreferences on</text>
+  <text class="t noteBody" x="712" y="769">alarms:batch:updated, then forces a widget redraw. The provider's</text>
+  <text class="t noteBody" x="712" y="788">onUpdate() renders from the snapshot even with the process dead.</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds design mockups for the Android home screen widget family under `docs/ui/widgets/`, supporting #156 (next-alarm widget) and #279 (alarm history widget):

- `widget-next-alarm-mockup.svg` — 4×2 hero, 2×1 narrow, light-theme variant, and empty state for the next-alarm widget, following the "alarm-focused hero" direction from #156's research
- `widget-history-mockup.svg` — 2×2 streak widget (recommended v1), 4×1 week strip with four dot states, and an invitation-style empty state
- `README.md` — indexes the mockups and records the conventions

Both mockups follow the screen-refresh-2026 v4 visual language (dark navy cards, `#4c8dff` accent, brand-orange eyebrows) and carry the alarm-card accent rail over as the widget family's signature. Since widget UI cannot use the webview — launchers render widgets via RemoteViews — each mockup includes a numbered "RemoteViews build sheet" mapping every visual element to the native view/drawable that implements it, plus the mechanism constraints already decided in #156's comments (static resolved trigger time, `threshold://` tap deep links, SharedPreferences snapshot rendering with the app process dead).

Docs only — no code changes. Both mockups are already posted to their issues (commit-SHA-pinned embeds).

## Test plan

- [x] Both SVGs rasterized with headless Chromium and visually verified (layout, chip alignment, text overflow)
- [x] No app/plugin code touched — docs-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9yxj9DDvz7xqkgKbsNKvC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9yxj9DDvz7xqkgKbsNKvC)_