### PR TITLE
Detect the full-screen-intent permission and add a ringing-screen fallback

### DIFF
--- a/apps/threshold/src/App.tsx
+++ b/apps/threshold/src/App.tsx
@@ -145,6 +145,21 @@ const App: React.FC = () => {
 			});
 		});
 
+		// Re-check for an active ringing alarm whenever the window regains focus (e.g. the user
+		// switches back to the app), not just at cold start -- a missed full-screen-intent launch
+		// (see DeepLinkService.checkForActiveRingingAlarm) can otherwise strand the user on Home
+		// with no way back to the ringing screen short of tapping the original notification.
+		if (os === 'android') {
+			win.onFocusChanged(({ payload: focused }) => {
+				if (!focused) return;
+				import('./services/DeepLinkService').then(({ checkForActiveRingingAlarm }) => {
+					checkForActiveRingingAlarm().catch((e) => {
+						console.error('Failed to check for active ringing alarm on focus:', e);
+					});
+				});
+			});
+		}
+
 		// Handle Back Button on Android
 		// TODO: When upgrading to Tauri 2.9.0+, switch to official @tauri-apps/api/app:
 		// const { onBackButtonPress } = await import('@tauri-apps/api/app');

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -24,6 +24,8 @@ import {
 	DialogTitle,
 	DialogContent,
 	CircularProgress,
+	Alert,
+	Button,
 } from '@mui/material';
 import { MobileToolbar } from '../components/MobileToolbar';
 import { ArrowBack as ArrowBackIcon, FileDownload as FileDownloadIcon } from '@mui/icons-material';
@@ -58,10 +60,42 @@ const Settings: React.FC = () => {
 	const [snoozeLength, setSnoozeLength] = useState<number>(SettingsService.getSnoozeLength());
 	const [snoozeDialogOpen, setSnoozeDialogOpen] = useState(false);
 	const [isExportingLogs, setIsExportingLogs] = useState(false);
+	const [fullScreenIntentGranted, setFullScreenIntentGranted] = useState<boolean | null>(null);
 
 	useEffect(() => {
 		setIsMobile(PlatformUtils.isMobile());
 		setIsAndroid(PlatformUtils.getPlatform() === 'android');
+	}, []);
+
+	// Re-checked on every window focus regain (not just on mount) so the banner clears itself
+	// after the user flips the toggle in system Settings and switches back, without needing to
+	// leave and re-enter this screen.
+	useEffect(() => {
+		if (PlatformUtils.getPlatform() !== 'android') return;
+
+		let unlisten: (() => void) | undefined;
+
+		const checkPermission = async () => {
+			try {
+				const { checkFullScreenIntentPermission } = await import('tauri-plugin-alarm-manager-api');
+				setFullScreenIntentGranted(await checkFullScreenIntentPermission());
+			} catch (e) {
+				console.error('Failed to check full-screen intent permission:', e);
+			}
+		};
+
+		checkPermission();
+		import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
+			getCurrentWindow()
+				.onFocusChanged(({ payload: focused }) => {
+					if (focused) checkPermission();
+				})
+				.then((fn) => {
+					unlisten = fn;
+				});
+		});
+
+		return () => unlisten?.();
 	}, []);
 
 	const handleTimeFormatChange = (enabled: boolean) => {
@@ -151,6 +185,35 @@ const Settings: React.FC = () => {
 				) : undefined
 			}
 		>
+			{isAndroid && fullScreenIntentGranted === false && (
+				<ListItem sx={{ px }}>
+					<Alert
+						severity="warning"
+						sx={{ width: '100%' }}
+						action={
+							<Button
+								color="inherit"
+								size="small"
+								onClick={async () => {
+									try {
+										const { openFullScreenIntentSettings } =
+											await import('tauri-plugin-alarm-manager-api');
+										await openFullScreenIntentSettings();
+									} catch (e) {
+										console.error('Failed to open full-screen intent settings:', e);
+									}
+								}}
+							>
+								Enable
+							</Button>
+						}
+					>
+						The ringing screen won't appear over the lock screen until "Full screen intent
+						notifications" is enabled for Threshold.
+					</Alert>
+				</ListItem>
+			)}
+
 			<ListItem sx={{ px }}>
 				<FormControl fullWidth>
 					<InputLabel id="silence-after-label">Silence After</InputLabel>

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -46,6 +46,32 @@ const NAV_ITEMS: { key: SettingsSection; label: string }[] = [
 	{ key: 'developer', label: 'Developer' },
 ];
 
