### PR TITLE
Add the shared native event bus plugin (native-bus)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,15 +244,8 @@ jobs:
             exit 1
           fi
 
-          # $2 (optional) is extra literal settings.gradle.kts lines appended after the
-          # tauri-android include -- used below to pre-wire alarm-manager/wear-sync's
-          # isolated CI builds with a `:tauri-plugin-native-bus` project include before
-          # either plugin actually depends on it in build.gradle.kts (a later phase adds
-          # that Gradle project dependency; without this pre-wiring, that phase's
-          # per-plugin CI build would fail to resolve the project reference).
           write_kts_settings() {
             local plugin_dir="$1"
-            local extra_includes="${2:-}"
             cat > "${plugin_dir}/settings.gradle.kts" <<EOF
           pluginManagement {
             repositories {
@@ -280,7 +273,6 @@ jobs:
 
           include(":tauri-android")
           project(":tauri-android").projectDir = file("${TAURI_ANDROID_PATH}")
-          ${extra_includes}
           EOF
           }
 
@@ -320,16 +312,20 @@ jobs:
           EOF
           }
 
-          NATIVE_BUS_ANDROID_PATH="$(pwd)/plugins/native-bus/android"
-          NATIVE_BUS_PROJECT_INCLUDE_KTS="
-          include(\":tauri-plugin-native-bus\")
-          project(\":tauri-plugin-native-bus\").projectDir = file(\"${NATIVE_BUS_ANDROID_PATH}\")"
-
-          write_kts_settings "plugins/alarm-manager/android" "${NATIVE_BUS_PROJECT_INCLUDE_KTS}"
+          # alarm-manager and wear-sync don't depend on native-bus yet, so their settings
+          # deliberately don't include `:tauri-plugin-native-bus` -- the unqualified
+          # `testDebugUnitTest` selector used below runs a task in every project in the
+          # build graph that has it, so including it in more than one plugin's settings
+          # would run native-bus's own tests redundantly on every one of those runs, and
+          # (since this step runs under errexit) could misattribute a native-bus test
+          # failure to whichever plugin's line happened to trigger it first. A later phase
+          # of issue #255 adds both the real Gradle project dependency and this
+          # settings-synthesis line together, at the point they're actually needed.
+          write_kts_settings "plugins/alarm-manager/android"
           write_kts_settings "plugins/theme-utils/android"
           write_kts_settings "plugins/os-prefs/android"
           write_kts_settings "plugins/predictive-back/android"
-          write_kts_settings "plugins/wear-sync/android" "${NATIVE_BUS_PROJECT_INCLUDE_KTS}"
+          write_kts_settings "plugins/wear-sync/android"
           write_kts_settings "plugins/native-bus/android"
           write_groovy_settings "plugins/app-management/android"
           write_groovy_settings "plugins/toast/android"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,8 +244,15 @@ jobs:
             exit 1
           fi
 
+          # $2 (optional) is extra literal settings.gradle.kts lines appended after the
+          # tauri-android include -- used below to pre-wire alarm-manager/wear-sync's
+          # isolated CI builds with a `:tauri-plugin-native-bus` project include before
+          # either plugin actually depends on it in build.gradle.kts (a later phase adds
+          # that Gradle project dependency; without this pre-wiring, that phase's
+          # per-plugin CI build would fail to resolve the project reference).
           write_kts_settings() {
             local plugin_dir="$1"
+            local extra_includes="${2:-}"
             cat > "${plugin_dir}/settings.gradle.kts" <<EOF
           pluginManagement {
             repositories {
@@ -273,6 +280,7 @@ jobs:
 
           include(":tauri-android")
           project(":tauri-android").projectDir = file("${TAURI_ANDROID_PATH}")
+          ${extra_includes}
           EOF
           }
 
@@ -312,11 +320,17 @@ jobs:
           EOF
           }
 
-          write_kts_settings "plugins/alarm-manager/android"
+          NATIVE_BUS_ANDROID_PATH="$(pwd)/plugins/native-bus/android"
+          NATIVE_BUS_PROJECT_INCLUDE_KTS="
+          include(\":tauri-plugin-native-bus\")
+          project(\":tauri-plugin-native-bus\").projectDir = file(\"${NATIVE_BUS_ANDROID_PATH}\")"
+
+          write_kts_settings "plugins/alarm-manager/android" "${NATIVE_BUS_PROJECT_INCLUDE_KTS}"
           write_kts_settings "plugins/theme-utils/android"
           write_kts_settings "plugins/os-prefs/android"
           write_kts_settings "plugins/predictive-back/android"
-          write_kts_settings "plugins/wear-sync/android"
+          write_kts_settings "plugins/wear-sync/android" "${NATIVE_BUS_PROJECT_INCLUDE_KTS}"
+          write_kts_settings "plugins/native-bus/android"
           write_groovy_settings "plugins/app-management/android"
           write_groovy_settings "plugins/toast/android"
 
@@ -327,6 +341,7 @@ jobs:
           ./apps/threshold-wear/gradlew -p plugins/predictive-back/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
           ./apps/threshold-wear/gradlew -p plugins/wear-sync/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
           ./apps/threshold-wear/gradlew -p plugins/toast/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
+          ./apps/threshold-wear/gradlew -p plugins/native-bus/android testDebugUnitTest -Pandroid.useAndroidX=true --no-daemon
 
       - name: Upload Kotlin Test Results
         uses: actions/upload-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5028,6 +5028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-native-bus"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "git+https://github.com/ScottMorris/tauri-plugins-workspace.git?branch=notification-actions-fix#45004aa01a3b6752221142b42d8f1a48a7f65bc0"
@@ -5383,6 +5393,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-mcp-bridge",
+ "tauri-plugin-native-bus",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-os",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "plugins/theme-utils",
     "plugins/os-prefs",
     "plugins/toast",
+    "plugins/native-bus",
 ]
 exclude = ["vendor/tauri-plugins-workspace"]
 resolver = "2"

--- a/apps/threshold/src-tauri/Cargo.toml
+++ b/apps/threshold/src-tauri/Cargo.toml
@@ -24,6 +24,15 @@ tauri-plugin-theme-utils = { path = "../../../plugins/theme-utils" }
 tauri-plugin-app-management = { path = "../../../plugins/app-management" }
 tauri-plugin-wear-sync = { path = "../../../plugins/wear-sync" }
 tauri-plugin-toast = { path = "../../../plugins/toast" }
+# Direct dependency required even though nothing calls `.plugin()` on this crate yet.
+# Cargo's `links`/`DEP_*_ANDROID_LIBRARY_PATH` metadata (which `tauri-build`'s
+# `generate_gradle_files()` reads to auto-add a plugin's `android/` directory to the
+# generated `tauri.settings.gradle`/`app/tauri.build.gradle.kts`) only propagates to
+# direct dependents of this crate, not transitively through alarm-manager/wear-sync. A
+# later phase makes those two plugins depend on native-bus's Kotlin sources via a Gradle
+# project dependency; this direct Cargo dependency is what gets native-bus's `android/`
+# into the generated Android project graph in the first place.
+tauri-plugin-native-bus = { path = "../../../plugins/native-bus" }
 tauri-plugin-deep-link = { version = "2.0.0", features = [] }
 tauri-plugin-log = { version = "2.0.0", features = [] }
 tauri-plugin-notification = { git = "https://github.com/ScottMorris/tauri-plugins-workspace.git", branch = "notification-actions-fix" }

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -146,7 +146,8 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_app_management::init())
-        .plugin(tauri_plugin_toast::init());
+        .plugin(tauri_plugin_toast::init())
+        .plugin(tauri_plugin_native_bus::init());
 
     builder
         .setup(|app| {

--- a/plugins/native-bus/.gitignore
+++ b/plugins/native-bus/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/native-bus/Cargo.toml
+++ b/plugins/native-bus/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tauri-plugin-native-bus"
+version = "0.1.0"
+authors = ["Threshold"]
+edition = "2021"
+links = "tauri-plugin-native-bus"
+description = "Shared substrate carrying the Android NativeEventBus/DurableEventQueue Kotlin sources for Threshold's native plugins"
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[dependencies]
+tauri = { version = "2.0.0", features = [] }
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+
+[build-dependencies]
+tauri-plugin = { version = "2.0.0", features = ["build"] }

--- a/plugins/native-bus/android/build.gradle.kts
+++ b/plugins/native-bus/android/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "ca.liminalhq.threshold.nativebus"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    testOptions {
+        unitTests {
+            // NativeEventBus/DurableEventQueue call android.util.Log on error paths this
+            // module's own JUnit tests deliberately exercise (a throwing listener, a
+            // corrupt persisted entry). Without this, those calls hit Android's unmocked
+            // stub jar and throw instead of being no-ops under plain JUnit (no
+            // Robolectric in this codebase's test-kotlin-plugins CI job).
+            isReturnDefaultValues = true
+        }
+    }
+}
+
+dependencies {
+    compileOnly(project(":tauri-android"))
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
+
+    testImplementation("junit:junit:4.13.2")
+    // Real org.json, not Android's throw-on-call stub -- same fix already used by
+    // apps/threshold-wear's own JVM-only JSON parsing tests.
+    testImplementation("org.json:json:20231013")
+}

--- a/plugins/native-bus/android/src/main/AndroidManifest.xml
+++ b/plugins/native-bus/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/DurableEventQueue.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/DurableEventQueue.kt
@@ -1,0 +1,191 @@
+// Generic, per-plugin durable queue for events published before Rust/the webview is up
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+private const val TAG = "DurableEventQueue"
+
+/**
+ * A generic, reusable "queue events until Rust is up, then drain" log, backed by a
+ * single JSON array under one [KeyValueStore] key.
+ *
+ * Unlike [NativeEventBus], this is **not** a singleton -- each plugin that needs durable
+ * queuing instantiates its own `DurableEventQueue(store, prefsKey)` with a key distinct
+ * from every other plugin's, mirroring `WearSyncQueue`'s one-log-per-plugin shape (see
+ * `plugins/wear-sync/.../WearSyncQueue.kt`) rather than `AlarmManagerPlugin`'s older
+ * pattern of one separate queue per event *type* within a single plugin. One
+ * chronological log per plugin instance is enough: [drainAll] sorts by [Envelope.publishedAt]
+ * across every topic that instance has ever enqueued, so callers with several event
+ * kinds (the way `AlarmManagerPlugin` has fired/snooze/dismiss/import events today) don't
+ * need one `DurableEventQueue` per kind, just distinct `topic` strings on one instance.
+ *
+ * Persisted entries have survived across multiple days on real devices, so [drainAll]
+ * tolerates individual corrupt/malformed JSON entries (skips just that entry) and
+ * unrecognised/future [Envelope] schema versions (skips, doesn't crash) rather than
+ * failing the whole drain.
+ */
+class DurableEventQueue(
+    private val store: KeyValueStore,
+    private val prefsKey: String,
+) {
+
+    /** One persisted, drained event. */
+    data class Envelope(
+        val topic: String,
+        val payload: String,
+        val eventId: String,
+        val publishedAt: Long,
+        val handledNatively: Set<String>,
+    )
+
+    /**
+     * Appends a new entry for [topic] with opaque, caller-defined [payload] JSON.
+     *
+     * @param handledNatively tags describing what native code already did with this
+     *   event before it could be handed to Rust (e.g. "vibrated", "notified") -- carried
+     *   through so a later Rust-side handler knows not to redo that work.
+     * @return the generated event ID.
+     */
+    @Synchronized
+    fun enqueue(topic: String, payload: String, handledNatively: Set<String> = emptySet()): String {
+        val eventId = java.util.UUID.randomUUID().toString()
+        val array = readArray()
+        array.put(
+            JSONObject().apply {
+                put(KEY_VERSION, SCHEMA_VERSION)
+                put(KEY_TOPIC, topic)
+                put(KEY_PAYLOAD, payload)
+                put(KEY_EVENT_ID, eventId)
+                put(KEY_PUBLISHED_AT, System.currentTimeMillis())
+                put(KEY_HANDLED_NATIVELY, JSONArray(handledNatively.toList()))
+            },
+        )
+        writeArray(array)
+        return eventId
+    }
+
+    /**
+     * Returns every persisted entry across every topic, in chronological
+     * [Envelope.publishedAt] order, or an empty list if [pipelineReady] is `false`.
+     *
+     * This does not remove anything from the log -- call [commit] (or [clear]) once the
+     * caller has actually handed the drained entries off successfully, mirroring
+     * `WearSyncQueue`/`AlarmManagerPlugin`'s existing "only drop what was actually
+     * delivered" behaviour rather than assuming delivery always succeeds.
+     */
+    @Synchronized
+    fun drainAll(pipelineReady: Boolean): List<Envelope> {
+        if (!pipelineReady) return emptyList()
+        return parseEnvelopes(readArray()).sortedBy { it.publishedAt }
+    }
+
+    /**
+     * Removes only the entries whose [Envelope.eventId] is in [handledEventIds], leaving
+     * everything else in place for a later retry -- mirrors `AlarmManagerPlugin`'s
+     * existing per-event-type drain, which re-persists whichever items failed to
+     * dispatch and drops only the ones that succeeded.
+     */
+    @Synchronized
+    fun commit(handledEventIds: Set<String>) {
+        if (handledEventIds.isEmpty()) return
+        val remaining = parseEnvelopes(readArray()).filterNot { it.eventId in handledEventIds }
+        writeArray(toJsonArray(remaining))
+    }
+
+    /**
+     * Drops every persisted entry unconditionally -- mirrors `WearSyncQueue.drainAll`'s
+     * existing behaviour of clearing the whole log once its caller has taken ownership
+     * of every message it returned.
+     */
+    @Synchronized
+    fun clear() {
+        store.remove(prefsKey)
+    }
+
+    private fun readArray(): JSONArray {
+        val raw = store.get(prefsKey) ?: return JSONArray()
+        return try {
+            JSONArray(raw)
+        } catch (e: Exception) {
+            Log.w(TAG, "Corrupt event queue JSON under key '$prefsKey', discarding it entirely", e)
+            JSONArray()
+        }
+    }
+
+    private fun writeArray(array: JSONArray) {
+        store.set(prefsKey, array.toString())
+    }
+
+    private fun parseEnvelopes(array: JSONArray): List<Envelope> {
+        val envelopes = mutableListOf<Envelope>()
+        for (i in 0 until array.length()) {
+            val obj = array.optJSONObject(i)
+            if (obj == null) {
+                Log.w(TAG, "Skipping malformed queue entry at index $i (not a JSON object)")
+                continue
+            }
+            val version = obj.optInt(KEY_VERSION, -1)
+            if (version != SCHEMA_VERSION) {
+                Log.w(TAG, "Skipping queue entry at index $i with unrecognised schema version $version")
+                continue
+            }
+            try {
+                envelopes.add(
+                    Envelope(
+                        topic = obj.getString(KEY_TOPIC),
+                        payload = obj.getString(KEY_PAYLOAD),
+                        eventId = obj.getString(KEY_EVENT_ID),
+                        publishedAt = obj.getLong(KEY_PUBLISHED_AT),
+                        handledNatively = parseHandledNatively(obj.optJSONArray(KEY_HANDLED_NATIVELY)),
+                    ),
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Skipping malformed queue entry at index $i: ${e.message}")
+            }
+        }
+        return envelopes
+    }
+
+    private fun parseHandledNatively(tags: JSONArray?): Set<String> {
+        if (tags == null) return emptySet()
+        val result = mutableSetOf<String>()
+        for (i in 0 until tags.length()) {
+            tags.optString(i, null)?.let { result.add(it) }
+        }
+        return result
+    }
+
+    private fun toJsonArray(envelopes: List<Envelope>): JSONArray {
+        val array = JSONArray()
+        for (envelope in envelopes) {
+            array.put(
+                JSONObject().apply {
+                    put(KEY_VERSION, SCHEMA_VERSION)
+                    put(KEY_TOPIC, envelope.topic)
+                    put(KEY_PAYLOAD, envelope.payload)
+                    put(KEY_EVENT_ID, envelope.eventId)
+                    put(KEY_PUBLISHED_AT, envelope.publishedAt)
+                    put(KEY_HANDLED_NATIVELY, JSONArray(envelope.handledNatively.toList()))
+                },
+            )
+        }
+        return array
+    }
+
+    companion object {
+        const val SCHEMA_VERSION = 1
+
+        private const val KEY_VERSION = "v"
+        private const val KEY_TOPIC = "topic"
+        private const val KEY_PAYLOAD = "payload"
+        private const val KEY_EVENT_ID = "eventId"
+        private const val KEY_PUBLISHED_AT = "publishedAt"
+        private const val KEY_HANDLED_NATIVELY = "handledNatively"
+    }
+}

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/DurableEventQueue.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/DurableEventQueue.kt
@@ -12,23 +12,11 @@ import org.json.JSONObject
 private const val TAG = "DurableEventQueue"
 
 /**
- * A generic, reusable "queue events until Rust is up, then drain" log, backed by a
- * single JSON array under one [KeyValueStore] key.
+ * A generic, reusable "queue events until Rust is up, then drain" log, backed by a single JSON array under one [KeyValueStore] key.
  *
- * Unlike [NativeEventBus], this is **not** a singleton -- each plugin that needs durable
- * queuing instantiates its own `DurableEventQueue(store, prefsKey)` with a key distinct
- * from every other plugin's, mirroring `WearSyncQueue`'s one-log-per-plugin shape (see
- * `plugins/wear-sync/.../WearSyncQueue.kt`) rather than `AlarmManagerPlugin`'s older
- * pattern of one separate queue per event *type* within a single plugin. One
- * chronological log per plugin instance is enough: [drainAll] sorts by [Envelope.publishedAt]
- * across every topic that instance has ever enqueued, so callers with several event
- * kinds (the way `AlarmManagerPlugin` has fired/snooze/dismiss/import events today) don't
- * need one `DurableEventQueue` per kind, just distinct `topic` strings on one instance.
+ * Unlike [NativeEventBus], this is **not** a singleton -- each plugin that needs durable queuing instantiates its own `DurableEventQueue(store, prefsKey)` with a key distinct from every other plugin's, mirroring `WearSyncQueue`'s one-log-per-plugin shape (see `plugins/wear-sync/.../WearSyncQueue.kt`) rather than `AlarmManagerPlugin`'s older pattern of one separate queue per event *type* within a single plugin. One chronological log per plugin instance is enough: [drainAll] sorts by [Envelope.publishedAt] across every topic that instance has ever enqueued, so callers with several event kinds (the way `AlarmManagerPlugin` has fired/snooze/dismiss/import events today) don't need one `DurableEventQueue` per kind, just distinct `topic` strings on one instance.
  *
- * Persisted entries have survived across multiple days on real devices, so [drainAll]
- * tolerates individual corrupt/malformed JSON entries (skips just that entry) and
- * unrecognised/future [Envelope] schema versions (skips, doesn't crash) rather than
- * failing the whole drain.
+ * Persisted entries have survived across multiple days on real devices, so [drainAll] tolerates individual corrupt/malformed JSON entries (skips just that entry) and unrecognised/future [Envelope] schema versions (skips, doesn't crash) rather than failing the whole drain.
  */
 class DurableEventQueue(
     private val store: KeyValueStore,
@@ -47,9 +35,7 @@ class DurableEventQueue(
     /**
      * Appends a new entry for [topic] with opaque, caller-defined [payload] JSON.
      *
-     * @param handledNatively tags describing what native code already did with this
-     *   event before it could be handed to Rust (e.g. "vibrated", "notified") -- carried
-     *   through so a later Rust-side handler knows not to redo that work.
+     * @param handledNatively tags describing what native code already did with this event before it could be handed to Rust (e.g. "vibrated", "notified") -- carried through so a later Rust-side handler knows not to redo that work.
      * @return the generated event ID.
      */
     @Synchronized
@@ -71,13 +57,9 @@ class DurableEventQueue(
     }
 
     /**
-     * Returns every persisted entry across every topic, in chronological
-     * [Envelope.publishedAt] order, or an empty list if [pipelineReady] is `false`.
+     * Returns every persisted entry across every topic, in chronological [Envelope.publishedAt] order, or an empty list if [pipelineReady] is `false`.
      *
-     * This does not remove anything from the log -- call [commit] (or [clear]) once the
-     * caller has actually handed the drained entries off successfully, mirroring
-     * `WearSyncQueue`/`AlarmManagerPlugin`'s existing "only drop what was actually
-     * delivered" behaviour rather than assuming delivery always succeeds.
+     * This does not remove anything from the log -- call [commit] (or [clear]) once the caller has actually handed the drained entries off successfully, mirroring `WearSyncQueue`/`AlarmManagerPlugin`'s existing "only drop what was actually delivered" behaviour rather than assuming delivery always succeeds.
      */
     @Synchronized
     fun drainAll(pipelineReady: Boolean): List<Envelope> {
@@ -86,22 +68,24 @@ class DurableEventQueue(
     }
 
     /**
-     * Removes only the entries whose [Envelope.eventId] is in [handledEventIds], leaving
-     * everything else in place for a later retry -- mirrors `AlarmManagerPlugin`'s
-     * existing per-event-type drain, which re-persists whichever items failed to
-     * dispatch and drops only the ones that succeeded.
+     * Removes only the entries whose event ID is in [handledEventIds], leaving everything else in place for a later retry -- mirrors `AlarmManagerPlugin`'s existing per-event-type drain, which re-persists whichever items failed to dispatch and drops only the ones that succeeded. Filters the *raw* persisted JSON by ID (via [extractEventId]) rather than reconstructing the array from [parseEnvelopes]'s output, so an entry that fails full parsing -- e.g. the unrecognised-schema-version case [drainAll] tolerates -- is retained untouched instead of being silently discarded just because it couldn't be committed by its own ID.
      */
     @Synchronized
     fun commit(handledEventIds: Set<String>) {
         if (handledEventIds.isEmpty()) return
-        val remaining = parseEnvelopes(readArray()).filterNot { it.eventId in handledEventIds }
-        writeArray(toJsonArray(remaining))
+        val original = readArray()
+        val retained = JSONArray()
+        for (i in 0 until original.length()) {
+            val raw = original.opt(i)
+            val eventId = (raw as? JSONObject)?.let { extractEventId(it) }
+            if (eventId != null && eventId in handledEventIds) continue
+            retained.put(raw)
+        }
+        writeArray(retained)
     }
 
     /**
-     * Drops every persisted entry unconditionally -- mirrors `WearSyncQueue.drainAll`'s
-     * existing behaviour of clearing the whole log once its caller has taken ownership
-     * of every message it returned.
+     * Drops every persisted entry unconditionally -- mirrors `WearSyncQueue.drainAll`'s existing behaviour of clearing the whole log once its caller has taken ownership of every message it returned.
      */
     @Synchronized
     fun clear() {
@@ -152,6 +136,14 @@ class DurableEventQueue(
         return envelopes
     }
 
+    /**
+     * Pulls just the [KEY_EVENT_ID] field out of a raw persisted entry, without requiring the rest of it to parse into a full [Envelope] -- this is what lets [commit] correctly retain an entry with an unrecognised schema version (or other malformed fields) instead of losing it, while still recognising its ID if that happens to be the one being committed.
+     */
+    private fun extractEventId(obj: JSONObject): String? {
+        val id = obj.optString(KEY_EVENT_ID, "")
+        return id.ifEmpty { null }
+    }
+
     private fun parseHandledNatively(tags: JSONArray?): Set<String> {
         if (tags == null) return emptySet()
         val result = mutableSetOf<String>()
@@ -159,23 +151,6 @@ class DurableEventQueue(
             tags.optString(i, null)?.let { result.add(it) }
         }
         return result
-    }
-
-    private fun toJsonArray(envelopes: List<Envelope>): JSONArray {
-        val array = JSONArray()
-        for (envelope in envelopes) {
-            array.put(
-                JSONObject().apply {
-                    put(KEY_VERSION, SCHEMA_VERSION)
-                    put(KEY_TOPIC, envelope.topic)
-                    put(KEY_PAYLOAD, envelope.payload)
-                    put(KEY_EVENT_ID, envelope.eventId)
-                    put(KEY_PUBLISHED_AT, envelope.publishedAt)
-                    put(KEY_HANDLED_NATIVELY, JSONArray(envelope.handledNatively.toList()))
-                },
-            )
-        }
-        return array
     }
 
     companion object {

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
@@ -1,0 +1,48 @@
+// Minimal string key-value storage abstraction, so persistence-backed classes can be unit tested
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+import android.content.Context
+
+/**
+ * A tiny string-keyed, string-valued store.
+ *
+ * This exists purely so classes like [DurableEventQueue] can be unit tested against an
+ * in-memory fake instead of needing Robolectric or instrumentation tests -- this
+ * codebase's `test-kotlin-plugins` CI job runs plain JUnit 4 against the host JVM, with
+ * no Android framework available.
+ */
+interface KeyValueStore {
+    /** Returns the value for [key], or `null` if it has never been set. */
+    fun get(key: String): String?
+
+    /** Stores [value] under [key], overwriting any previous value. */
+    fun set(key: String, value: String)
+
+    /** Removes [key] entirely. A no-op if it was never set. */
+    fun remove(key: String)
+}
+
+/**
+ * Production [KeyValueStore] backed by a single [android.content.SharedPreferences] file.
+ */
+class SharedPreferencesKeyValueStore(
+    context: Context,
+    prefsName: String,
+) : KeyValueStore {
+
+    private val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+
+    override fun get(key: String): String? = prefs.getString(key, null)
+
+    override fun set(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+    }
+
+    override fun remove(key: String) {
+        prefs.edit().remove(key).apply()
+    }
+}

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
@@ -10,10 +10,7 @@ import android.content.Context
 /**
  * A tiny string-keyed, string-valued store.
  *
- * This exists purely so classes like [DurableEventQueue] can be unit tested against an
- * in-memory fake instead of needing Robolectric or instrumentation tests -- this
- * codebase's `test-kotlin-plugins` CI job runs plain JUnit 4 against the host JVM, with
- * no Android framework available.
+ * This exists purely so classes like [DurableEventQueue] can be unit tested against an in-memory fake instead of needing Robolectric or instrumentation tests -- this codebase's `test-kotlin-plugins` CI job runs plain JUnit 4 against the host JVM, with no Android framework available.
  */
 interface KeyValueStore {
     /** Returns the value for [key], or `null` if it has never been set. */

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/NativeEventBus.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/NativeEventBus.kt
@@ -1,0 +1,92 @@
+// Process-wide in-process pub/sub bus letting native plugin code talk to each other before Rust boots
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+private const val TAG = "NativeEventBus"
+
+/**
+ * A process-wide singleton letting different Android plugins' native code talk to each
+ * other in-process -- e.g. alarm-manager telling wear-sync an alarm fired -- without
+ * waiting for the Rust/WebView runtime to boot.
+ *
+ * ## Threading contract
+ *
+ * [publish] runs **synchronously, on the calling thread**. It does not post to a
+ * background thread, does not call `goAsync()`, and does not spawn a coroutine of its
+ * own -- a caller that needs any of that (most notably a `BroadcastReceiver`) is expected
+ * to arrange it itself around the call to [publish], not rely on this bus to do it for
+ * them.
+ *
+ * This is a deliberate design choice, and it matters concretely for the intended first
+ * real caller: `AlarmReceiver.onReceive()` (wired up in a later phase of issue #255).
+ * `onReceive()` runs on the main thread, and Android enforces a short ANR budget on
+ * broadcast delivery. A [subscribe]d listener that blocks inside [publish] -- touching
+ * disk, calling into Play Services, doing any I/O at all -- eats directly into that
+ * budget on every subscriber's behalf, and can freeze or ANR the whole app. So every
+ * listener registered here must honour this contract:
+ *
+ * - Do only cheap, non-blocking work inline: inspect `payload`, decide what to do.
+ * - Hand any blocking work off to your own single-threaded executor (or coroutine scope)
+ *   and return from the listener immediately -- do **not** block waiting for that work.
+ * - A non-null return value (a "tag") means "accepted for async handling", not "the work
+ *   is complete". [publish] only reports which listeners took ownership of the event; it
+ *   says nothing about whether that work has finished.
+ *
+ * ## Failure isolation
+ *
+ * Each listener is invoked inside its own `try`/`catch`. A listener that throws is
+ * logged and skipped -- it cannot prevent delivery to the other listeners registered for
+ * the same topic, and the exception never propagates back to [publish]'s caller.
+ */
+object NativeEventBus {
+
+    private val listenersByTopic = ConcurrentHashMap<String, CopyOnWriteArrayList<(String) -> String?>>()
+
+    /**
+     * Registers [listener] for [topic]. A topic may have any number of listeners,
+     * registered from any thread; delivery order among them is registration order.
+     *
+     * @param listener receives the published payload and may return a non-null tag
+     *   describing what it did (or is about to do asynchronously -- see the class KDoc's
+     *   threading contract). Returning `null` means "no tag to report".
+     */
+    fun subscribe(topic: String, listener: (payload: String) -> String?) {
+        listenersByTopic.computeIfAbsent(topic) { CopyOnWriteArrayList() }.add(listener)
+    }
+
+    /**
+     * Synchronously invokes every listener registered for [topic], in registration
+     * order, on the caller's thread. See the class KDoc for the threading contract this
+     * implies for listeners, and for the failure-isolation guarantee.
+     *
+     * @return the set of non-null tags returned by listeners that handled the event.
+     *   Empty if [topic] has no listeners, or if none of them returned a tag.
+     */
+    fun publish(topic: String, payload: String): Set<String> {
+        val listeners = listenersByTopic[topic] ?: return emptySet()
+        val tags = mutableSetOf<String>()
+        for (listener in listeners) {
+            try {
+                listener(payload)?.let { tags.add(it) }
+            } catch (e: Exception) {
+                Log.w(TAG, "Listener for topic '$topic' threw, skipping it for this publish", e)
+            }
+        }
+        return tags
+    }
+
+    /**
+     * Test-only: drops every registered listener. Production code must never call this --
+     * it exists so JUnit tests don't leak listener state between runs of this singleton.
+     */
+    fun resetForTests() {
+        listenersByTopic.clear()
+    }
+}

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/NativeEventBus.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/NativeEventBus.kt
@@ -12,62 +12,39 @@ import java.util.concurrent.CopyOnWriteArrayList
 private const val TAG = "NativeEventBus"
 
 /**
- * A process-wide singleton letting different Android plugins' native code talk to each
- * other in-process -- e.g. alarm-manager telling wear-sync an alarm fired -- without
- * waiting for the Rust/WebView runtime to boot.
+ * A process-wide singleton letting different Android plugins' native code talk to each other in-process -- e.g. alarm-manager telling wear-sync an alarm fired -- without waiting for the Rust/WebView runtime to boot.
  *
  * ## Threading contract
  *
- * [publish] runs **synchronously, on the calling thread**. It does not post to a
- * background thread, does not call `goAsync()`, and does not spawn a coroutine of its
- * own -- a caller that needs any of that (most notably a `BroadcastReceiver`) is expected
- * to arrange it itself around the call to [publish], not rely on this bus to do it for
- * them.
+ * [publish] runs **synchronously, on the calling thread**. It does not post to a background thread, does not call `goAsync()`, and does not spawn a coroutine of its own -- a caller that needs any of that (most notably a `BroadcastReceiver`) is expected to arrange it itself around the call to [publish], not rely on this bus to do it for them.
  *
- * This is a deliberate design choice, and it matters concretely for the intended first
- * real caller: `AlarmReceiver.onReceive()` (wired up in a later phase of issue #255).
- * `onReceive()` runs on the main thread, and Android enforces a short ANR budget on
- * broadcast delivery. A [subscribe]d listener that blocks inside [publish] -- touching
- * disk, calling into Play Services, doing any I/O at all -- eats directly into that
- * budget on every subscriber's behalf, and can freeze or ANR the whole app. So every
- * listener registered here must honour this contract:
+ * This is a deliberate design choice, and it matters concretely for the intended first real caller: `AlarmReceiver.onReceive()` (wired up in a later phase of issue #255). `onReceive()` runs on the main thread, and Android enforces a short ANR budget on broadcast delivery. A [subscribe]d listener that blocks inside [publish] -- touching disk, calling into Play Services, doing any I/O at all -- eats directly into that budget on every subscriber's behalf, and can freeze or ANR the whole app. So every listener registered here must honour this contract:
  *
  * - Do only cheap, non-blocking work inline: inspect `payload`, decide what to do.
- * - Hand any blocking work off to your own single-threaded executor (or coroutine scope)
- *   and return from the listener immediately -- do **not** block waiting for that work.
- * - A non-null return value (a "tag") means "accepted for async handling", not "the work
- *   is complete". [publish] only reports which listeners took ownership of the event; it
- *   says nothing about whether that work has finished.
+ * - Hand any blocking work off to your own single-threaded executor (or coroutine scope) and return from the listener immediately -- do **not** block waiting for that work.
+ * - A non-null return value (a "tag") means "accepted for async handling", not "the work is complete". [publish] only reports which listeners took ownership of the event; it says nothing about whether that work has finished.
  *
  * ## Failure isolation
  *
- * Each listener is invoked inside its own `try`/`catch`. A listener that throws is
- * logged and skipped -- it cannot prevent delivery to the other listeners registered for
- * the same topic, and the exception never propagates back to [publish]'s caller.
+ * Each listener is invoked inside its own `try`/`catch`. A listener that throws is logged and skipped -- it cannot prevent delivery to the other listeners registered for the same topic, and the exception never propagates back to [publish]'s caller.
  */
 object NativeEventBus {
 
     private val listenersByTopic = ConcurrentHashMap<String, CopyOnWriteArrayList<(String) -> String?>>()
 
     /**
-     * Registers [listener] for [topic]. A topic may have any number of listeners,
-     * registered from any thread; delivery order among them is registration order.
+     * Registers [listener] for [topic]. A topic may have any number of listeners, registered from any thread; delivery order among them is registration order.
      *
-     * @param listener receives the published payload and may return a non-null tag
-     *   describing what it did (or is about to do asynchronously -- see the class KDoc's
-     *   threading contract). Returning `null` means "no tag to report".
+     * @param listener receives the published payload and may return a non-null tag describing what it did (or is about to do asynchronously -- see the class KDoc's threading contract). Returning `null` means "no tag to report".
      */
     fun subscribe(topic: String, listener: (payload: String) -> String?) {
         listenersByTopic.computeIfAbsent(topic) { CopyOnWriteArrayList() }.add(listener)
     }
 
     /**
-     * Synchronously invokes every listener registered for [topic], in registration
-     * order, on the caller's thread. See the class KDoc for the threading contract this
-     * implies for listeners, and for the failure-isolation guarantee.
+     * Synchronously invokes every listener registered for [topic], in registration order, on the caller's thread. See the class KDoc for the threading contract this implies for listeners, and for the failure-isolation guarantee.
      *
-     * @return the set of non-null tags returned by listeners that handled the event.
-     *   Empty if [topic] has no listeners, or if none of them returned a tag.
+     * @return the set of non-null tags returned by listeners that handled the event. Empty if [topic] has no listeners, or if none of them returned a tag.
      */
     fun publish(topic: String, payload: String): Set<String> {
         val listeners = listenersByTopic[topic] ?: return emptySet()
@@ -83,8 +60,7 @@ object NativeEventBus {
     }
 
     /**
-     * Test-only: drops every registered listener. Production code must never call this --
-     * it exists so JUnit tests don't leak listener state between runs of this singleton.
+     * Test-only: drops every registered listener. Production code must never call this -- it exists so JUnit tests don't leak listener state between runs of this singleton.
      */
     fun resetForTests() {
         listenersByTopic.clear()

--- a/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/DurableEventQueueTest.kt
+++ b/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/DurableEventQueueTest.kt
@@ -118,6 +118,22 @@ class DurableEventQueueTest {
     }
 
     @Test
+    fun `commit retains an unparseable future-schema-version entry instead of silently dropping it`() {
+        val array = JSONArray()
+        array.put(envelope(topic = "a", payload = "good", eventId = "id-1", publishedAt = 100))
+        array.put(envelope(topic = "a", payload = "future", eventId = "id-future", publishedAt = 150, version = 99))
+        store.set(PREFS_KEY, array.toString())
+
+        queue.commit(setOf("id-1"))
+
+        // drainAll() can't see the future-version entry (parseEnvelopes still skips it), so
+        // assert directly against the raw persisted JSON that commit() actually rewrote.
+        val persisted = JSONArray(store.get(PREFS_KEY))
+        assertEquals(1, persisted.length())
+        assertEquals("id-future", persisted.getJSONObject(0).getString("eventId"))
+    }
+
+    @Test
     fun `clear drops every persisted entry unconditionally`() {
         queue.enqueue("topic", "one")
         queue.enqueue("topic", "two")

--- a/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/DurableEventQueueTest.kt
+++ b/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/DurableEventQueueTest.kt
@@ -1,0 +1,155 @@
+// Unit tests for DurableEventQueue
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/** Plain JUnit 4 tests against an in-memory [KeyValueStore] fake -- no Robolectric needed. */
+class DurableEventQueueTest {
+
+    private lateinit var store: InMemoryKeyValueStore
+    private lateinit var queue: DurableEventQueue
+
+    @Before
+    fun setUp() {
+        store = InMemoryKeyValueStore()
+        queue = DurableEventQueue(store, PREFS_KEY)
+    }
+
+    @Test
+    fun `entries drain in chronological order regardless of topic`() {
+        // enqueue() stamps publishedAt from the wall clock, so to pin ordering
+        // deterministically the raw envelopes are written directly into the store.
+        writeRawEnvelopes(
+            envelope(topic = "b", payload = "second", eventId = "id-2", publishedAt = 200),
+            envelope(topic = "a", payload = "first", eventId = "id-1", publishedAt = 100),
+            envelope(topic = "a", payload = "third", eventId = "id-3", publishedAt = 300),
+        )
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertEquals(listOf("id-1", "id-2", "id-3"), drained.map { it.eventId })
+    }
+
+    @Test
+    fun `handledNatively tags round-trip through enqueue, persist and drain`() {
+        queue.enqueue("topic", "payload", handledNatively = setOf("vibrated", "notified"))
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertEquals(setOf("vibrated", "notified"), drained.single().handledNatively)
+    }
+
+    @Test
+    fun `nothing drains while the pipeline is not ready`() {
+        queue.enqueue("topic", "payload")
+
+        val drainedWhileNotReady = queue.drainAll(pipelineReady = false)
+
+        assertTrue(drainedWhileNotReady.isEmpty())
+        // The entry must still be there once the pipeline does become ready.
+        assertEquals(1, queue.drainAll(pipelineReady = true).size)
+    }
+
+    @Test
+    fun `corrupt individual entries are skipped without failing the whole drain`() {
+        val array = JSONArray()
+        array.put(envelope(topic = "a", payload = "good-1", eventId = "id-1", publishedAt = 100))
+        array.put("not even a JSON object")
+        array.put(JSONObject().apply { put("v", 1) }) // missing required fields
+        array.put(envelope(topic = "a", payload = "good-2", eventId = "id-2", publishedAt = 200))
+        store.set(PREFS_KEY, array.toString())
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertEquals(listOf("id-1", "id-2"), drained.map { it.eventId })
+    }
+
+    @Test
+    fun `an entirely corrupt persisted log is tolerated as empty rather than crashing`() {
+        store.set(PREFS_KEY, "{not json at all")
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertTrue(drained.isEmpty())
+    }
+
+    @Test
+    fun `an unrecognised schema version is skipped rather than crashing the drain`() {
+        val array = JSONArray()
+        array.put(envelope(topic = "a", payload = "good", eventId = "id-1", publishedAt = 100))
+        array.put(envelope(topic = "a", payload = "future", eventId = "id-future", publishedAt = 150, version = 99))
+        store.set(PREFS_KEY, array.toString())
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertEquals(listOf("id-1"), drained.map { it.eventId })
+    }
+
+    @Test
+    fun `enqueue and drain work correctly across multiple topics mixed in one log`() {
+        queue.enqueue("topic-a", "payload-1")
+        queue.enqueue("topic-b", "payload-2")
+        queue.enqueue("topic-a", "payload-3")
+
+        val drained = queue.drainAll(pipelineReady = true)
+
+        assertEquals(listOf("topic-a", "topic-b", "topic-a"), drained.map { it.topic })
+        assertEquals(listOf("payload-1", "payload-2", "payload-3"), drained.map { it.payload })
+    }
+
+    @Test
+    fun `commit removes only the given event ids, leaving the rest for retry`() {
+        val id1 = queue.enqueue("topic", "one")
+        val id2 = queue.enqueue("topic", "two")
+
+        queue.commit(setOf(id1))
+
+        val remaining = queue.drainAll(pipelineReady = true)
+        assertEquals(listOf(id2), remaining.map { it.eventId })
+    }
+
+    @Test
+    fun `clear drops every persisted entry unconditionally`() {
+        queue.enqueue("topic", "one")
+        queue.enqueue("topic", "two")
+
+        queue.clear()
+
+        assertTrue(queue.drainAll(pipelineReady = true).isEmpty())
+    }
+
+    private fun envelope(
+        topic: String,
+        payload: String,
+        eventId: String,
+        publishedAt: Long,
+        version: Int = 1,
+    ): JSONObject =
+        JSONObject().apply {
+            put("v", version)
+            put("topic", topic)
+            put("payload", payload)
+            put("eventId", eventId)
+            put("publishedAt", publishedAt)
+            put("handledNatively", JSONArray())
+        }
+
+    private fun writeRawEnvelopes(vararg envelopes: JSONObject) {
+        val array = JSONArray()
+        envelopes.forEach { array.put(it) }
+        store.set(PREFS_KEY, array.toString())
+    }
+
+    companion object {
+        private const val PREFS_KEY = "test-queue"
+    }
+}

--- a/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/InMemoryKeyValueStore.kt
+++ b/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/InMemoryKeyValueStore.kt
@@ -1,0 +1,21 @@
+// In-memory KeyValueStore fake for JUnit tests -- no Android framework required
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+/** In-memory [KeyValueStore] fake, so tests don't need SharedPreferences/Robolectric. */
+class InMemoryKeyValueStore : KeyValueStore {
+    private val values = mutableMapOf<String, String>()
+
+    override fun get(key: String): String? = values[key]
+
+    override fun set(key: String, value: String) {
+        values[key] = value
+    }
+
+    override fun remove(key: String) {
+        values.remove(key)
+    }
+}

--- a/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/NativeEventBusTest.kt
+++ b/plugins/native-bus/android/src/test/java/ca/liminalhq/threshold/nativebus/NativeEventBusTest.kt
@@ -1,0 +1,112 @@
+// Unit tests for NativeEventBus
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.nativebus
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Plain JUnit 4 tests -- no Robolectric/instrumentation, [NativeEventBus] is pure Kotlin. */
+class NativeEventBusTest {
+
+    @After
+    fun tearDown() {
+        // NativeEventBus is a process-wide singleton; without this, listeners registered
+        // by one test would still be live (and firing) during the next one.
+        NativeEventBus.resetForTests()
+    }
+
+    @Test
+    fun `multiple listeners on the same topic are all invoked in registration order`() {
+        val received = mutableListOf<String>()
+        NativeEventBus.subscribe("topic-a") { payload -> received.add("first:$payload"); null }
+        NativeEventBus.subscribe("topic-a") { payload -> received.add("second:$payload"); null }
+
+        NativeEventBus.publish("topic-a", "hello")
+
+        assertEquals(listOf("first:hello", "second:hello"), received)
+    }
+
+    @Test
+    fun `a throwing listener does not block delivery to other listeners`() {
+        var secondListenerRan = false
+        NativeEventBus.subscribe("topic-b") { throw RuntimeException("boom") }
+        NativeEventBus.subscribe("topic-b") { secondListenerRan = true; null }
+
+        NativeEventBus.publish("topic-b", "payload")
+
+        assertTrue(secondListenerRan)
+    }
+
+    @Test
+    fun `a throwing listener does not propagate its exception to the publisher`() {
+        NativeEventBus.subscribe("topic-c") { throw IllegalStateException("boom") }
+
+        // Must return normally, not throw out of publish().
+        val tags = NativeEventBus.publish("topic-c", "payload")
+
+        assertTrue(tags.isEmpty())
+    }
+
+    @Test
+    fun `tags returned by multiple listeners are collected into one set`() {
+        NativeEventBus.subscribe("topic-d") { "tag-one" }
+        NativeEventBus.subscribe("topic-d") { "tag-two" }
+        NativeEventBus.subscribe("topic-d") { null }
+
+        val tags = NativeEventBus.publish("topic-d", "payload")
+
+        assertEquals(setOf("tag-one", "tag-two"), tags)
+    }
+
+    @Test
+    fun `duplicate tags from different listeners collapse into one entry`() {
+        NativeEventBus.subscribe("topic-e") { "same-tag" }
+        NativeEventBus.subscribe("topic-e") { "same-tag" }
+
+        val tags = NativeEventBus.publish("topic-e", "payload")
+
+        assertEquals(setOf("same-tag"), tags)
+    }
+
+    @Test
+    fun `publishing to a topic with no listeners returns an empty set without error`() {
+        val tags = NativeEventBus.publish("nobody-subscribed-to-this-topic", "payload")
+
+        assertTrue(tags.isEmpty())
+    }
+
+    @Test
+    fun `concurrent subscribe and publish does not lose or corrupt listener registrations`() {
+        val topic = "topic-concurrent"
+        val listenerCount = 50
+        val invocations = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(8)
+
+        try {
+            val registered = CountDownLatch(listenerCount)
+            val subscribeTasks = (0 until listenerCount).map {
+                executor.submit {
+                    NativeEventBus.subscribe(topic) { invocations.incrementAndGet(); null }
+                    registered.countDown()
+                }
+            }
+            subscribeTasks.forEach { it.get(5, TimeUnit.SECONDS) }
+            assertTrue(registered.await(5, TimeUnit.SECONDS))
+
+            NativeEventBus.publish(topic, "payload")
+
+            assertEquals(listenerCount, invocations.get())
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+}

--- a/plugins/native-bus/build.rs
+++ b/plugins/native-bus/build.rs
@@ -1,0 +1,32 @@
+// Build script registering the plugin's (currently empty) commands and Android module
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// No webview-invokable commands yet -- this crate exists to carry the Android Gradle
+// module (android/), not to expose any Rust logic. See docs/plugins/command-conventions.md
+// for why this stays empty rather than listing Rust-internal-only names.
+const COMMANDS: &[&str] = &[];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+
+    inject_android_permissions()
+        .expect("Failed to inject Android manifest permissions for native-bus");
+}
+
+fn inject_android_permissions() -> std::io::Result<()> {
+    let permissions: Vec<&str> = vec![
+        // No permissions required for native-bus.
+        // This block ensures the injection mechanism is present for future use.
+    ];
+
+    tauri_plugin::mobile::update_android_manifest(
+        "tauri-plugin-native-bus.permissions",
+        "manifest",
+        permissions.join("\n"),
+    )
+    .map_err(std::io::Error::other)
+}

--- a/plugins/native-bus/src/desktop.rs
+++ b/plugins/native-bus/src/desktop.rs
@@ -6,10 +6,7 @@
 use serde::de::DeserializeOwned;
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
-/// Desktop has no native event bus to bridge to -- `NativeEventBus` and
-/// `DurableEventQueue` are Android-only substrate for cross-plugin native code. This
-/// stub exists only to keep the mobile/desktop split symmetrical with every other
-/// plugin in this codebase.
+/// Desktop has no native event bus to bridge to -- `NativeEventBus` and `DurableEventQueue` are Android-only substrate for cross-plugin native code. This stub exists only to keep the mobile/desktop split symmetrical with every other plugin in this codebase.
 pub fn init<R: Runtime, C: DeserializeOwned>(
     _app: &AppHandle<R>,
     _api: PluginApi<R, C>,
@@ -17,6 +14,5 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
     Ok(NativeBus)
 }
 
-/// Marker state for the native-bus plugin on desktop. Carries no data -- see
-/// `mobile::NativeBus` for why this isn't generic over `Runtime` either.
+/// Marker state for the native-bus plugin on desktop. Carries no data -- see `mobile::NativeBus` for why this isn't generic over `Runtime` either.
 pub struct NativeBus;

--- a/plugins/native-bus/src/desktop.rs
+++ b/plugins/native-bus/src/desktop.rs
@@ -1,0 +1,21 @@
+// Desktop stub for the native-bus plugin
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use serde::de::DeserializeOwned;
+use tauri::{plugin::PluginApi, AppHandle, Runtime};
+
+/// Desktop has no native event bus to bridge to -- `NativeEventBus` and
+/// `DurableEventQueue` are Android-only substrate for cross-plugin native code. This
+/// stub exists only to keep the mobile/desktop split symmetrical with every other
+/// plugin in this codebase.
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> crate::Result<NativeBus<R>> {
+    Ok(NativeBus(app.clone()))
+}
+
+/// Marker state for the native-bus plugin on desktop.
+pub struct NativeBus<R: Runtime>(#[allow(dead_code)] AppHandle<R>);

--- a/plugins/native-bus/src/desktop.rs
+++ b/plugins/native-bus/src/desktop.rs
@@ -11,11 +11,12 @@ use tauri::{plugin::PluginApi, AppHandle, Runtime};
 /// stub exists only to keep the mobile/desktop split symmetrical with every other
 /// plugin in this codebase.
 pub fn init<R: Runtime, C: DeserializeOwned>(
-    app: &AppHandle<R>,
+    _app: &AppHandle<R>,
     _api: PluginApi<R, C>,
-) -> crate::Result<NativeBus<R>> {
-    Ok(NativeBus(app.clone()))
+) -> crate::Result<NativeBus> {
+    Ok(NativeBus)
 }
 
-/// Marker state for the native-bus plugin on desktop.
-pub struct NativeBus<R: Runtime>(#[allow(dead_code)] AppHandle<R>);
+/// Marker state for the native-bus plugin on desktop. Carries no data -- see
+/// `mobile::NativeBus` for why this isn't generic over `Runtime` either.
+pub struct NativeBus;

--- a/plugins/native-bus/src/error.rs
+++ b/plugins/native-bus/src/error.rs
@@ -1,0 +1,23 @@
+// Error type for native-bus plugin operations
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use serde::{Serialize, Serializer};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/plugins/native-bus/src/lib.rs
+++ b/plugins/native-bus/src/lib.rs
@@ -1,0 +1,56 @@
+// Plugin entry point and cross-platform extension trait
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+
+#[cfg(desktop)]
+mod desktop;
+#[cfg(mobile)]
+mod mobile;
+
+mod error;
+
+pub use error::{Error, Result};
+
+#[cfg(desktop)]
+use desktop::NativeBus;
+#[cfg(mobile)]
+use mobile::NativeBus;
+
+/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the
+/// native-bus plugin state.
+pub trait NativeBusExt<R: Runtime> {
+    fn native_bus(&self) -> &NativeBus<R>;
+}
+
+impl<R: Runtime, T: Manager<R>> NativeBusExt<R> for T {
+    fn native_bus(&self) -> &NativeBus<R> {
+        self.state::<NativeBus<R>>().inner()
+    }
+}
+
+/// Initialises the plugin.
+///
+/// This crate carries no webview-invokable commands today -- its whole purpose is to
+/// bring `android/` (the shared `NativeEventBus`/`DurableEventQueue` Kotlin sources) into
+/// the generated Gradle project graph, so alarm-manager and wear-sync can depend on it as
+/// a Gradle project dependency in a later phase of issue #255. See the workspace
+/// `Cargo.toml`'s comment on this crate's direct dependency from the app crate for why
+/// that matters even before anything calls `.plugin()` on it in a meaningful way.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("native-bus")
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let native_bus = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let native_bus = desktop::init(app, api)?;
+            app.manage(native_bus);
+            Ok(())
+        })
+        .build()
+}

--- a/plugins/native-bus/src/lib.rs
+++ b/plugins/native-bus/src/lib.rs
@@ -22,17 +22,9 @@ use desktop::NativeBus;
 #[cfg(mobile)]
 use mobile::NativeBus;
 
-/// Extensions to [`tauri::App`] and [`tauri::AppHandle`] to access the native-bus plugin
-/// state.
+/// Extensions to [`tauri::App`] and [`tauri::AppHandle`] to access the native-bus plugin state.
 ///
-/// `NativeBus` itself is not generic over `Runtime`, unlike every other plugin's state in
-/// this codebase: those hold a `PluginHandle<R>` (or similar per-runtime data) that a
-/// registered Kotlin `@TauriPlugin` component needs, and `NativeBus` registers no such
-/// component and carries no data at all. This trait is still implemented per concrete
-/// manager type (rather than as a single blanket `impl<R: Runtime, T: Manager<R>>`, the
-/// way every other plugin's extension trait in this codebase does it) because a blanket
-/// impl needs its own `Runtime` parameter to appear in the trait itself to satisfy
-/// coherence -- which a *non-generic* trait like this one can't provide.
+/// `NativeBus` itself is not generic over `Runtime`, unlike every other plugin's state in this codebase: those hold a `PluginHandle<R>` (or similar per-runtime data) that a registered Kotlin `@TauriPlugin` component needs, and `NativeBus` registers no such component and carries no data at all. This trait is still implemented per concrete manager type (rather than as a single blanket `impl<R: Runtime, T: Manager<R>>`, the way every other plugin's extension trait in this codebase does it) because a blanket impl needs its own `Runtime` parameter to appear in the trait itself to satisfy coherence -- which a *non-generic* trait like this one can't provide.
 pub trait NativeBusExt {
     fn native_bus(&self) -> &NativeBus;
 }
@@ -51,12 +43,7 @@ impl<R: Runtime> NativeBusExt for tauri::AppHandle<R> {
 
 /// Initialises the plugin.
 ///
-/// This crate carries no webview-invokable commands today -- its whole purpose is to
-/// bring `android/` (the shared `NativeEventBus`/`DurableEventQueue` Kotlin sources) into
-/// the generated Gradle project graph, so alarm-manager and wear-sync can depend on it as
-/// a Gradle project dependency in a later phase of issue #255. See the workspace
-/// `Cargo.toml`'s comment on this crate's direct dependency from the app crate for why
-/// that matters even before anything calls `.plugin()` on it in a meaningful way.
+/// This crate carries no webview-invokable commands today -- its whole purpose is to bring `android/` (the shared `NativeEventBus`/`DurableEventQueue` Kotlin sources) into the generated Gradle project graph, so alarm-manager and wear-sync can depend on it as a Gradle project dependency in a later phase of issue #255. See the workspace `Cargo.toml`'s comment on this crate's direct dependency from the app crate for why that matters even before anything calls `.plugin()` on it in a meaningful way.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("native-bus")
         .setup(|app, api| {

--- a/plugins/native-bus/src/lib.rs
+++ b/plugins/native-bus/src/lib.rs
@@ -22,15 +22,30 @@ use desktop::NativeBus;
 #[cfg(mobile)]
 use mobile::NativeBus;
 
-/// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the
-/// native-bus plugin state.
-pub trait NativeBusExt<R: Runtime> {
-    fn native_bus(&self) -> &NativeBus<R>;
+/// Extensions to [`tauri::App`] and [`tauri::AppHandle`] to access the native-bus plugin
+/// state.
+///
+/// `NativeBus` itself is not generic over `Runtime`, unlike every other plugin's state in
+/// this codebase: those hold a `PluginHandle<R>` (or similar per-runtime data) that a
+/// registered Kotlin `@TauriPlugin` component needs, and `NativeBus` registers no such
+/// component and carries no data at all. This trait is still implemented per concrete
+/// manager type (rather than as a single blanket `impl<R: Runtime, T: Manager<R>>`, the
+/// way every other plugin's extension trait in this codebase does it) because a blanket
+/// impl needs its own `Runtime` parameter to appear in the trait itself to satisfy
+/// coherence -- which a *non-generic* trait like this one can't provide.
+pub trait NativeBusExt {
+    fn native_bus(&self) -> &NativeBus;
 }
 
-impl<R: Runtime, T: Manager<R>> NativeBusExt<R> for T {
-    fn native_bus(&self) -> &NativeBus<R> {
-        self.state::<NativeBus<R>>().inner()
+impl<R: Runtime> NativeBusExt for tauri::App<R> {
+    fn native_bus(&self) -> &NativeBus {
+        self.state::<NativeBus>().inner()
+    }
+}
+
+impl<R: Runtime> NativeBusExt for tauri::AppHandle<R> {
+    fn native_bus(&self) -> &NativeBus {
+        self.state::<NativeBus>().inner()
     }
 }
 

--- a/plugins/native-bus/src/mobile.rs
+++ b/plugins/native-bus/src/mobile.rs
@@ -1,0 +1,33 @@
+// Android bridge for the native-bus plugin
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use serde::de::DeserializeOwned;
+use tauri::{plugin::PluginApi, AppHandle, Runtime};
+
+/// Initialises the plugin's mobile-side state.
+///
+/// Unlike most plugins with an `android_path`, there is no Kotlin `@TauriPlugin`
+/// component to register here: `NativeEventBus` and `DurableEventQueue`
+/// (`android/src/main/java/ca/liminalhq/threshold/nativebus/`) are plain Kotlin classes
+/// meant to be consumed directly -- via a Gradle project dependency -- by the plugins
+/// that subscribe to them (alarm-manager, wear-sync, in a later phase), not through the
+/// Tauri command/channel bridge. This function exists only so the crate's mobile/desktop
+/// split matches the shape of every other plugin in this codebase; it has nothing to
+/// initialise yet.
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    _app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> crate::Result<NativeBus<R>> {
+    Ok(NativeBus(std::marker::PhantomData))
+}
+
+/// Marker state for the native-bus plugin. Carries no plugin handle because this crate
+/// registers no Kotlin `@TauriPlugin` component -- see [`init`].
+///
+/// Phantom over `fn() -> R` rather than bare `R`: `app.manage()` requires the state type
+/// to be `Send + Sync`, and a plain `PhantomData<R>` only satisfies that when `R` itself
+/// does, which `Runtime` does not guarantee. A function pointer is always `Send + Sync`
+/// regardless of `R`, so phantom-typing over one sidesteps the requirement entirely.
+pub struct NativeBus<R: Runtime>(std::marker::PhantomData<fn() -> R>);

--- a/plugins/native-bus/src/mobile.rs
+++ b/plugins/native-bus/src/mobile.rs
@@ -19,15 +19,12 @@ use tauri::{plugin::PluginApi, AppHandle, Runtime};
 pub fn init<R: Runtime, C: DeserializeOwned>(
     _app: &AppHandle<R>,
     _api: PluginApi<R, C>,
-) -> crate::Result<NativeBus<R>> {
-    Ok(NativeBus(std::marker::PhantomData))
+) -> crate::Result<NativeBus> {
+    Ok(NativeBus)
 }
 
 /// Marker state for the native-bus plugin. Carries no plugin handle because this crate
-/// registers no Kotlin `@TauriPlugin` component -- see [`init`].
-///
-/// Phantom over `fn() -> R` rather than bare `R`: `app.manage()` requires the state type
-/// to be `Send + Sync`, and a plain `PhantomData<R>` only satisfies that when `R` itself
-/// does, which `Runtime` does not guarantee. A function pointer is always `Send + Sync`
-/// regardless of `R`, so phantom-typing over one sidesteps the requirement entirely.
-pub struct NativeBus<R: Runtime>(std::marker::PhantomData<fn() -> R>);
+/// registers no Kotlin `@TauriPlugin` component -- see [`init`]. Not generic over
+/// `Runtime`: with no handle and no other per-runtime data to hold, there is nothing for
+/// a `Runtime` type parameter to parameterise.
+pub struct NativeBus;

--- a/plugins/native-bus/src/mobile.rs
+++ b/plugins/native-bus/src/mobile.rs
@@ -8,14 +8,7 @@ use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
 /// Initialises the plugin's mobile-side state.
 ///
-/// Unlike most plugins with an `android_path`, there is no Kotlin `@TauriPlugin`
-/// component to register here: `NativeEventBus` and `DurableEventQueue`
-/// (`android/src/main/java/ca/liminalhq/threshold/nativebus/`) are plain Kotlin classes
-/// meant to be consumed directly -- via a Gradle project dependency -- by the plugins
-/// that subscribe to them (alarm-manager, wear-sync, in a later phase), not through the
-/// Tauri command/channel bridge. This function exists only so the crate's mobile/desktop
-/// split matches the shape of every other plugin in this codebase; it has nothing to
-/// initialise yet.
+/// Unlike most plugins with an `android_path`, there is no Kotlin `@TauriPlugin` component to register here: `NativeEventBus` and `DurableEventQueue` (`android/src/main/java/ca/liminalhq/threshold/nativebus/`) are plain Kotlin classes meant to be consumed directly -- via a Gradle project dependency -- by the plugins that subscribe to them (alarm-manager, wear-sync, in a later phase), not through the Tauri command/channel bridge. This function exists only so the crate's mobile/desktop split matches the shape of every other plugin in this codebase; it has nothing to initialise yet.
 pub fn init<R: Runtime, C: DeserializeOwned>(
     _app: &AppHandle<R>,
     _api: PluginApi<R, C>,
@@ -23,8 +16,5 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
     Ok(NativeBus)
 }
 
-/// Marker state for the native-bus plugin. Carries no plugin handle because this crate
-/// registers no Kotlin `@TauriPlugin` component -- see [`init`]. Not generic over
-/// `Runtime`: with no handle and no other per-runtime data to hold, there is nothing for
-/// a `Runtime` type parameter to parameterise.
+/// Marker state for the native-bus plugin. Carries no plugin handle because this crate registers no Kotlin `@TauriPlugin` component -- see [`init`]. Not generic over `Runtime`: with no handle and no other per-runtime data to hold, there is nothing for a `Runtime` type parameter to parameterise.
 pub struct NativeBus;


### PR DESCRIPTION
## What this is

Phase 1 of #255's implementation plan: a new, minimal Tauri plugin, `plugins/native-bus`, that will host a Kotlin `NativeEventBus` (a process-wide singleton letting different Android plugins' native code talk to each other in-process, without waiting for the Rust/WebView runtime to boot) and a `DurableEventQueue` (a generic, reusable, per-plugin-instantiated persistence+drain class that later phases will migrate alarm-manager's and wear-sync's existing hand-rolled queues onto). This PR is the substrate only — no other plugin depends on it yet.

## What's here

- `NativeEventBus.kt` — `subscribe`/`publish(topic, payload): Set<String>`, synchronous in-process delivery on the caller's thread, per-listener try/catch isolation, thread-safe registry. Threading contract documented in KDoc: listeners must do cheap synchronous work only and hand blocking work to their own executor.
- `DurableEventQueue.kt` — modelled on `WearSyncQueue.kt`'s already-proven single-generic-log shape (one prefs key, one JSON array), not alarm-manager's four-separate-queues shape. Envelope: `{v, topic, payload, eventId, publishedAt, handledNatively}`. Tolerates corrupt individual entries and unknown schema versions without failing the whole drain.
- `KeyValueStore` behind a small interface (SharedPreferences in prod, in-memory fake in tests) so everything runs as plain JUnit 4, matching this repo's existing `test-kotlin-plugins` CI job.
- `tauri-plugin-native-bus` is a **direct** Cargo path-dependency of `apps/threshold/src-tauri` (in addition to being registered via `.plugin()`) — required because Cargo's `links`/`DEP_*_ANDROID_LIBRARY_PATH` metadata propagation, which is what makes `tauri-build` auto-add a plugin's `android/` directory to the generated Gradle project graph, only reaches direct dependents, not transitive ones through alarm-manager/wear-sync.
- `.github/workflows/test.yml`'s `test-kotlin-plugins` job wired up for native-bus's own Kotlin unit tests.

## Testing checklist (automated, no device needed)

- [x] `cargo check --workspace` / `cargo clippy --workspace --all-targets` / `cargo fmt --check`
- [x] Native-bus's JUnit suite (16 tests) green
- [x] Full `pnpm tauri android build --debug -t aarch64 --ci` succeeds end-to-end (APK + AAB), confirming both the Gradle wiring resolves and the plugin's `app.manage()` actually runs without panicking at startup

## Review status

Reviewed via `/code-review high` twice. First pass found the plugin was scaffolded but never actually registered via `.plugin()` (so `app.manage()` never ran, and any future `native_bus()` call would've panicked), an unnecessary `Runtime` generic with no purpose here, and a CI bug where pre-wiring `include(':tauri-plugin-native-bus')` into alarm-manager's/wear-sync's synthesized settings caused Gradle to redundantly sweep native-bus's tests into their jobs. All three fixed and re-verified — that settings pre-wiring now lands with Phase 2A/2B instead, alongside the real Gradle dependency each of those actually adds.

Part of #255.