### PR TITLE
Fix the Play deploy CI job never checking out the repo

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -647,6 +647,12 @@ jobs:
     env:
       PLAY_DEPLOY_READY: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
+      # Needed for whatsNewDirectory below (distribution/whatsnew, distribution/whatsnew-wear) --
+      # this job otherwise only downloads build artefacts, so it had no repo source at all.
+      # No submodules needed; distribution/ isn't part of vendor/tauri-plugins-workspace.
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Download Android artefacts
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

`deploy-android-play` was the one job in `release-build.yml` that never ran `actions/checkout` -- it only downloads build artefacts, so `distribution/whatsnew`/`distribution/whatsnew-wear` (passed as `whatsNewDirectory` to `r0adkll/upload-google-play`) never existed on the runner. This surfaced for the first time in the real `v0.3.0` release run: the phone `.aab` uploaded fine, then the job crashed with `ENOENT` scanning `distribution/whatsnew`, and the Wear deploy step never even ran (GitHub Actions halts remaining steps in a job by default once one fails).

Fixes #286

## Change

Adds a plain `actions/checkout@v6` (no `submodules: recursive` -- `distribution/` isn't part of the `vendor/tauri-plugins-workspace` submodule) as the first step of `deploy-android-play`, matching every other job in this workflow.

## Test plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Real validation is re-running the release workflow for `v0.3.0` after this merges -- can't dry-run a GitHub Actions workflow file locally