+// The Android permissions/OS states that can silently degrade alarm reliability with no error
+// surfaced anywhere -- see issue #281 (full-screen intent) and #282's Developer settings
+// diagnostic. Ownership follows the plugin that already declares/drives each one: the first
+// three are alarm-manager's (it already owns the ringing pipeline and declares their manifest
+// permissions), while notifications is a generic OS concern that lives in os-prefs instead.
+type PermissionKey = 'fullScreenIntent' | 'exactAlarm' | 'batteryOptimization' | 'notifications';
+
+const PERMISSION_INFO: Record<PermissionKey, { label: string; description: string }> = {
+	fullScreenIntent: {
+		label: 'Full-screen intent',
+		description: 'Lets the ringing screen take over the lock screen instead of just a banner',
+	},
+	exactAlarm: {
+		label: 'Exact alarm scheduling',
+		description: 'Alarms fire on time instead of drifting into an inexact window',
+	},
+	batteryOptimization: {
+		label: 'Battery optimization exemption',
+		description: 'Keeps Doze/App Standby from throttling the ringing pipeline',
+	},
+	notifications: {
+		label: 'Notifications',
+		description: 'Required for the ringing and upcoming-alarm notifications to post at all',
+	},
+};
+
 const Settings: React.FC = () => {
 	const navigate = useNavigate();
 	const { theme, setTheme, forceDark, setForceDark, useMaterialYou, setUseMaterialYou } =
@@ -60,35 +86,59 @@ const Settings: React.FC = () => {
 	const [snoozeLength, setSnoozeLength] = useState<number>(SettingsService.getSnoozeLength());
 	const [snoozeDialogOpen, setSnoozeDialogOpen] = useState(false);
 	const [isExportingLogs, setIsExportingLogs] = useState(false);
-	const [fullScreenIntentGranted, setFullScreenIntentGranted] = useState<boolean | null>(null);
+	const [permissionStatus, setPermissionStatus] = useState<Record<PermissionKey, boolean | null>>({
+		fullScreenIntent: null,
+		exactAlarm: null,
+		batteryOptimization: null,
+		notifications: null,
+	});
 
 	useEffect(() => {
 		setIsMobile(PlatformUtils.isMobile());
 		setIsAndroid(PlatformUtils.getPlatform() === 'android');
 	}, []);
 
-	// Re-checked on every window focus regain (not just on mount) so the banner clears itself
-	// after the user flips the toggle in system Settings and switches back, without needing to
-	// leave and re-enter this screen.
+	// Re-checked on every window focus regain (not just on mount) so both the Alarm Settings
+	// banner and the Developer settings diagnostic clear themselves after the user flips a
+	// toggle in system Settings and switches back, without needing to leave and re-enter this
+	// screen.
 	useEffect(() => {
 		if (PlatformUtils.getPlatform() !== 'android') return;
 
 		let unlisten: (() => void) | undefined;
 
-		const checkPermission = async () => {
+		const checkPermissions = async () => {
 			try {
-				const { checkFullScreenIntentPermission } = await import('tauri-plugin-alarm-manager-api');
-				setFullScreenIntentGranted(await checkFullScreenIntentPermission());
+				const alarmManager = await import('tauri-plugin-alarm-manager-api');
+				const [fullScreenIntent, exactAlarm, batteryOptimization] = await Promise.all([
+					alarmManager.checkFullScreenIntentPermission(),
+					alarmManager.checkExactAlarmPermission(),
+					alarmManager.checkBatteryOptimizationExemption(),
+				]);
+				setPermissionStatus((prev) => ({
+					...prev,
+					fullScreenIntent,
+					exactAlarm,
+					batteryOptimization,
+				}));
 			} catch (e) {
-				console.error('Failed to check full-screen intent permission:', e);
+				console.error('Failed to check alarm-manager permissions:', e);
+			}
+
+			try {
+				const { isPermissionGranted } = await import('@tauri-apps/plugin-notification');
+				const notifications = await isPermissionGranted();
+				setPermissionStatus((prev) => ({ ...prev, notifications }));
+			} catch (e) {
+				console.error('Failed to check notification permission:', e);
 			}
 		};
 
-		checkPermission();
+		checkPermissions();
 		import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
 			getCurrentWindow()
 				.onFocusChanged(({ payload: focused }) => {
-					if (focused) checkPermission();
+					if (focused) checkPermissions();
 				})
 				.then((fn) => {
 					unlisten = fn;
@@ -97,6 +147,36 @@ const Settings: React.FC = () => {
 
 		return () => unlisten?.();
 	}, []);
+
+	const openPermissionSettings = async (key: PermissionKey) => {
+		try {
+			switch (key) {
+				case 'fullScreenIntent': {
+					const { openFullScreenIntentSettings } = await import('tauri-plugin-alarm-manager-api');
+					await openFullScreenIntentSettings();
+					break;
+				}
+				case 'exactAlarm': {
+					const { openExactAlarmSettings } = await import('tauri-plugin-alarm-manager-api');
+					await openExactAlarmSettings();
+					break;
+				}
+				case 'batteryOptimization': {
+					const { openBatteryOptimizationSettings } =
+						await import('tauri-plugin-alarm-manager-api');
+					await openBatteryOptimizationSettings();
+					break;
+				}
+				case 'notifications': {
+					const { openNotificationSettings } = await import('tauri-plugin-os-prefs-api');
+					await openNotificationSettings();
+					break;
+				}
+			}
+		} catch (e) {
+			console.error(`Failed to open settings for ${key}:`, e);
+		}
+	};
 
 	const handleTimeFormatChange = (enabled: boolean) => {
 		setIs24h(enabled);
@@ -185,7 +265,7 @@ const Settings: React.FC = () => {
 				) : undefined
 			}
 		>
-			{isAndroid && fullScreenIntentGranted === false && (
+			{isAndroid && permissionStatus.fullScreenIntent === false && (
 				<ListItem sx={{ px }}>
 					<Alert
 						severity="warning"
@@ -194,15 +274,7 @@ const Settings: React.FC = () => {
 							<Button
 								color="inherit"
 								size="small"
-								onClick={async () => {
-									try {
-										const { openFullScreenIntentSettings } =
-											await import('tauri-plugin-alarm-manager-api');
-										await openFullScreenIntentSettings();
-									} catch (e) {
-										console.error('Failed to open full-screen intent settings:', e);
-									}
-								}}
+								onClick={() => openPermissionSettings('fullScreenIntent')}
 							>
 								Enable
 							</Button>
@@ -273,6 +345,31 @@ const Settings: React.FC = () => {
 				) : undefined
 			}
 		>
+			{isAndroid && (
+				<>
+					<ListSubheader sx={{ bgcolor: 'transparent' }}>Permissions</ListSubheader>
+					{(Object.keys(PERMISSION_INFO) as PermissionKey[]).map((key) => {
+						const granted = permissionStatus[key];
+						const info = PERMISSION_INFO[key];
+						return (
+							<ListItem key={key} sx={{ px }}>
+								<ListItemText
+									primary={info.label}
+									secondary={`${
+										granted === null ? 'Checking…' : granted ? 'Granted' : 'Not granted'
+									} — ${info.description}`}
+								/>
+								{granted === false && (
+									<Button size="small" onClick={() => openPermissionSettings(key)}>
+										Fix
+									</Button>
+								)}
+							</ListItem>
+						);
+					})}
+				</>
+			)}
+
 			<ListItem sx={{ px }}>
 				<ListItemText
 					primary="Test Alarm Ring"

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -370,6 +370,8 @@ const Settings: React.FC = () => {
 				</>
 			)}
 
+			<ListSubheader sx={{ bgcolor: 'transparent', mt: 2 }}>Testing</ListSubheader>
+
 			<ListItem sx={{ px }}>
 				<ListItemText
 					primary="Test Alarm Ring"

--- a/apps/threshold/src/services/DeepLinkService.ts
+++ b/apps/threshold/src/services/DeepLinkService.ts
@@ -52,6 +52,36 @@ export async function initDeepLinks(router: typeof routerType) {
 	} catch (e) {
 		console.error('Failed to register deep link listener:', e);
 	}
+
+	// Fallback for when the ringing notification's full-screen intent never fires (e.g. the
+	// USE_FULL_SCREEN_INTENT special permission is off on Android 14+) or the app is simply
+	// reopened from the home-screen icon while an alarm is still ringing -- neither case
+	// delivers a deep link, so there'd otherwise be no way back to the ringing screen short of
+	// tapping the notification itself. Harmless no-op if a deep link already navigated here.
+	await checkForActiveRingingAlarm();
+}
+
+/**
+ * Routes to the ringing screen if a native alarm is currently ringing and we're not already
+ * there. Called once at startup and again on every window focus regain (see App.tsx), since a
+ * missed full-screen-intent launch can be discovered either at cold start or on resume.
+ */
+export async function checkForActiveRingingAlarm() {
+	if (!routerInstance) return;
+
+	try {
+		const { getCurrentlyRingingAlarm } = await import('tauri-plugin-alarm-manager-api');
+		const id = await getCurrentlyRingingAlarm();
+		if (id == null) return;
+
+		const target = `/ringing/${id}`;
+		if (routerInstance.state.location.pathname === target) return;
+
+		console.log('[DeepLink] Routing to active ringing alarm as a fallback:', target);
+		routerInstance.navigate({ to: target as any });
+	} catch (e) {
+		console.error('[DeepLink] Failed to check for an active ringing alarm:', e);
+	}
 }
 
 /**

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -14,6 +14,7 @@ import android.media.MediaPlayer
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import android.webkit.WebView
 import app.tauri.annotation.Command
 import app.tauri.annotation.InvokeArg
@@ -301,6 +302,50 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             activity.setTurnScreenOn(false)
         }
         invoke.resolve()
+    }
+
+    // Android 14+ (API 34) made USE_FULL_SCREEN_INTENT a user-revocable special permission
+    // (Settings > Apps > Threshold > Special app access > "Full screen intent notifications").
+    // When it's off, canUseFullScreenIntent() returns false and the OS silently downgrades the
+    // ringing notification's full-screen intent to an ordinary heads-up banner instead of
+    // launching the ringing Activity -- no error, no callback. Below API 34 the permission is
+    // granted unconditionally by declaring it in the manifest, so there's nothing to check.
+    @Command
+    fun checkFullScreenIntentPermission(invoke: Invoke) {
+        val granted = if (Build.VERSION.SDK_INT >= 34) {
+            val notificationManager =
+                activity.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+            notificationManager.canUseFullScreenIntent()
+        } else {
+            true
+        }
+        val ret = JSObject()
+        ret.put("granted", granted)
+        invoke.resolve(ret)
+    }
+
+    @Command
+    fun openFullScreenIntentSettings(invoke: Invoke) {
+        if (Build.VERSION.SDK_INT >= 34) {
+            val intent = Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+                data = Uri.parse("package:${activity.packageName}")
+            }
+            activity.startActivity(intent)
+        }
+        invoke.resolve()
+    }
+
+    // Ringing-screen navigation is otherwise driven entirely by the notification's full-screen
+    // intent (see DeepLinkService.ts) -- if that launch is ever missed (permission denied, OS
+    // quirk, or the app is simply reopened from the home-screen icon while an alarm is still
+    // ringing), there is no other signal telling the frontend an alarm is active. This exposes
+    // AlarmRingingService's own in-memory state so the frontend can route there as a fallback.
+    @Command
+    fun getCurrentlyRingingAlarm(invoke: Invoke) {
+        val ret = JSObject()
+        val id = AlarmRingingService.currentlyRingingAlarmId
+        ret.put("id", if (id > 0) id else null)
+        invoke.resolve(ret)
     }
 
     @Command

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -335,6 +335,55 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         invoke.resolve()
     }
 
+    // Android 12+ (API 31) made scheduling an exact alarm ("clock/alarm" apps) a user-revocable
+    // permission too -- if revoked, AlarmManager.setAlarmClock() silently degrades to an inexact
+    // window (the alarm can fire minutes late) instead of throwing. Below API 31 exact alarms
+    // were unconditionally allowed, so there's nothing to check.
+    @Command
+    fun checkExactAlarmPermission(invoke: Invoke) {
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val alarmManager = activity.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+        val ret = JSObject()
+        ret.put("granted", granted)
+        invoke.resolve(ret)
+    }
+
+    @Command
+    fun openExactAlarmSettings(invoke: Invoke) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+                data = Uri.parse("package:${activity.packageName}")
+            }
+            activity.startActivity(intent)
+        }
+        invoke.resolve()
+    }
+
+    // Doze/App Standby can defer or throttle the alarm's native wake/ring path if the app isn't
+    // exempted from battery optimization, again with nothing surfaced to the user when it
+    // happens. Available on every OS version this app supports (minSdk 26), unlike the two
+    // checks above.
+    @Command
+    fun checkBatteryOptimizationExemption(invoke: Invoke) {
+        val powerManager = activity.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
+        val ret = JSObject()
+        ret.put("granted", powerManager.isIgnoringBatteryOptimizations(activity.packageName))
+        invoke.resolve(ret)
+    }
+
+    @Command
+    fun openBatteryOptimizationSettings(invoke: Invoke) {
+        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+            data = Uri.parse("package:${activity.packageName}")
+        }
+        activity.startActivity(intent)
+        invoke.resolve()
+    }
+
     // Ringing-screen navigation is otherwise driven entirely by the notification's full-screen
     // intent (see DeepLinkService.ts) -- if that launch is ever missed (permission denied, OS
     // quirk, or the app is simply reopened from the home-screen icon while an alarm is still

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmRingingService.kt
@@ -37,6 +37,13 @@ class AlarmRingingService : Service() {
         const val ACTION_SNOOZE = "com.threshold.ACTION_SNOOZE"
         const val NOTIFICATION_ID = 999
         private const val TAG = "AlarmRingingService"
+
+        // Read by AlarmManagerPlugin.getCurrentlyRingingAlarm() so the frontend can detect an
+        // active alarm on a plain app launch/resume, not just via the full-screen-intent deep
+        // link. -1 means nothing is currently ringing.
+        @Volatile
+        var currentlyRingingAlarmId: Int = -1
+            private set
     }
 
     override fun onBind(intent: Intent?): IBinder? {
@@ -79,6 +86,7 @@ class AlarmRingingService : Service() {
 
         val soundUriStr = intent.getStringExtra("ALARM_SOUND_URI")
         currentAlarmId = intent.getIntExtra("ALARM_ID", -1)
+        currentlyRingingAlarmId = currentAlarmId
 
         Log.d(TAG, "Starting service for alarm $currentAlarmId with sound $soundUriStr")
         NativeEventLog.log(applicationContext, TAG, "Ringing service starting for alarm id=$currentAlarmId")
@@ -94,6 +102,10 @@ class AlarmRingingService : Service() {
         super.onDestroy()
         Log.d(TAG, "Service destroying")
         NativeEventLog.log(applicationContext, TAG, "Ringing service destroying for alarm id=$currentAlarmId")
+
+        if (currentlyRingingAlarmId == currentAlarmId) {
+            currentlyRingingAlarmId = -1
+        }
 
         stopAudio()
         stopVibration()

--- a/plugins/alarm-manager/build.rs
+++ b/plugins/alarm-manager/build.rs
@@ -12,6 +12,10 @@ const COMMANDS: &[&str] = &[
     "stop_ringing",
     "check_full_screen_intent_permission",
     "open_full_screen_intent_settings",
+    "check_exact_alarm_permission",
+    "open_exact_alarm_settings",
+    "check_battery_optimization_exemption",
+    "open_battery_optimization_settings",
     "get_currently_ringing_alarm",
 ];
 
@@ -42,6 +46,11 @@ fn inject_android_permissions() {
         r#"<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />"#,
         // Legacy alarm permission (often required by older Android versions/vendors)
         r#"<uses-permission android:name="com.android.alarm.permission.SET_ALARM" />"#,
+        // Lets openBatteryOptimizationSettings prompt for an exemption -- required to declare
+        // this normal (install-time-granted) permission before ACTION_REQUEST_IGNORE_BATTERY_
+        // OPTIMIZATIONS can be used; querying isIgnoringBatteryOptimizations() itself needs no
+        // permission.
+        r#"<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />"#,
     ];
 
     tauri_plugin::mobile::update_android_manifest(

--- a/plugins/alarm-manager/build.rs
+++ b/plugins/alarm-manager/build.rs
@@ -6,7 +6,14 @@
 // Webview-invokable surface only. Commands reached exclusively via
 // `run_mobile_plugin` from Rust (e.g. the pipeline-ready handshake) bypass the
 // ACL entirely and must not be listed here.
-const COMMANDS: &[&str] = &["cancel", "pick_alarm_sound", "stop_ringing"];
+const COMMANDS: &[&str] = &[
+    "cancel",
+    "pick_alarm_sound",
+    "stop_ringing",
+    "check_full_screen_intent_permission",
+    "open_full_screen_intent_settings",
+    "get_currently_ringing_alarm",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS)

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -48,6 +48,32 @@ export async function openFullScreenIntentSettings(): Promise<void> {
 	await invoke('plugin:alarm-manager|open_full_screen_intent_settings');
 }
 
+/** Whether Android will schedule this app's alarms exactly rather than degrading to a window. */
+export async function checkExactAlarmPermission(): Promise<boolean> {
+	const result = await invoke<{ granted: boolean }>(
+		'plugin:alarm-manager|check_exact_alarm_permission',
+	);
+	return result.granted;
+}
+
+/** Opens the OS settings screen for the exact-alarm-scheduling special permission (Android 12+). */
+export async function openExactAlarmSettings(): Promise<void> {
+	await invoke('plugin:alarm-manager|open_exact_alarm_settings');
+}
+
+/** Whether this app is exempted from Doze/App Standby battery optimization. */
+export async function checkBatteryOptimizationExemption(): Promise<boolean> {
+	const result = await invoke<{ granted: boolean }>(
+		'plugin:alarm-manager|check_battery_optimization_exemption',
+	);
+	return result.granted;
+}
+
+/** Opens the OS settings screen to request a battery-optimization exemption. */
+export async function openBatteryOptimizationSettings(): Promise<void> {
+	await invoke('plugin:alarm-manager|open_battery_optimization_settings');
+}
+
 /**
  * The alarm ID currently ringing natively, if any -- a fallback for detecting an active alarm
  * outside the normal full-screen-intent deep-link launch path.

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -34,3 +34,27 @@ export async function pickAlarmSound(options: PickAlarmSoundOptions): Promise<Pi
 export async function stopRinging(): Promise<void> {
 	await invoke('plugin:alarm-manager|stop_ringing');
 }
+
+/** Whether Android will actually honour the ringing notification's full-screen intent. */
+export async function checkFullScreenIntentPermission(): Promise<boolean> {
+	const result = await invoke<{ granted: boolean }>(
+		'plugin:alarm-manager|check_full_screen_intent_permission',
+	);
+	return result.granted;
+}
+
+/** Opens the OS settings screen for the full-screen-intent special permission (Android 14+). */
+export async function openFullScreenIntentSettings(): Promise<void> {
+	await invoke('plugin:alarm-manager|open_full_screen_intent_settings');
+}
+
+/**
+ * The alarm ID currently ringing natively, if any -- a fallback for detecting an active alarm
+ * outside the normal full-screen-intent deep-link launch path.
+ */
+export async function getCurrentlyRingingAlarm(): Promise<number | null> {
+	const result = await invoke<{ id: number | null }>(
+		'plugin:alarm-manager|get_currently_ringing_alarm',
+	);
+	return result.id;
+}

--- a/plugins/alarm-manager/permissions/autogenerated/commands/check_battery_optimization_exemption.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/check_battery_optimization_exemption.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-battery-optimization-exemption"
+description = "Enables the check_battery_optimization_exemption command without any pre-configured scope."
+commands.allow = ["check_battery_optimization_exemption"]
+
+[[permission]]
+identifier = "deny-check-battery-optimization-exemption"
+description = "Denies the check_battery_optimization_exemption command without any pre-configured scope."
+commands.deny = ["check_battery_optimization_exemption"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/check_exact_alarm_permission.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/check_exact_alarm_permission.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-exact-alarm-permission"
+description = "Enables the check_exact_alarm_permission command without any pre-configured scope."
+commands.allow = ["check_exact_alarm_permission"]
+
+[[permission]]
+identifier = "deny-check-exact-alarm-permission"
+description = "Denies the check_exact_alarm_permission command without any pre-configured scope."
+commands.deny = ["check_exact_alarm_permission"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/check_full_screen_intent_permission.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/check_full_screen_intent_permission.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-check-full-screen-intent-permission"
+description = "Enables the check_full_screen_intent_permission command without any pre-configured scope."
+commands.allow = ["check_full_screen_intent_permission"]
+
+[[permission]]
+identifier = "deny-check-full-screen-intent-permission"
+description = "Denies the check_full_screen_intent_permission command without any pre-configured scope."
+commands.deny = ["check_full_screen_intent_permission"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/get_currently_ringing_alarm.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/get_currently_ringing_alarm.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-currently-ringing-alarm"
+description = "Enables the get_currently_ringing_alarm command without any pre-configured scope."
+commands.allow = ["get_currently_ringing_alarm"]
+
+[[permission]]
+identifier = "deny-get-currently-ringing-alarm"
+description = "Denies the get_currently_ringing_alarm command without any pre-configured scope."
+commands.deny = ["get_currently_ringing_alarm"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/open_battery_optimization_settings.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/open_battery_optimization_settings.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-open-battery-optimization-settings"
+description = "Enables the open_battery_optimization_settings command without any pre-configured scope."
+commands.allow = ["open_battery_optimization_settings"]
+
+[[permission]]
+identifier = "deny-open-battery-optimization-settings"
+description = "Denies the open_battery_optimization_settings command without any pre-configured scope."
+commands.deny = ["open_battery_optimization_settings"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/open_exact_alarm_settings.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/open_exact_alarm_settings.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-open-exact-alarm-settings"
+description = "Enables the open_exact_alarm_settings command without any pre-configured scope."
+commands.allow = ["open_exact_alarm_settings"]
+
+[[permission]]
+identifier = "deny-open-exact-alarm-settings"
+description = "Denies the open_exact_alarm_settings command without any pre-configured scope."
+commands.deny = ["open_exact_alarm_settings"]

--- a/plugins/alarm-manager/permissions/autogenerated/commands/open_full_screen_intent_settings.toml
+++ b/plugins/alarm-manager/permissions/autogenerated/commands/open_full_screen_intent_settings.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-open-full-screen-intent-settings"
+description = "Enables the open_full_screen_intent_settings command without any pre-configured scope."
+commands.allow = ["open_full_screen_intent_settings"]
+
+[[permission]]
+identifier = "deny-open-full-screen-intent-settings"
+description = "Denies the open_full_screen_intent_settings command without any pre-configured scope."
+commands.deny = ["open_full_screen_intent_settings"]

--- a/plugins/alarm-manager/permissions/autogenerated/reference.md
+++ b/plugins/alarm-manager/permissions/autogenerated/reference.md
@@ -7,6 +7,9 @@ Default permissions for the alarm-manager plugin
 - `allow-cancel`
 - `allow-pick-alarm-sound`
 - `allow-stop-ringing`
+- `allow-check-full-screen-intent-permission`
+- `allow-open-full-screen-intent-settings`
+- `allow-get-currently-ringing-alarm`
 
 ## Permission Table
 
@@ -39,6 +42,84 @@ Enables the cancel command without any pre-configured scope.
 <td>
 
 Denies the cancel command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-check-full-screen-intent-permission`
+
+</td>
+<td>
+
+Enables the check_full_screen_intent_permission command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-check-full-screen-intent-permission`
+
+</td>
+<td>
+
+Denies the check_full_screen_intent_permission command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-get-currently-ringing-alarm`
+
+</td>
+<td>
+
+Enables the get_currently_ringing_alarm command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-get-currently-ringing-alarm`
+
+</td>
+<td>
+
+Denies the get_currently_ringing_alarm command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-open-full-screen-intent-settings`
+
+</td>
+<td>
+
+Enables the open_full_screen_intent_settings command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-open-full-screen-intent-settings`
+
+</td>
+<td>
+
+Denies the open_full_screen_intent_settings command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/alarm-manager/permissions/autogenerated/reference.md
+++ b/plugins/alarm-manager/permissions/autogenerated/reference.md
@@ -9,6 +9,10 @@ Default permissions for the alarm-manager plugin
 - `allow-stop-ringing`
 - `allow-check-full-screen-intent-permission`
 - `allow-open-full-screen-intent-settings`
+- `allow-check-exact-alarm-permission`
+- `allow-open-exact-alarm-settings`
+- `allow-check-battery-optimization-exemption`
+- `allow-open-battery-optimization-settings`
 - `allow-get-currently-ringing-alarm`
 
 ## Permission Table
@@ -42,6 +46,58 @@ Enables the cancel command without any pre-configured scope.
 <td>
 
 Denies the cancel command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-check-battery-optimization-exemption`
+
+</td>
+<td>
+
+Enables the check_battery_optimization_exemption command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-check-battery-optimization-exemption`
+
+</td>
+<td>
+
+Denies the check_battery_optimization_exemption command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-check-exact-alarm-permission`
+
+</td>
+<td>
+
+Enables the check_exact_alarm_permission command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-check-exact-alarm-permission`
+
+</td>
+<td>
+
+Denies the check_exact_alarm_permission command without any pre-configured scope.
 
 </td>
 </tr>
@@ -94,6 +150,58 @@ Enables the get_currently_ringing_alarm command without any pre-configured scope
 <td>
 
 Denies the get_currently_ringing_alarm command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-open-battery-optimization-settings`
+
+</td>
+<td>
+
+Enables the open_battery_optimization_settings command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-open-battery-optimization-settings`
+
+</td>
+<td>
+
+Denies the open_battery_optimization_settings command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:allow-open-exact-alarm-settings`
+
+</td>
+<td>
+
+Enables the open_exact_alarm_settings command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`alarm-manager:deny-open-exact-alarm-settings`
+
+</td>
+<td>
+
+Denies the open_exact_alarm_settings command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/alarm-manager/permissions/default.toml
+++ b/plugins/alarm-manager/permissions/default.toml
@@ -4,4 +4,7 @@ permissions = [
     "allow-cancel",
     "allow-pick-alarm-sound",
     "allow-stop-ringing",
+    "allow-check-full-screen-intent-permission",
+    "allow-open-full-screen-intent-settings",
+    "allow-get-currently-ringing-alarm",
 ]

--- a/plugins/alarm-manager/permissions/default.toml
+++ b/plugins/alarm-manager/permissions/default.toml
@@ -6,5 +6,9 @@ permissions = [
     "allow-stop-ringing",
     "allow-check-full-screen-intent-permission",
     "allow-open-full-screen-intent-settings",
+    "allow-check-exact-alarm-permission",
+    "allow-open-exact-alarm-settings",
+    "allow-check-battery-optimization-exemption",
+    "allow-open-battery-optimization-settings",
     "allow-get-currently-ringing-alarm",
 ]

--- a/plugins/alarm-manager/permissions/schemas/schema.json
+++ b/plugins/alarm-manager/permissions/schemas/schema.json
@@ -307,6 +307,42 @@
           "markdownDescription": "Denies the cancel command without any pre-configured scope."
         },
         {
+          "description": "Enables the check_full_screen_intent_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-full-screen-intent-permission",
+          "markdownDescription": "Enables the check_full_screen_intent_permission command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_full_screen_intent_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-full-screen-intent-permission",
+          "markdownDescription": "Denies the check_full_screen_intent_permission command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_currently_ringing_alarm command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-currently-ringing-alarm",
+          "markdownDescription": "Enables the get_currently_ringing_alarm command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_currently_ringing_alarm command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-currently-ringing-alarm",
+          "markdownDescription": "Denies the get_currently_ringing_alarm command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open_full_screen_intent_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-open-full-screen-intent-settings",
+          "markdownDescription": "Enables the open_full_screen_intent_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_full_screen_intent_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-open-full-screen-intent-settings",
+          "markdownDescription": "Denies the open_full_screen_intent_settings command without any pre-configured scope."
+        },
+        {
           "description": "Enables the pick_alarm_sound command without any pre-configured scope.",
           "type": "string",
           "const": "allow-pick-alarm-sound",
@@ -331,10 +367,10 @@
           "markdownDescription": "Denies the stop_ringing command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`",
+          "description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-get-currently-ringing-alarm`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`"
+          "markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-get-currently-ringing-alarm`"
         }
       ]
     }

--- a/plugins/alarm-manager/permissions/schemas/schema.json
+++ b/plugins/alarm-manager/permissions/schemas/schema.json
@@ -307,6 +307,30 @@
           "markdownDescription": "Denies the cancel command without any pre-configured scope."
         },
         {
+          "description": "Enables the check_battery_optimization_exemption command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-battery-optimization-exemption",
+          "markdownDescription": "Enables the check_battery_optimization_exemption command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_battery_optimization_exemption command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-battery-optimization-exemption",
+          "markdownDescription": "Denies the check_battery_optimization_exemption command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the check_exact_alarm_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-check-exact-alarm-permission",
+          "markdownDescription": "Enables the check_exact_alarm_permission command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_exact_alarm_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-check-exact-alarm-permission",
+          "markdownDescription": "Denies the check_exact_alarm_permission command without any pre-configured scope."
+        },
+        {
           "description": "Enables the check_full_screen_intent_permission command without any pre-configured scope.",
           "type": "string",
           "const": "allow-check-full-screen-intent-permission",
@@ -329,6 +353,30 @@
           "type": "string",
           "const": "deny-get-currently-ringing-alarm",
           "markdownDescription": "Denies the get_currently_ringing_alarm command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open_battery_optimization_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-open-battery-optimization-settings",
+          "markdownDescription": "Enables the open_battery_optimization_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_battery_optimization_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-open-battery-optimization-settings",
+          "markdownDescription": "Denies the open_battery_optimization_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open_exact_alarm_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-open-exact-alarm-settings",
+          "markdownDescription": "Enables the open_exact_alarm_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_exact_alarm_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-open-exact-alarm-settings",
+          "markdownDescription": "Denies the open_exact_alarm_settings command without any pre-configured scope."
         },
         {
           "description": "Enables the open_full_screen_intent_settings command without any pre-configured scope.",
@@ -367,10 +415,10 @@
           "markdownDescription": "Denies the stop_ringing command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-get-currently-ringing-alarm`",
+          "description": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-check-exact-alarm-permission`\n- `allow-open-exact-alarm-settings`\n- `allow-check-battery-optimization-exemption`\n- `allow-open-battery-optimization-settings`\n- `allow-get-currently-ringing-alarm`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-get-currently-ringing-alarm`"
+          "markdownDescription": "Default permissions for the alarm-manager plugin\n#### This default permission set includes:\n\n- `allow-cancel`\n- `allow-pick-alarm-sound`\n- `allow-stop-ringing`\n- `allow-check-full-screen-intent-permission`\n- `allow-open-full-screen-intent-settings`\n- `allow-check-exact-alarm-permission`\n- `allow-open-exact-alarm-settings`\n- `allow-check-battery-optimization-exemption`\n- `allow-open-battery-optimization-settings`\n- `allow-get-currently-ringing-alarm`"
         }
       ]
     }

--- a/plugins/alarm-manager/src/commands.rs
+++ b/plugins/alarm-manager/src/commands.rs
@@ -26,3 +26,24 @@ pub async fn pick_alarm_sound<R: Runtime>(
 pub async fn stop_ringing<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     app.alarm_manager().stop_ringing()
 }
+
+#[command]
+pub async fn check_full_screen_intent_permission<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<FullScreenIntentPermission> {
+    let granted = app.alarm_manager().check_full_screen_intent_permission()?;
+    Ok(FullScreenIntentPermission { granted })
+}
+
+#[command]
+pub async fn open_full_screen_intent_settings<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.alarm_manager().open_full_screen_intent_settings()
+}
+
+#[command]
+pub async fn get_currently_ringing_alarm<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<CurrentlyRingingAlarm> {
+    let id = app.alarm_manager().get_currently_ringing_alarm()?;
+    Ok(CurrentlyRingingAlarm { id })
+}

--- a/plugins/alarm-manager/src/commands.rs
+++ b/plugins/alarm-manager/src/commands.rs
@@ -30,14 +30,40 @@ pub async fn stop_ringing<R: Runtime>(app: AppHandle<R>) -> Result<()> {
 #[command]
 pub async fn check_full_screen_intent_permission<R: Runtime>(
     app: AppHandle<R>,
-) -> Result<FullScreenIntentPermission> {
+) -> Result<PermissionStatus> {
     let granted = app.alarm_manager().check_full_screen_intent_permission()?;
-    Ok(FullScreenIntentPermission { granted })
+    Ok(PermissionStatus { granted })
 }
 
 #[command]
 pub async fn open_full_screen_intent_settings<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     app.alarm_manager().open_full_screen_intent_settings()
+}
+
+#[command]
+pub async fn check_exact_alarm_permission<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<PermissionStatus> {
+    let granted = app.alarm_manager().check_exact_alarm_permission()?;
+    Ok(PermissionStatus { granted })
+}
+
+#[command]
+pub async fn open_exact_alarm_settings<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.alarm_manager().open_exact_alarm_settings()
+}
+
+#[command]
+pub async fn check_battery_optimization_exemption<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<PermissionStatus> {
+    let granted = app.alarm_manager().check_battery_optimization_exemption()?;
+    Ok(PermissionStatus { granted })
+}
+
+#[command]
+pub async fn open_battery_optimization_settings<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.alarm_manager().open_battery_optimization_settings()
 }
 
 #[command]

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -92,4 +92,19 @@ impl<R: Runtime> AlarmManager<R> {
         println!("Desktop: Stop ringing request received");
         Ok(())
     }
+
+    /// Not an Android concept; nothing to gate.
+    pub fn check_full_screen_intent_permission(&self) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    pub fn open_full_screen_intent_settings(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    /// Desktop ringing already navigates the frontend directly via the `alarm-ring` event;
+    /// there's no separate native ringing state to query.
+    pub fn get_currently_ringing_alarm(&self) -> crate::Result<Option<i32>> {
+        Ok(None)
+    }
 }

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -102,6 +102,24 @@ impl<R: Runtime> AlarmManager<R> {
         Ok(())
     }
 
+    /// Not an Android concept; nothing to gate.
+    pub fn check_exact_alarm_permission(&self) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    pub fn open_exact_alarm_settings(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    /// Not an Android concept; nothing to gate.
+    pub fn check_battery_optimization_exemption(&self) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    pub fn open_battery_optimization_settings(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
     /// Desktop ringing already navigates the frontend directly via the `alarm-ring` event;
     /// there's no separate native ringing state to query.
     pub fn get_currently_ringing_alarm(&self) -> crate::Result<Option<i32>> {

--- a/plugins/alarm-manager/src/lib.rs
+++ b/plugins/alarm-manager/src/lib.rs
@@ -49,6 +49,10 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::stop_ringing,
             commands::check_full_screen_intent_permission,
             commands::open_full_screen_intent_settings,
+            commands::check_exact_alarm_permission,
+            commands::open_exact_alarm_settings,
+            commands::check_battery_optimization_exemption,
+            commands::open_battery_optimization_settings,
             commands::get_currently_ringing_alarm
         ])
         .setup(|app, api| {
@@ -123,6 +127,10 @@ mod acl_tests {
         "stop_ringing",
         "check_full_screen_intent_permission",
         "open_full_screen_intent_settings",
+        "check_exact_alarm_permission",
+        "open_exact_alarm_settings",
+        "check_battery_optimization_exemption",
+        "open_battery_optimization_settings",
         "get_currently_ringing_alarm",
     ];
 

--- a/plugins/alarm-manager/src/lib.rs
+++ b/plugins/alarm-manager/src/lib.rs
@@ -46,7 +46,10 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         .invoke_handler(tauri::generate_handler![
             commands::cancel,
             commands::pick_alarm_sound,
-            commands::stop_ringing
+            commands::stop_ringing,
+            commands::check_full_screen_intent_permission,
+            commands::open_full_screen_intent_settings,
+            commands::get_currently_ringing_alarm
         ])
         .setup(|app, api| {
             #[cfg(mobile)]
@@ -114,7 +117,14 @@ mod acl_tests {
     // Every command here MUST have a matching `allow-*` permission in
     // `permissions/default.toml`, or the ACL silently denies it at runtime (the
     // exact bug fixed in Threshold issue #195).
-    const WEBVIEW_COMMANDS: &[&str] = &["cancel", "pick_alarm_sound", "stop_ringing"];
+    const WEBVIEW_COMMANDS: &[&str] = &[
+        "cancel",
+        "pick_alarm_sound",
+        "stop_ringing",
+        "check_full_screen_intent_permission",
+        "open_full_screen_intent_settings",
+        "get_currently_ringing_alarm",
+    ];
 
     const DEFAULT_TOML: &str = include_str!("../permissions/default.toml");
 

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -238,7 +238,7 @@ impl<R: Runtime> AlarmManager<R> {
         #[cfg(target_os = "android")]
         return self
             .handle
-            .run_mobile_plugin::<FullScreenIntentPermission>("checkFullScreenIntentPermission", ())
+            .run_mobile_plugin::<PermissionStatus>("checkFullScreenIntentPermission", ())
             .map(|r| r.granted)
             .map_err(Into::into);
 
@@ -252,6 +252,58 @@ impl<R: Runtime> AlarmManager<R> {
         return self
             .handle
             .run_mobile_plugin("openFullScreenIntentSettings", ())
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// Whether Android will schedule this app's alarms exactly rather than silently degrading
+    /// to an inexact window. Always `true` on desktop/pre-API-31.
+    pub fn check_exact_alarm_permission(&self) -> crate::Result<bool> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin::<PermissionStatus>("checkExactAlarmPermission", ())
+            .map(|r| r.granted)
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// Opens the OS settings screen for the exact-alarm-scheduling special permission.
+    pub fn open_exact_alarm_settings(&self) -> crate::Result<()> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin("openExactAlarmSettings", ())
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// Whether this app is exempted from Doze/App Standby battery optimization. Always `true`
+    /// on desktop, where the concept doesn't apply.
+    pub fn check_battery_optimization_exemption(&self) -> crate::Result<bool> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin::<PermissionStatus>("checkBatteryOptimizationExemption", ())
+            .map(|r| r.granted)
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// Opens the OS settings screen for the battery-optimization exemption request.
+    pub fn open_battery_optimization_settings(&self) -> crate::Result<()> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin("openBatteryOptimizationSettings", ())
             .map_err(Into::into);
 
         #[cfg(not(target_os = "android"))]

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -232,6 +232,46 @@ impl<R: Runtime> AlarmManager<R> {
         Err(not_implemented_on_ios())
     }
 
+    /// Whether Android will actually honour the ringing notification's full-screen intent.
+    /// Always `true` on desktop/pre-API-34, where the concept doesn't apply.
+    pub fn check_full_screen_intent_permission(&self) -> crate::Result<bool> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin::<FullScreenIntentPermission>("checkFullScreenIntentPermission", ())
+            .map(|r| r.granted)
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// Opens the OS settings screen for the full-screen-intent special permission.
+    pub fn open_full_screen_intent_settings(&self) -> crate::Result<()> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin("openFullScreenIntentSettings", ())
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
+    /// The alarm ID `AlarmRingingService` is currently ringing for, if any -- a fallback for
+    /// the frontend to detect an active alarm outside the normal deep-link launch path.
+    pub fn get_currently_ringing_alarm(&self) -> crate::Result<Option<i32>> {
+        #[cfg(target_os = "android")]
+        return self
+            .handle
+            .run_mobile_plugin::<CurrentlyRingingAlarm>("getCurrentlyRingingAlarm", ())
+            .map(|r| r.id)
+            .map_err(Into::into);
+
+        #[cfg(not(target_os = "android"))]
+        Err(not_implemented_on_ios())
+    }
+
     pub fn mark_alarm_pipeline_ready(&self) -> crate::Result<()> {
         #[cfg(not(target_os = "android"))]
         {

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -85,6 +85,18 @@ pub struct NativeDismissRequestedPayload {
     pub id: i32,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FullScreenIntentPermission {
+    pub granted: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrentlyRingingAlarm {
+    pub id: Option<i32>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -85,9 +85,12 @@ pub struct NativeDismissRequestedPayload {
     pub id: i32,
 }
 
+/// Shared response shape for the plugin's various silently-degrading-permission checks
+/// (full-screen intent, exact alarm scheduling, battery optimization exemption) -- they're
+/// structurally identical, so one type covers all three rather than one per permission.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FullScreenIntentPermission {
+pub struct PermissionStatus {
     pub granted: bool,
 }
 

--- a/plugins/os-prefs/android/src/main/java/ca/liminalhq/threshold/osprefs/OsPrefsPlugin.kt
+++ b/plugins/os-prefs/android/src/main/java/ca/liminalhq/threshold/osprefs/OsPrefsPlugin.kt
@@ -6,6 +6,7 @@
 package ca.liminalhq.threshold.osprefs
 
 import android.app.Activity
+import android.content.Intent
 import android.util.Log
 import android.text.format.DateFormat
 import android.provider.Settings
@@ -45,5 +46,19 @@ class OsPrefsPlugin(private val activity: Activity) : Plugin(activity) {
         val ret = JSObject()
         ret.put("scale", scale)
         invoke.resolve(ret)
+    }
+
+    // Generic OS settings jump, not alarm-specific -- POST_NOTIFICATIONS governs every
+    // notification the app posts, not just alarm ringing, so it lives here rather than in
+    // the alarm-manager plugin. Current grant status is queried directly from the frontend via
+    // @tauri-apps/plugin-notification's isPermissionGranted(); this only covers the recovery
+    // path once a user has denied it, since requesting again doesn't reshow the OS dialog.
+    @Command
+    fun openNotificationSettings(invoke: Invoke) {
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, activity.packageName)
+        }
+        activity.startActivity(intent)
+        invoke.resolve()
     }
 }

--- a/plugins/os-prefs/build.rs
+++ b/plugins/os-prefs/build.rs
@@ -3,7 +3,11 @@
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-const COMMANDS: &[&str] = &["get_time_format", "get_animator_duration_scale"];
+const COMMANDS: &[&str] = &[
+    "get_time_format",
+    "get_animator_duration_scale",
+    "open_notification_settings",
+];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS)

--- a/plugins/os-prefs/guest-js/index.ts
+++ b/plugins/os-prefs/guest-js/index.ts
@@ -21,3 +21,8 @@ export async function getTimeFormat(): Promise<TimeFormatResponse> {
 export async function getAnimatorDurationScale(): Promise<AnimatorDurationScaleResponse> {
 	return await invoke<AnimatorDurationScaleResponse>('plugin:os-prefs|get_animator_duration_scale');
 }
+
+/** Opens the OS notification settings screen for this app. */
+export async function openNotificationSettings(): Promise<void> {
+	await invoke('plugin:os-prefs|open_notification_settings');
+}

--- a/plugins/os-prefs/permissions/autogenerated/commands/open_notification_settings.toml
+++ b/plugins/os-prefs/permissions/autogenerated/commands/open_notification_settings.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-open-notification-settings"
+description = "Enables the open_notification_settings command without any pre-configured scope."
+commands.allow = ["open_notification_settings"]
+
+[[permission]]
+identifier = "deny-open-notification-settings"
+description = "Denies the open_notification_settings command without any pre-configured scope."
+commands.deny = ["open_notification_settings"]

--- a/plugins/os-prefs/permissions/autogenerated/reference.md
+++ b/plugins/os-prefs/permissions/autogenerated/reference.md
@@ -6,6 +6,7 @@ Default permissions for the os-prefs plugin
 
 - `allow-get-time-format`
 - `allow-get-animator-duration-scale`
+- `allow-open-notification-settings`
 
 ## Permission Table
 
@@ -64,6 +65,32 @@ Enables the get_time_format command without any pre-configured scope.
 <td>
 
 Denies the get_time_format command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`os-prefs:allow-open-notification-settings`
+
+</td>
+<td>
+
+Enables the open_notification_settings command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`os-prefs:deny-open-notification-settings`
+
+</td>
+<td>
+
+Denies the open_notification_settings command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/os-prefs/permissions/default.toml
+++ b/plugins/os-prefs/permissions/default.toml
@@ -3,4 +3,5 @@ description = "Default permissions for the os-prefs plugin"
 permissions = [
     "allow-get-time-format",
     "allow-get-animator-duration-scale",
+    "allow-open-notification-settings",
 ]

--- a/plugins/os-prefs/permissions/schemas/schema.json
+++ b/plugins/os-prefs/permissions/schemas/schema.json
@@ -319,10 +319,22 @@
           "markdownDescription": "Denies the get_time_format command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the os-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`\n- `allow-get-animator-duration-scale`",
+          "description": "Enables the open_notification_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-open-notification-settings",
+          "markdownDescription": "Enables the open_notification_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_notification_settings command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-open-notification-settings",
+          "markdownDescription": "Denies the open_notification_settings command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the os-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`\n- `allow-get-animator-duration-scale`\n- `allow-open-notification-settings`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the os-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`\n- `allow-get-animator-duration-scale`"
+          "markdownDescription": "Default permissions for the os-prefs plugin\n#### This default permission set includes:\n\n- `allow-get-time-format`\n- `allow-get-animator-duration-scale`\n- `allow-open-notification-settings`"
         }
       ]
     }

--- a/plugins/os-prefs/src/commands.rs
+++ b/plugins/os-prefs/src/commands.rs
@@ -20,3 +20,8 @@ pub(crate) async fn get_animator_duration_scale<R: Runtime>(
 ) -> Result<AnimatorDurationScaleResponse> {
     app.os_prefs().get_animator_duration_scale()
 }
+
+#[command]
+pub(crate) async fn open_notification_settings<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    app.os_prefs().open_notification_settings()
+}

--- a/plugins/os-prefs/src/desktop.rs
+++ b/plugins/os-prefs/src/desktop.rs
@@ -29,4 +29,9 @@ impl<R: Runtime> OsPrefs<R> {
         // No equivalent desktop setting wired up -- always full speed.
         Ok(AnimatorDurationScaleResponse { scale: 1.0 })
     }
+
+    /// Not an Android concept; nothing to open.
+    pub fn open_notification_settings(&self) -> crate::Result<()> {
+        Ok(())
+    }
 }

--- a/plugins/os-prefs/src/lib.rs
+++ b/plugins/os-prefs/src/lib.rs
@@ -42,7 +42,8 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("os-prefs")
         .invoke_handler(tauri::generate_handler![
             commands::get_time_format,
-            commands::get_animator_duration_scale
+            commands::get_animator_duration_scale,
+            commands::open_notification_settings
         ])
         .setup(|app, api| {
             #[cfg(mobile)]

--- a/plugins/os-prefs/src/mobile.rs
+++ b/plugins/os-prefs/src/mobile.rs
@@ -68,4 +68,20 @@ impl<R: Runtime> OsPrefs<R> {
             Ok(AnimatorDurationScaleResponse { scale: 1.0 })
         }
     }
+
+    /// Opens the OS notification settings screen for this app.
+    pub fn open_notification_settings(&self) -> crate::Result<()> {
+        #[cfg(target_os = "android")]
+        {
+            self.handle
+                .run_mobile_plugin("openNotificationSettings", ())
+                .map_err(Into::into)
+        }
+
+        #[cfg(target_os = "ios")]
+        {
+            // Stub implementation for iOS -- no equivalent settings deep link wired up yet.
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Android 14+ silently downgrades the ringing notification's full-screen intent to an ordinary heads-up banner when the `USE_FULL_SCREEN_INTENT` special permission is off, with no error or callback -- the ringing screen never appears over the lock screen. This adds a `canUseFullScreenIntent()` check plus a Settings screen banner that prompts the user to `ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` to re-enable it.

Independent of that, ringing-screen navigation was otherwise 100% dependent on the notification's full-screen-intent deep link -- reopening the app manually while an alarm is still ringing (or any other missed launch) left no way back in short of tapping the original notification. `getCurrentlyRingingAlarm()` now exposes `AlarmRingingService`'s native ringing state as a fallback, checked once at startup and again on every window focus regain.

On top of that, a Developer settings diagnostic now covers the other Android permissions/OS states that can silently degrade alarm reliability the same way: exact-alarm scheduling, battery-optimization exemption, and notifications (the one of the four with a normal Allow/Deny dialog, included here for the recovery path once denied). A bigger "dedicated alarm-health screen, possibly tied into a future onboarding flow" idea came up during that work and is captured separately in #283 rather than folded into this PR.

Fixes #281

## Changes

- `AlarmManagerPlugin.kt`: `checkFullScreenIntentPermission`/`openFullScreenIntentSettings`, `checkExactAlarmPermission`/`openExactAlarmSettings`, `checkBatteryOptimizationExemption`/`openBatteryOptimizationSettings`, `getCurrentlyRingingAlarm` commands.
- `AlarmRingingService.kt`: tracks `currentlyRingingAlarmId` statically so the plugin command has something to read.
- `OsPrefsPlugin.kt`: `openNotificationSettings` -- lives here rather than alarm-manager since `POST_NOTIFICATIONS` covers every notification the app posts, not just alarm ringing.
- Rust (`plugins/alarm-manager`, `plugins/os-prefs`): matching commands wired through `mobile.rs`/`desktop.rs`/`commands.rs`/`lib.rs`, ACL permissions added, autogenerated permission files regenerated. The three alarm-manager permission checks share one `PermissionStatus { granted: bool }` response type rather than one struct each.
- `guest-js/index.ts` (both plugins): TS bindings for the new commands.
- `DeepLinkService.ts`: new `checkForActiveRingingAlarm()`, called after cold-start deep link handling and on every window focus regain (`App.tsx`).
- `Settings.tsx`: Alarm Settings still shows the full-screen-intent warning banner (now reading from a consolidated `permissionStatus` state); Developer settings gets a new "Permissions" block listing live status for all four, each with a "Fix" button that deep-links to the right OS settings screen. Rechecked on mount and window focus regain.

## Test plan

- [x] `cargo check`/`cargo test` for `alarm-manager`, `os-prefs`, and the `threshold` app (desktop target)
- [x] `pnpm -r run typecheck`
- [x] `pnpm --filter threshold test` (56 passing)
- [x] `cargo fmt --check` / `cargo clippy -D warnings` clean
- [x] `prettier --check` clean
- [x] Full Android debug build via the `ghcr.io/liminal-hq/tauri-dev-mobile` container (`scripts/build-android-dev.sh`), run twice (once per commit) -- Kotlin and the Rust plugins compile cleanly against a real Android target each time, APK produced
- [x] On-device functional verification of the full-screen-intent fix (permission toggle off/on, lock-screen ring, manual reopen while ringing) -- confirmed working: banner appeared, alarm rang with the degraded notification, manual reopen from the launcher correctly landed on the ringing screen
- [ ] On-device functional verification of the three new Developer settings diagnostic entries (exact-alarm, battery-optimization, notifications) -- not yet done, worth a pass before merge
