### PR TITLE
Warm main's build caches so new PR branches aren't always cold

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,14 @@ name: Test
 
 on:
   pull_request:
+  # Also run on push to main solely to warm test-rust/test-kotlin-*'s caches under main's own
+  # branch scope -- GitHub Actions caches only fall back current branch -> base branch -> default
+  # branch, and with no push-to-main trigger at all, no cache ever existed at that fallback tier.
+  # Every brand-new PR branch's first run was a guaranteed full cold compile forever, not just
+  # until some cache warmed up. The lint/typecheck/report jobs below stay pull_request-only via
+  # their own `if:` since they don't populate any cache and add nothing by re-running on merge.
+  push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,6 +18,7 @@ concurrency:
 jobs:
   test-js:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -56,6 +65,7 @@ jobs:
 
   lint-mermaid:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -79,6 +89,7 @@ jobs:
 
   check-license-headers:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -323,7 +334,7 @@ jobs:
 
   report:
     runs-on: ubuntu-24.04
-    if: always()
+    if: always() && github.event_name == 'pull_request'
     needs:
       [
         test-js,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
 
   test-rust:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -159,6 +160,7 @@ jobs:
 
   test-kotlin-wear:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       contents: read
       packages: read
@@ -194,6 +196,7 @@ jobs:
 
   test-kotlin-plugins:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary

Analyzed CI job timings across recent runs and found `test-rust` swinging from 22s to 5m58s between two otherwise-similar PRs. Root cause confirmed from the raw logs: `test.yml` only triggers `on: pull_request`, so no build cache is ever saved under `main`'s branch scope. GitHub Actions caches fall back current branch -> base branch -> default branch -- with nothing at that last tier, every brand-new PR branch's *first* CI run is a guaranteed full cold compile, permanently, not something that self-heals.

Fixes #288

## Change

- Added `push: branches: [main]` to `test.yml`'s triggers.
- Scoped it so only the cache-populating jobs (`test-rust`, `test-kotlin-wear`, `test-kotlin-plugins`) actually run on that trigger. `test-js`, `lint-mermaid`, `check-license-headers`, and `report` are gated behind `if: github.event_name == 'pull_request'`, since they add no cache value and `report`'s artifact-download steps would otherwise break against jobs that were skipped on a push-triggered run.

## Test plan

- [x] YAML parses cleanly
- [ ] Real validation is the next merge to `main` actually populating `main`-scoped caches, and the *following* new branch's first run seeing a faster `test-rust`/`test-kotlin-*` -- can't simulate branch-scoped cache fallback locally