### PR TITLE
Release v0.3.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,52 @@ This document tracks all releases of the Threshold application.
 
 ---
 
+## Version 0.3.0
+
+**Release Date:** July 25, 2026
+**Status:** Released
+
+> [!NOTE]
+> This release fixes a bug where Android could silently disable the ringing screen's lock-screen takeover, adds a fallback so the ringing screen is always reachable even when that happens, and gives Settings > Developer a diagnostic panel for the handful of Android permissions that can silently degrade alarm reliability.
+
+### ✨ New Features
+
+**Alarm Permission Diagnostics**
+
+- Settings > Developer now shows live status for the four Android permissions/OS states that can silently degrade alarm reliability -- full-screen intent, exact-alarm scheduling, battery-optimization exemption, and notifications -- each with a "Fix" button that deep-links straight to the relevant OS settings screen
+
+### 🐛 Bug Fixes
+
+- Fixed the ringing screen not appearing over the lock screen when Android's full-screen-intent special permission is off (Android 14+), with a warning banner in Settings prompting the user to re-enable it
+- Added a fallback so the ringing screen is reachable even if the automatic full-screen launch is missed for any reason -- reopening the app manually, or switching back to it, now still routes to an active alarm
+- Fixed `minimizeApp` blocking on writing its native event log line
+- Fixed `pick_alarm_sound`'s open-ended picker wait tying up a shared runtime thread instead of awaiting asynchronously
+- Native event logs are now bridged into the existing log export feature (phone and Wear), so on-device failures are diagnosable from one export
+
+### 🛠️ Build and Release
+
+- Split Google Play deployment out of the `build-android` CI job
+- Fixed `release-build.yml` being schema-invalid due to secrets referenced in a step `if:`
+
+### 📚 Documentation
+
+- Added home screen widget SVG mockups for next-alarm and history widgets (design reference, no shipped code)
+
+### 📝 Technical Details
+
+**Major PRs Merged:**
+
+- [#282](https://github.com/liminal-hq/threshold/pull/282) - Detect the full-screen-intent permission and add a ringing-screen fallback, plus a Developer settings permissions diagnostic
+- [#266](https://github.com/liminal-hq/threshold/pull/266) - Bridge native event logs into the existing export feature
+
+**Commit/Contributor Summary (`0.2.0` → `0.3.0`):**
+
+- **Commits:** 23
+- **Merged PRs:** 7
+- **Contributors:** Scott Morris
+
+---
+
 ## Version 0.2.0
 
 **Release Date:** July 15, 2026

--- a/apps/threshold-wear/build.gradle.kts
+++ b/apps/threshold-wear/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "ca.liminalhq.threshold"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1000002000
-        versionName = "0.2.0"
+        versionCode = 1000003000
+        versionName = "0.3.0"
     }
 
     signingConfigs {

--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "threshold",
 	"private": true,
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/threshold/src-tauri/tauri.conf.json
+++ b/apps/threshold/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Threshold",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"identifier": "ca.liminalhq.threshold",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/distribution/whatsnew-wear/whatsnew-en-CA
+++ b/distribution/whatsnew-wear/whatsnew-en-CA
@@ -1,6 +1,2 @@
-🔔 What's New
-• Alarm scheduling now runs fully natively for better reliability
-
-🐛 Fixes
-• Fixed sync status getting stuck
-• Fixed a data-loss bug affecting active days on repeating alarms
+🔧 Behind the Scenes
+• Improved on-device diagnostics to help track down sync and ringing issues faster

--- a/distribution/whatsnew/whatsnew-en-CA
+++ b/distribution/whatsnew/whatsnew-en-CA
@@ -1,9 +1,7 @@
-🔔 What's New
-• Refreshed Home, Edit Alarm, and Settings screens with smoother animations
-• Predictive-back gesture support with a live screen peek
-• Alarm scheduling now runs fully natively for better reliability
-
 🐛 Fixes
-• Fixed a ghost notification left behind on alarm delete
-• Fixed scrolling getting stuck on some screens
-• Fixed sync issues with the Wear companion app
+• Fixed the ringing screen sometimes not appearing over the lock screen, with a Settings prompt to fix the underlying permission
+• Reopening the app while an alarm rings now always reaches the ringing screen
+• Fixed a couple of native alarm-sound and event-log bugs
+
+🔧 Developer Settings
+• Added a diagnostics panel showing the status of Android permissions that affect alarm reliability


### PR DESCRIPTION
## Summary

Version bump (0.2.0 → 0.3.0, minor) plus `RELEASE_NOTES.md` and both Play "What's new" texts for the release covering everything merged since v0.2.0 -- primarily #282 (the full-screen-intent permission fix, ringing-screen fallback, and Developer settings permissions diagnostic), plus the native event-log bridging, picker/minimizeApp fixes, and CI/build cleanup already on `main`.

## Changes

- `apps/threshold/src-tauri/tauri.conf.json`, `apps/threshold/package.json`, `apps/threshold-wear/build.gradle.kts`: version bump to 0.3.0 (via `pnpm version:release --ci --bump minor`)
- `RELEASE_NOTES.md`: v0.3.0 entry
- `distribution/whatsnew/whatsnew-en-CA` / `distribution/whatsnew-wear/whatsnew-en-CA`: Play Store "What's new" copy for phone and Wear

## Next step

Once this merges, push the `v0.3.0` tag from the resulting merge commit to trigger `release-build.yml` (signed builds, GitHub Release, Play Console internal-track drafts).