### PR TITLE
Migrate alarm-manager onto the shared DurableEventQueue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,7 @@ jobs:
 
           write_kts_settings() {
             local plugin_dir="$1"
+            local extra_includes="${2:-}"
             cat > "${plugin_dir}/settings.gradle.kts" <<EOF
           pluginManagement {
             repositories {
@@ -273,6 +274,7 @@ jobs:
 
           include(":tauri-android")
           project(":tauri-android").projectDir = file("${TAURI_ANDROID_PATH}")
+          ${extra_includes}
           EOF
           }
 
@@ -312,16 +314,23 @@ jobs:
           EOF
           }
 
-          # alarm-manager and wear-sync don't depend on native-bus yet, so their settings
-          # deliberately don't include `:tauri-plugin-native-bus` -- the unqualified
-          # `testDebugUnitTest` selector used below runs a task in every project in the
-          # build graph that has it, so including it in more than one plugin's settings
-          # would run native-bus's own tests redundantly on every one of those runs, and
-          # (since this step runs under errexit) could misattribute a native-bus test
-          # failure to whichever plugin's line happened to trigger it first. A later phase
-          # of issue #255 adds both the real Gradle project dependency and this
-          # settings-synthesis line together, at the point they're actually needed.
-          write_kts_settings "plugins/alarm-manager/android"
+          # alarm-manager now has a real `implementation(project(":tauri-plugin-native-bus"))`
+          # dependency (Phase 2A of issue #255), so its isolated settings needs the matching
+          # project include below or its build would fail to resolve that reference. wear-sync
+          # doesn't depend on native-bus yet, so its settings deliberately still omits this --
+          # the unqualified `testDebugUnitTest` selector used below runs a task in every
+          # project in the build graph that has it, so including it in more than one plugin's
+          # settings runs native-bus's own tests redundantly on every one of those runs, and
+          # (since this step runs under errexit) could misattribute a native-bus test failure
+          # to whichever plugin's line happened to trigger it first -- an accepted, documented
+          # tradeoff now that alarm-manager's build genuinely needs the project reference. A
+          # later phase of issue #255 adds the same wiring for wear-sync once it migrates too.
+          NATIVE_BUS_ANDROID_PATH="$(pwd)/plugins/native-bus/android"
+          NATIVE_BUS_PROJECT_INCLUDE_KTS="
+          include(\":tauri-plugin-native-bus\")
+          project(\":tauri-plugin-native-bus\").projectDir = file(\"${NATIVE_BUS_ANDROID_PATH}\")"
+
+          write_kts_settings "plugins/alarm-manager/android" "${NATIVE_BUS_PROJECT_INCLUDE_KTS}"
           write_kts_settings "plugins/theme-utils/android"
           write_kts_settings "plugins/os-prefs/android"
           write_kts_settings "plugins/predictive-back/android"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@ This document tracks all releases of the Threshold application.
 
 ---
 
+## Unreleased
+
+> [!NOTE]
+> **Note for whoever writes the release notes for the version that ships this:** `alarm-manager`'s four legacy per-type native event queues (fired/snooze/dismiss/import) were migrated on first launch into the shared `native-bus` event log; the migration is one-way, so an app downgrade to a build predating this change would no longer see any events left behind in the new log format.
+
+---
+
 ## Version 0.3.0
 
 **Release Date:** July 25, 2026

--- a/plugins/alarm-manager/android/build.gradle.kts
+++ b/plugins/alarm-manager/android/build.gradle.kts
@@ -25,12 +25,25 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    testOptions {
+        unitTests {
+            // The migration/drain JUnit tests exercise Log.w() warning paths (corrupt legacy
+            // JSON, an unregistered channel) that hit Android's unmocked stub jar and throw
+            // instead of being no-ops under plain JUnit (no Robolectric in this codebase's
+            // test-kotlin-plugins CI job) -- same fix as plugins/native-bus's build.gradle.kts.
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 dependencies {
     compileOnly(project(":tauri-android"))
+    implementation(project(":tauri-plugin-native-bus"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.25")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.activity:activity:1.8.0")
     testImplementation("junit:junit:4.13.2")
+    // Real org.json, not Android's throw-on-call stub -- same fix already used by
+    // plugins/native-bus and apps/threshold-wear's own JVM-only JSON parsing tests.
+    testImplementation("org.json:json:20231013")
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -23,13 +23,200 @@ import app.tauri.plugin.Channel
 import app.tauri.plugin.Plugin
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
-import app.tauri.plugin.JSArray
 import android.util.Log
 import androidx.activity.result.ActivityResult
 import android.content.BroadcastReceiver
 import android.content.IntentFilter
+import ca.liminalhq.threshold.nativebus.DurableEventQueue
+import ca.liminalhq.threshold.nativebus.KeyValueStore
+import ca.liminalhq.threshold.nativebus.SharedPreferencesKeyValueStore
 import org.json.JSONArray
 import org.json.JSONObject
+
+private const val TAG = "AlarmManagerPlugin"
+private const val CALLBACK_PREFS = "AlarmManagerCallbacks"
+
+// Topics are the existing Tauri event names these four channels ultimately emit as (see
+// plugins/alarm-manager/src/mobile.rs) -- reusing them as DurableEventQueue topics means the
+// unified log's contents are self-describing without inventing a second naming scheme.
+// `internal` (not `private`) so this file's JUnit tests can reference the exact same strings
+// rather than duplicating them.
+internal const val TOPIC_FIRED = "alarm-manager:native-fired"
+internal const val TOPIC_SNOOZE = "alarm-manager:snooze-requested"
+internal const val TOPIC_DISMISS = "alarm-manager:dismiss-requested"
+internal const val TOPIC_IMPORT = "alarm-manager:import-requested"
+
+// The single unified log, replacing the four legacy keys below. Same prefs file as the legacy
+// queues (CALLBACK_PREFS) -- only the key, and the fact there's now just one of them, changes.
+internal const val EVENT_LOG_KEY = "event_log"
+
+// Pre-migration queue keys. Only ever read by migrateLegacyQueues(), which removes them once
+// their contents have been folded into EVENT_LOG_KEY -- see that function for the one-time
+// migration this repo's release notes call out.
+internal const val LEGACY_KEY_PENDING_ALARM_EVENTS = "pending_alarm_events"
+internal const val LEGACY_KEY_PENDING_SNOOZE_EVENTS = "pending_snooze_events"
+internal const val LEGACY_KEY_PENDING_DISMISS_EVENTS = "pending_dismiss_events"
+internal const val LEGACY_KEY_PENDING_IMPORT_EVENTS = "pending_import_events"
+
+/**
+ * One-time migration off the four legacy per-type queues (pre-[DurableEventQueue]) onto the
+ * unified event log under [EVENT_LOG_KEY] in [store]. Returns the number of entries migrated.
+ *
+ * Production devices have been observed carrying pending entries across multiple days, so
+ * this folds any leftovers into the new log -- preserving each entry's own data -- rather than
+ * silently dropping them. This is one-way: once the legacy keys are removed here, a downgrade
+ * to a build that only knows the old queues would no longer see events left in the new log
+ * (see RELEASE_NOTES.md).
+ *
+ * [DurableEventQueue.enqueue] always stamps `publishedAt` from the wall clock, which isn't
+ * what we want here -- migrated entries should drain in a sensible relative order (fired
+ * events by their own `actualFiredAt`; the others, which never recorded a timestamp, by their
+ * original per-queue array position) rather than all colliding on the single instant migration
+ * happened to run. Since the public API has no seam for supplying an explicit `publishedAt`,
+ * this writes envelopes directly into the log's JSON array using the same
+ * "v"/"topic"/"payload"/"eventId"/"publishedAt"/"handledNatively" schema [DurableEventQueue]
+ * itself reads (see its KDoc and `DurableEventQueueTest`'s `writeRawEnvelopes` helper for the
+ * same technique) -- a deliberate, documented duplication of that private schema, acceptable
+ * because it's exercised by this file's own migration tests.
+ *
+ * A standalone function operating purely against [KeyValueStore] (not SharedPreferences/
+ * Context directly) so it's unit-testable against an in-memory fake -- mirrors
+ * `resolveActiveDays` in `SetAlarmActivity.kt`.
+ */
+internal fun migrateLegacyQueues(store: KeyValueStore): Int {
+    val legacyKeys = listOf(
+        LEGACY_KEY_PENDING_ALARM_EVENTS,
+        LEGACY_KEY_PENDING_SNOOZE_EVENTS,
+        LEGACY_KEY_PENDING_DISMISS_EVENTS,
+        LEGACY_KEY_PENDING_IMPORT_EVENTS,
+    )
+    if (legacyKeys.none { store.get(it) != null }) return 0
+
+    val envelopes = JSONArray()
+    try {
+        val existing = JSONArray(store.get(EVENT_LOG_KEY) ?: "[]")
+        for (i in 0 until existing.length()) envelopes.put(existing.get(i))
+    } catch (e: Exception) {
+        Log.w(TAG, "Existing event log under '$EVENT_LOG_KEY' was corrupt, discarding it before migration", e)
+    }
+
+    // Fallback publishedAt for legacy entries that never recorded their own timestamp
+    // (snooze/dismiss/import): now, offset by each entry's index within its own legacy array.
+    // The entries in each legacy array are already in chronological (append) order, so the
+    // offset preserves that relative order without every migrated entry colliding on the
+    // exact same millisecond.
+    val fallbackBase = System.currentTimeMillis()
+
+    var migratedCount = 0
+    migratedCount += migrateLegacyArray(store, LEGACY_KEY_PENDING_ALARM_EVENTS, TOPIC_FIRED, envelopes) { item, index ->
+        val payload = JSONObject().apply {
+            put("id", item.optInt("id", -1))
+            put("actualFiredAt", item.optLong("actualFiredAt", fallbackBase + index))
+        }
+        val publishedAt = if (item.has("actualFiredAt")) {
+            item.optLong("actualFiredAt", fallbackBase + index)
+        } else {
+            fallbackBase + index
+        }
+        payload to publishedAt
+    }
+    migratedCount += migrateLegacyArray(store, LEGACY_KEY_PENDING_SNOOZE_EVENTS, TOPIC_SNOOZE, envelopes) { item, index ->
+        JSONObject().apply { put("id", item.optInt("id", -1)) } to fallbackBase + index
+    }
+    migratedCount += migrateLegacyArray(store, LEGACY_KEY_PENDING_DISMISS_EVENTS, TOPIC_DISMISS, envelopes) { item, index ->
+        JSONObject().apply { put("id", item.optInt("id", -1)) } to fallbackBase + index
+    }
+    migratedCount += migrateLegacyArray(store, LEGACY_KEY_PENDING_IMPORT_EVENTS, TOPIC_IMPORT, envelopes) { item, index ->
+        val payload = JSONObject().apply {
+            put("id", item.optInt("id", -1))
+            put("hour", item.optInt("hour", 0))
+            put("minute", item.optInt("minute", 0))
+            put("label", item.optString("label", ""))
+            put("activeDays", item.optJSONArray("activeDays") ?: JSONArray())
+            put("triggerAt", item.optLong("triggerAt", 0))
+        }
+        payload to fallbackBase + index
+    }
+
+    if (migratedCount > 0) {
+        store.set(EVENT_LOG_KEY, envelopes.toString())
+    }
+    legacyKeys.forEach { store.remove(it) }
+    return migratedCount
+}
+
+/**
+ * Migrates one legacy queue array (under [legacyKey] in [store]) into [outEnvelopes],
+ * skipping entries with no valid `id`. [toPayloadAndPublishedAt] receives each legacy item
+ * plus its index within its own legacy array and returns the new-schema payload object and
+ * the `publishedAt` to stamp it with. Returns the number of entries migrated.
+ */
+private fun migrateLegacyArray(
+    store: KeyValueStore,
+    legacyKey: String,
+    topic: String,
+    outEnvelopes: JSONArray,
+    toPayloadAndPublishedAt: (item: JSONObject, index: Int) -> Pair<JSONObject, Long>,
+): Int {
+    val raw = store.get(legacyKey) ?: return 0
+    val array = try {
+        JSONArray(raw)
+    } catch (e: Exception) {
+        Log.w(TAG, "Legacy queue under '$legacyKey' was corrupt, dropping it during migration", e)
+        return 0
+    }
+
+    var count = 0
+    for (i in 0 until array.length()) {
+        val item = array.optJSONObject(i) ?: continue
+        val id = item.optInt("id", -1)
+        if (id <= 0) continue
+
+        val (payload, publishedAt) = toPayloadAndPublishedAt(item, i)
+        outEnvelopes.put(
+            JSONObject().apply {
+                put("v", DurableEventQueue.SCHEMA_VERSION)
+                put("topic", topic)
+                put("payload", payload.toString())
+                put("eventId", java.util.UUID.randomUUID().toString())
+                put("publishedAt", publishedAt)
+                put("handledNatively", JSONArray())
+            },
+        )
+        count++
+    }
+    return count
+}
+
+/**
+ * Drains every entry in [queue] (across every topic, in chronological
+ * [DurableEventQueue.Envelope.publishedAt] order) and hands each one to [dispatch], which
+ * attempts delivery for the given topic/payload and returns whether it succeeded. Only
+ * successfully-dispatched entries are committed (removed) from [queue] -- anything [dispatch]
+ * returns `false` for stays queued for a later retry, mirroring the pre-migration per-type
+ * drain/replay behaviour. Returns the number of entries actually dispatched.
+ *
+ * A standalone function (not a method) so it's unit-testable against a real
+ * [DurableEventQueue]/in-memory [KeyValueStore] pair, with a fake [dispatch], and no Android
+ * framework (Context, Channel) involved at all -- mirrors [migrateLegacyQueues] above.
+ */
+internal fun drainAndDispatch(queue: DurableEventQueue, dispatch: (topic: String, payload: String) -> Boolean): Int {
+    val drained = queue.drainAll(pipelineReady = true)
+    if (drained.isEmpty()) return 0
+
+    val handledEventIds = mutableSetOf<String>()
+    for (envelope in drained) {
+        if (dispatch(envelope.topic, envelope.payload)) {
+            handledEventIds.add(envelope.eventId)
+        }
+    }
+    if (handledEventIds.isNotEmpty()) queue.commit(handledEventIds)
+    return handledEventIds.size
+}
+
+private fun keyValueStore(context: Context): KeyValueStore = SharedPreferencesKeyValueStore(context, CALLBACK_PREFS)
+
+private fun eventQueue(context: Context): DurableEventQueue = DurableEventQueue(keyValueStore(context), EVENT_LOG_KEY)
 
 @InvokeArg
 class ScheduleRequest {
@@ -81,13 +268,6 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
     private var alarmPipelineReady: Boolean = false
 
     companion object {
-        private const val TAG = "AlarmManagerPlugin"
-        private const val CALLBACK_PREFS = "AlarmManagerCallbacks"
-        private const val KEY_PENDING_ALARM_EVENTS = "pending_alarm_events"
-        private const val KEY_PENDING_SNOOZE_EVENTS = "pending_snooze_events"
-        private const val KEY_PENDING_DISMISS_EVENTS = "pending_dismiss_events"
-        private const val KEY_PENDING_IMPORT_EVENTS = "pending_import_events"
-
         @Volatile
         var instance: AlarmManagerPlugin? = null
             private set
@@ -95,43 +275,25 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         @Synchronized
         fun notifyAlarmFired(context: Context, alarmId: Int, actualFiredAt: Long = System.currentTimeMillis()) {
             if (alarmId <= 0) return
-
-            val plugin = instance
-            if (plugin != null && plugin.dispatchAlarmFiredEvent(alarmId, actualFiredAt)) {
-                Log.d(TAG, "Dispatched native alarm fired immediately: id=$alarmId")
-                return
+            val payload = JSONObject().apply {
+                put("id", alarmId)
+                put("actualFiredAt", actualFiredAt)
             }
-
-            queueAlarmEvent(context, alarmId, actualFiredAt)
-            Log.i(TAG, "Queued native alarm fired event (plugin/channel not ready): id=$alarmId")
+            enqueueAndDrain(context, TOPIC_FIRED, payload)
         }
 
         @Synchronized
         fun notifySnoozeRequested(context: Context, alarmId: Int) {
             if (alarmId <= 0) return
-
-            val plugin = instance
-            if (plugin != null && plugin.dispatchSnoozeRequestedEvent(alarmId)) {
-                Log.d(TAG, "Dispatched snooze requested immediately: id=$alarmId")
-                return
-            }
-
-            queueSnoozeEvent(context, alarmId)
-            Log.i(TAG, "Queued snooze requested event (plugin/channel not ready): id=$alarmId")
+            val payload = JSONObject().apply { put("id", alarmId) }
+            enqueueAndDrain(context, TOPIC_SNOOZE, payload)
         }
 
         @Synchronized
         fun notifyAlarmDismissed(context: Context, alarmId: Int) {
             if (alarmId <= 0) return
-
-            val plugin = instance
-            if (plugin != null && plugin.dispatchDismissRequestedEvent(alarmId)) {
-                Log.d(TAG, "Dispatched dismiss requested immediately: id=$alarmId")
-                return
-            }
-
-            queueDismissEvent(context, alarmId)
-            Log.i(TAG, "Queued dismiss requested event (plugin/channel not ready): id=$alarmId")
+            val payload = JSONObject().apply { put("id", alarmId) }
+            enqueueAndDrain(context, TOPIC_DISMISS, payload)
         }
 
         @Synchronized
@@ -145,75 +307,28 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             triggerAt: Long,
         ) {
             if (id <= 0) return
-
-            val plugin = instance
-            if (plugin != null &&
-                plugin.dispatchImportRequestedEvent(id, hour, minute, label, activeDays, triggerAt)
-            ) {
-                Log.d(TAG, "Dispatched import requested immediately: id=$id")
-                return
-            }
-
-            queueImportEvent(context, id, hour, minute, label, activeDays, triggerAt)
-            Log.i(TAG, "Queued import requested event (plugin/channel not ready): id=$id")
-        }
-
-        @Synchronized
-        private fun queueAlarmEvent(context: Context, alarmId: Int, actualFiredAt: Long) {
-            val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-            val queue = JSONArray(prefs.getString(KEY_PENDING_ALARM_EVENTS, "[]"))
-            queue.put(JSONObject().apply {
-                put("id", alarmId)
-                put("actualFiredAt", actualFiredAt)
-            })
-            prefs.edit().putString(KEY_PENDING_ALARM_EVENTS, queue.toString()).apply()
-            NativeEventLog.log(context, TAG, "Queued fired event id=$alarmId (queue depth=${queue.length()})")
-        }
-
-        @Synchronized
-        private fun queueSnoozeEvent(context: Context, alarmId: Int) {
-            val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-            val queue = JSONArray(prefs.getString(KEY_PENDING_SNOOZE_EVENTS, "[]"))
-            queue.put(JSONObject().apply {
-                put("id", alarmId)
-            })
-            prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, queue.toString()).apply()
-            NativeEventLog.log(context, TAG, "Queued snooze event id=$alarmId (queue depth=${queue.length()})")
-        }
-
-        @Synchronized
-        private fun queueDismissEvent(context: Context, alarmId: Int) {
-            val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-            val queue = JSONArray(prefs.getString(KEY_PENDING_DISMISS_EVENTS, "[]"))
-            queue.put(JSONObject().apply {
-                put("id", alarmId)
-            })
-            prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, queue.toString()).apply()
-            NativeEventLog.log(context, TAG, "Queued dismiss event id=$alarmId (queue depth=${queue.length()})")
-        }
-
-        @Synchronized
-        private fun queueImportEvent(
-            context: Context,
-            id: Int,
-            hour: Int,
-            minute: Int,
-            label: String,
-            activeDays: List<Int>,
-            triggerAt: Long,
-        ) {
-            val prefs = context.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-            val queue = JSONArray(prefs.getString(KEY_PENDING_IMPORT_EVENTS, "[]"))
-            queue.put(JSONObject().apply {
+            val payload = JSONObject().apply {
                 put("id", id)
                 put("hour", hour)
                 put("minute", minute)
                 put("label", label)
                 put("activeDays", JSONArray(activeDays))
                 put("triggerAt", triggerAt)
-            })
-            prefs.edit().putString(KEY_PENDING_IMPORT_EVENTS, queue.toString()).apply()
-            NativeEventLog.log(context, TAG, "Queued import event id=$id (queue depth=${queue.length()})")
+            }
+            enqueueAndDrain(context, TOPIC_IMPORT, payload)
+        }
+
+        // Every event flows through the log -- there is no separate "dispatch immediately"
+        // path any more. When the pipeline is already up and the right channel is registered,
+        // drainQueuedEvents() below delivers this same entry within the same call, so the net
+        // effect (and latency) matches the old immediate-dispatch path; when it isn't, the
+        // entry simply stays in the log until markAlarmPipelineReady() (or a later event of
+        // any topic) drains it.
+        @Synchronized
+        private fun enqueueAndDrain(context: Context, topic: String, payload: JSONObject) {
+            val eventId = eventQueue(context).enqueue(topic, payload.toString())
+            NativeEventLog.log(context, TAG, "Enqueued '$topic' event $eventId: $payload")
+            instance?.drainQueuedEvents()
         }
     }
 
@@ -221,11 +336,19 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         super.load(webView)
         instance = this
         Log.d(TAG, "Plugin loaded.")
+
+        val migratedCount = migrateLegacyQueues(keyValueStore(activity))
+        if (migratedCount > 0) {
+            Log.i(TAG, "Migrated $migratedCount legacy queued event(s) into the unified event log")
+            NativeEventLog.log(
+                activity,
+                TAG,
+                "Migrated $migratedCount legacy queued event(s) into the unified event log",
+            )
+        }
+
         applyRingingWindowFlags(activity.intent)
-        drainPendingAlarmEvents()
-        drainPendingSnoozeEvents()
-        drainPendingDismissEvents()
-        drainPendingImportEvents()
+        drainQueuedEvents()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -433,10 +556,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
     fun markAlarmPipelineReady(invoke: Invoke) {
         alarmPipelineReady = true
         Log.d(TAG, "Alarm pipeline marked ready")
-        drainPendingAlarmEvents()
-        drainPendingSnoozeEvents()
-        drainPendingDismissEvents()
-        drainPendingImportEvents()
+        drainQueuedEvents()
         invoke.resolve()
     }
 
@@ -474,223 +594,47 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         }
     }
 
-    private fun dispatchSnoozeRequestedEvent(alarmId: Int): Boolean {
-        if (!alarmPipelineReady) return false
-        val channel = snoozeEventChannel ?: return false
-        return try {
-            val event = JSObject().apply {
-                put("id", alarmId)
-            }
-            channel.send(event)
-            true
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to dispatch snooze requested event", e)
-            false
-        }
+    /** Maps a [DurableEventQueue] topic to the Channel Rust registered to receive it. */
+    private fun channelForTopic(topic: String): Channel? = when (topic) {
+        TOPIC_FIRED -> alarmEventChannel
+        TOPIC_SNOOZE -> snoozeEventChannel
+        TOPIC_DISMISS -> dismissEventChannel
+        TOPIC_IMPORT -> importEventChannel
+        else -> null
     }
 
-    private fun dispatchDismissRequestedEvent(alarmId: Int): Boolean {
-        if (!alarmPipelineReady) return false
-        val channel = dismissEventChannel ?: return false
-        return try {
-            val event = JSObject().apply {
-                put("id", alarmId)
-            }
-            channel.send(event)
-            true
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to dispatch dismiss requested event", e)
-            false
-        }
-    }
-
-    private fun dispatchAlarmFiredEvent(alarmId: Int, actualFiredAt: Long): Boolean {
-        if (!alarmPipelineReady) return false
-        val channel = alarmEventChannel ?: return false
-        return try {
-            val event = JSObject().apply {
-                put("id", alarmId)
-                put("actualFiredAt", actualFiredAt)
-            }
-            channel.send(event)
-            true
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to dispatch native alarm fired event", e)
-            false
-        }
-    }
-
-    private fun dispatchImportRequestedEvent(
-        id: Int,
-        hour: Int,
-        minute: Int,
-        label: String,
-        activeDays: List<Int>,
-        triggerAt: Long,
-    ): Boolean {
-        if (!alarmPipelineReady) return false
-        val channel = importEventChannel ?: return false
-        return try {
-            val event = JSObject().apply {
-                put("id", id)
-                put("hour", hour)
-                put("minute", minute)
-                put("label", label)
-                put("activeDays", JSArray(activeDays))
-                put("triggerAt", triggerAt)
-            }
-            channel.send(event)
-            true
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to dispatch import requested event", e)
-            false
-        }
-    }
-
+    /**
+     * Drains every queued event (all topics, chronological arrival order) and dispatches each
+     * to the Channel matching its topic. A no-op while [alarmPipelineReady] is `false`.
+     *
+     * This is the single delivery path to Rust: [notifyAlarmFired] and friends always enqueue
+     * first and then call this immediately, so when the pipeline is already up this runs in
+     * the very same call rather than as a separate "replay later" pass. The actual drain/topic
+     * -> outcome bookkeeping lives in [drainAndDispatch]; this just supplies the Android-side
+     * dispatch (Channel lookup + send).
+     */
     @Synchronized
-    private fun drainPendingAlarmEvents() {
+    private fun drainQueuedEvents() {
         if (!alarmPipelineReady) return
-        val channel = alarmEventChannel ?: return
-        val prefs = activity.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-        val rawQueue = prefs.getString(KEY_PENDING_ALARM_EVENTS, "[]") ?: "[]"
-        val queue = JSONArray(rawQueue)
-        if (queue.length() == 0) return
-
-        val remaining = JSONArray()
-        for (i in 0 until queue.length()) {
-            val item = queue.optJSONObject(i) ?: continue
-            val id = item.optInt("id", -1)
-            val actualFiredAt = item.optLong("actualFiredAt", System.currentTimeMillis())
-            if (id <= 0) continue
-
-            try {
-                val event = JSObject().apply {
-                    put("id", id)
-                    put("actualFiredAt", actualFiredAt)
+        val queue = eventQueue(activity)
+        val handledCount = drainAndDispatch(queue) { topic, payload ->
+            val channel = channelForTopic(topic)
+            if (channel == null) {
+                Log.w(TAG, "No channel registered for topic '$topic', leaving event queued")
+                false
+            } else {
+                try {
+                    channel.send(JSObject(payload))
+                    true
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to dispatch queued event (topic '$topic')", e)
+                    false
                 }
-                channel.send(event)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to replay queued native alarm fired event id=$id", e)
-                remaining.put(item)
             }
         }
-
-        prefs.edit().putString(KEY_PENDING_ALARM_EVENTS, remaining.toString()).apply()
-        Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued native alarm fired event(s)")
-        NativeEventLog.log(
-            activity,
-            TAG,
-            "Drained fired events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
-        )
-    }
-
-    @Synchronized
-    private fun drainPendingSnoozeEvents() {
-        if (!alarmPipelineReady) return
-        val channel = snoozeEventChannel ?: return
-        val prefs = activity.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-        val rawQueue = prefs.getString(KEY_PENDING_SNOOZE_EVENTS, "[]") ?: "[]"
-        val queue = JSONArray(rawQueue)
-        if (queue.length() == 0) return
-
-        val remaining = JSONArray()
-        for (i in 0 until queue.length()) {
-            val item = queue.optJSONObject(i) ?: continue
-            val id = item.optInt("id", -1)
-            if (id <= 0) continue
-
-            try {
-                val event = JSObject().apply {
-                    put("id", id)
-                }
-                channel.send(event)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to replay queued snooze requested event id=$id", e)
-                remaining.put(item)
-            }
+        if (handledCount > 0) {
+            Log.i(TAG, "Drained $handledCount queued event(s)")
+            NativeEventLog.log(activity, TAG, "Drained $handledCount queued event(s)")
         }
-
-        prefs.edit().putString(KEY_PENDING_SNOOZE_EVENTS, remaining.toString()).apply()
-        Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued snooze requested event(s)")
-        NativeEventLog.log(
-            activity,
-            TAG,
-            "Drained snooze events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
-        )
-    }
-
-    @Synchronized
-    private fun drainPendingDismissEvents() {
-        if (!alarmPipelineReady) return
-        val channel = dismissEventChannel ?: return
-        val prefs = activity.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-        val rawQueue = prefs.getString(KEY_PENDING_DISMISS_EVENTS, "[]") ?: "[]"
-        val queue = JSONArray(rawQueue)
-        if (queue.length() == 0) return
-
-        val remaining = JSONArray()
-        for (i in 0 until queue.length()) {
-            val item = queue.optJSONObject(i) ?: continue
-            val id = item.optInt("id", -1)
-            if (id <= 0) continue
-
-            try {
-                val event = JSObject().apply {
-                    put("id", id)
-                }
-                channel.send(event)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to replay queued dismiss requested event id=$id", e)
-                remaining.put(item)
-            }
-        }
-
-        prefs.edit().putString(KEY_PENDING_DISMISS_EVENTS, remaining.toString()).apply()
-        Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued dismiss requested event(s)")
-        NativeEventLog.log(
-            activity,
-            TAG,
-            "Drained dismiss events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
-        )
-    }
-
-    @Synchronized
-    private fun drainPendingImportEvents() {
-        if (!alarmPipelineReady) return
-        val channel = importEventChannel ?: return
-        val prefs = activity.getSharedPreferences(CALLBACK_PREFS, Context.MODE_PRIVATE)
-        val rawQueue = prefs.getString(KEY_PENDING_IMPORT_EVENTS, "[]") ?: "[]"
-        val queue = JSONArray(rawQueue)
-        if (queue.length() == 0) return
-
-        val remaining = JSONArray()
-        for (i in 0 until queue.length()) {
-            val item = queue.optJSONObject(i) ?: continue
-            val id = item.optInt("id", -1)
-            if (id <= 0) continue
-
-            try {
-                val event = JSObject().apply {
-                    put("id", id)
-                    put("hour", item.optInt("hour", 0))
-                    put("minute", item.optInt("minute", 0))
-                    put("label", item.optString("label", ""))
-                    put("activeDays", item.optJSONArray("activeDays") ?: JSONArray())
-                    put("triggerAt", item.optLong("triggerAt", 0))
-                }
-                channel.send(event)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to replay queued import requested event id=$id", e)
-                remaining.put(item)
-            }
-        }
-
-        prefs.edit().putString(KEY_PENDING_IMPORT_EVENTS, remaining.toString()).apply()
-        Log.i(TAG, "Replayed ${queue.length() - remaining.length()} queued import requested event(s)")
-        NativeEventLog.log(
-            activity,
-            TAG,
-            "Drained import events: replayed ${queue.length() - remaining.length()}, remaining ${remaining.length()}",
-        )
     }
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -36,52 +36,29 @@ import org.json.JSONObject
 private const val TAG = "AlarmManagerPlugin"
 private const val CALLBACK_PREFS = "AlarmManagerCallbacks"
 
-// Topics are the existing Tauri event names these four channels ultimately emit as (see
-// plugins/alarm-manager/src/mobile.rs) -- reusing them as DurableEventQueue topics means the
-// unified log's contents are self-describing without inventing a second naming scheme.
-// `internal` (not `private`) so this file's JUnit tests can reference the exact same strings
-// rather than duplicating them.
+// Topics are the existing Tauri event names these four channels ultimately emit as (see plugins/alarm-manager/src/mobile.rs) -- reusing them as DurableEventQueue topics means the unified log's contents are self-describing without inventing a second naming scheme. `internal` (not `private`) so this file's JUnit tests can reference the exact same strings rather than duplicating them.
 internal const val TOPIC_FIRED = "alarm-manager:native-fired"
 internal const val TOPIC_SNOOZE = "alarm-manager:snooze-requested"
 internal const val TOPIC_DISMISS = "alarm-manager:dismiss-requested"
 internal const val TOPIC_IMPORT = "alarm-manager:import-requested"
 
-// The single unified log, replacing the four legacy keys below. Same prefs file as the legacy
-// queues (CALLBACK_PREFS) -- only the key, and the fact there's now just one of them, changes.
+// The single unified log, replacing the four legacy keys below. Same prefs file as the legacy queues (CALLBACK_PREFS) -- only the key, and the fact there's now just one of them, changes.
 internal const val EVENT_LOG_KEY = "event_log"
 
-// Pre-migration queue keys. Only ever read by migrateLegacyQueues(), which removes them once
-// their contents have been folded into EVENT_LOG_KEY -- see that function for the one-time
-// migration this repo's release notes call out.
+// Pre-migration queue keys. Only ever read by migrateLegacyQueues(), which removes them once their contents have been folded into EVENT_LOG_KEY -- see that function for the one-time migration this repo's release notes call out.
 internal const val LEGACY_KEY_PENDING_ALARM_EVENTS = "pending_alarm_events"
 internal const val LEGACY_KEY_PENDING_SNOOZE_EVENTS = "pending_snooze_events"
 internal const val LEGACY_KEY_PENDING_DISMISS_EVENTS = "pending_dismiss_events"
 internal const val LEGACY_KEY_PENDING_IMPORT_EVENTS = "pending_import_events"
 
 /**
- * One-time migration off the four legacy per-type queues (pre-[DurableEventQueue]) onto the
- * unified event log under [EVENT_LOG_KEY] in [store]. Returns the number of entries migrated.
+ * One-time migration off the four legacy per-type queues (pre-[DurableEventQueue]) onto the unified event log under [EVENT_LOG_KEY] in [store]. Returns the number of entries migrated.
  *
- * Production devices have been observed carrying pending entries across multiple days, so
- * this folds any leftovers into the new log -- preserving each entry's own data -- rather than
- * silently dropping them. This is one-way: once the legacy keys are removed here, a downgrade
- * to a build that only knows the old queues would no longer see events left in the new log
- * (see RELEASE_NOTES.md).
+ * Production devices have been observed carrying pending entries across multiple days, so this folds any leftovers into the new log -- preserving each entry's own data -- rather than silently dropping them. This is one-way: once the legacy keys are removed here, a downgrade to a build that only knows the old queues would no longer see events left in the new log (see RELEASE_NOTES.md).
  *
- * [DurableEventQueue.enqueue] always stamps `publishedAt` from the wall clock, which isn't
- * what we want here -- migrated entries should drain in a sensible relative order (fired
- * events by their own `actualFiredAt`; the others, which never recorded a timestamp, by their
- * original per-queue array position) rather than all colliding on the single instant migration
- * happened to run. Since the public API has no seam for supplying an explicit `publishedAt`,
- * this writes envelopes directly into the log's JSON array using the same
- * "v"/"topic"/"payload"/"eventId"/"publishedAt"/"handledNatively" schema [DurableEventQueue]
- * itself reads (see its KDoc and `DurableEventQueueTest`'s `writeRawEnvelopes` helper for the
- * same technique) -- a deliberate, documented duplication of that private schema, acceptable
- * because it's exercised by this file's own migration tests.
+ * [DurableEventQueue.enqueue] always stamps `publishedAt` from the wall clock, which isn't what we want here -- migrated entries should drain in a sensible relative order (fired events by their own `actualFiredAt`; the others, which never recorded a timestamp, by their original per-queue array position) rather than all colliding on the single instant migration happened to run. Since the public API has no seam for supplying an explicit `publishedAt`, this writes envelopes directly into the log's JSON array using the same "v"/"topic"/"payload"/"eventId"/"publishedAt"/"handledNatively" schema [DurableEventQueue] itself reads (see its KDoc and `DurableEventQueueTest`'s `writeRawEnvelopes` helper for the same technique) -- a deliberate, documented duplication of that private schema, acceptable because it's exercised by this file's own migration tests.
  *
- * A standalone function operating purely against [KeyValueStore] (not SharedPreferences/
- * Context directly) so it's unit-testable against an in-memory fake -- mirrors
- * `resolveActiveDays` in `SetAlarmActivity.kt`.
+ * A standalone function operating purely against [KeyValueStore] (not SharedPreferences/Context directly) so it's unit-testable against an in-memory fake -- mirrors `resolveActiveDays` in `SetAlarmActivity.kt`.
  */
 internal fun migrateLegacyQueues(store: KeyValueStore): Int {
     val legacyKeys = listOf(
@@ -90,12 +67,7 @@ internal fun migrateLegacyQueues(store: KeyValueStore): Int {
         LEGACY_KEY_PENDING_DISMISS_EVENTS,
         LEGACY_KEY_PENDING_IMPORT_EVENTS,
     )
-    // The pre-migration drain code these queues replace never removed a legacy key once
-    // drained -- it always rewrote the queue back to "[]" instead. So on essentially any
-    // device that's ever used alarms, all four legacy keys already exist by the time this
-    // runs; a plain non-null check would make this fast path never actually trigger. Parsing
-    // each one and checking for a genuinely non-empty array is what actually distinguishes
-    // "has real pending data" from "exists but was already drained to empty".
+    // The pre-migration drain code these queues replace never removed a legacy key once drained -- it always rewrote the queue back to "[]" instead. So on essentially any device that's ever used alarms, all four legacy keys already exist by the time this runs; a plain non-null check would make this fast path never actually trigger. Parsing each one and checking for a genuinely non-empty array is what actually distinguishes "has real pending data" from "exists but was already drained to empty".
     if (legacyKeys.none { hasPendingLegacyEntries(store.get(it)) }) return 0
 
     val envelopes = JSONArray()
@@ -106,11 +78,7 @@ internal fun migrateLegacyQueues(store: KeyValueStore): Int {
         Log.w(TAG, "Existing event log under '$EVENT_LOG_KEY' was corrupt, discarding it before migration", e)
     }
 
-    // Fallback publishedAt for legacy entries that never recorded their own timestamp
-    // (snooze/dismiss/import): now, offset by each entry's index within its own legacy array.
-    // The entries in each legacy array are already in chronological (append) order, so the
-    // offset preserves that relative order without every migrated entry colliding on the
-    // exact same millisecond.
+    // Fallback publishedAt for legacy entries that never recorded their own timestamp (snooze/dismiss/import): now, offset by each entry's index within its own legacy array. The entries in each legacy array are already in chronological (append) order, so the offset preserves that relative order without every migrated entry colliding on the exact same millisecond.
     val fallbackBase = System.currentTimeMillis()
 
     var migratedCount = 0
@@ -144,26 +112,14 @@ internal fun migrateLegacyQueues(store: KeyValueStore): Int {
         payload to fallbackBase + index
     }
 
-    // Written as one atomic batch rather than a separate set() + four remove() calls: if the
-    // process were killed between them, the next launch would see the new log already holding
-    // these entries but the legacy keys still present with their original data, re-trigger
-    // migration, and duplicate every entry in the log (each one reported to Rust twice --
-    // e.g. the same alarm fired/dismissed twice). Batching makes that intermediate state
-    // unobservable -- either both the log write and all four removals land, or neither does.
+    // Written as one atomic batch rather than a separate set() + four remove() calls: if the process were killed between them, the next launch would see the new log already holding these entries but the legacy keys still present with their original data, re-trigger migration, and duplicate every entry in the log (each one reported to Rust twice -- e.g. the same alarm fired/dismissed twice). Batching makes that intermediate state unobservable -- either both the log write and all four removals land, or neither does.
     val sets = if (migratedCount > 0) mapOf(EVENT_LOG_KEY to envelopes.toString()) else emptyMap()
     store.batch(sets = sets, removes = legacyKeys.toSet())
     return migratedCount
 }
 
 /**
- * Whether [raw] (a legacy queue's raw stored value) holds at least one entry worth migrating.
- * `null` (never set) and a parsed-empty array (`"[]"`, or equivalent with whitespace) both mean
- * "nothing to migrate" -- the latter matters because the pre-migration drain code always
- * rewrote a queue back to `"[]"` after draining it rather than removing the key, so a
- * non-null check alone can't tell "never had anything" apart from "already drained". Malformed
- * JSON is treated as "has something" so the real per-key parse in [migrateLegacyArray] (which
- * already tolerates and logs corrupt JSON) is what handles it, rather than this fast-path guard
- * silently skipping a corrupt-but-non-empty legacy queue.
+ * Whether [raw] (a legacy queue's raw stored value) holds at least one entry worth migrating. `null` (never set) and a parsed-empty array (`"[]"`, or equivalent with whitespace) both mean "nothing to migrate" -- the latter matters because the pre-migration drain code always rewrote a queue back to `"[]"` after draining it rather than removing the key, so a non-null check alone can't tell "never had anything" apart from "already drained". Malformed JSON is treated as "has something" so the real per-key parse in [migrateLegacyArray] (which already tolerates and logs corrupt JSON) is what handles it, rather than this fast-path guard silently skipping a corrupt-but-non-empty legacy queue.
  */
 private fun hasPendingLegacyEntries(raw: String?): Boolean {
     if (raw.isNullOrEmpty()) return false
@@ -175,10 +131,7 @@ private fun hasPendingLegacyEntries(raw: String?): Boolean {
 }
 
 /**
- * Migrates one legacy queue array (under [legacyKey] in [store]) into [outEnvelopes],
- * skipping entries with no valid `id`. [toPayloadAndPublishedAt] receives each legacy item
- * plus its index within its own legacy array and returns the new-schema payload object and
- * the `publishedAt` to stamp it with. Returns the number of entries migrated.
+ * Migrates one legacy queue array (under [legacyKey] in [store]) into [outEnvelopes], skipping entries with no valid `id`. [toPayloadAndPublishedAt] receives each legacy item plus its index within its own legacy array and returns the new-schema payload object and the `publishedAt` to stamp it with. Returns the number of entries migrated.
  */
 private fun migrateLegacyArray(
     store: KeyValueStore,
@@ -218,30 +171,13 @@ private fun migrateLegacyArray(
 }
 
 /**
- * Drains every entry in [queue] (across every topic, in chronological
- * [DurableEventQueue.Envelope.publishedAt] order) and hands each one to [dispatch], which
- * attempts delivery for the given topic/payload and returns whether it succeeded. Only
- * successfully-dispatched entries are committed (removed) from [queue] -- anything [dispatch]
- * returns `false` for stays queued for a later retry, mirroring the pre-migration per-type
- * drain/replay behaviour. Returns the number of entries actually dispatched.
+ * Drains every entry in [queue] (across every topic, in chronological [DurableEventQueue.Envelope.publishedAt] order) and hands each one to [dispatch], which attempts delivery for the given topic/payload and returns whether it succeeded. Only successfully-dispatched entries are committed (removed) from [queue] -- anything [dispatch] returns `false` for stays queued for a later retry, mirroring the pre-migration per-type drain/replay behaviour. Returns the number of entries actually dispatched.
  *
- * A standalone function (not a method) so it's unit-testable against a real
- * [DurableEventQueue]/in-memory [KeyValueStore] pair, with a fake [dispatch], and no Android
- * framework (Context, Channel) involved at all -- mirrors [migrateLegacyQueues] above.
+ * A standalone function (not a method) so it's unit-testable against a real [DurableEventQueue]/in-memory [KeyValueStore] pair, with a fake [dispatch], and no Android framework (Context, Channel) involved at all -- mirrors [migrateLegacyQueues] above.
  *
- * Two consequences of this design are intentional, not oversights, per issue #255's Unified
- * design (decision 7: every event flows through the log; drain-now replaces the old two-path
- * split; total order is preserved by draining everything, across all four topics, in
- * chronological order on every call):
- * - A process kill mid-drain -- after some [dispatch] calls have already succeeded but before
- *   the trailing [DurableEventQueue.commit] runs -- can redeliver already-delivered entries
- *   (possibly for a different topic than whichever call triggered this drain) on the next
- *   launch. Issue #255's Phase 3C adds Rust-side last-N eventId dedup specifically to absorb
- *   this.
- * - [enqueueAndDrain] below drains the *entire* cross-topic backlog synchronously on every
- *   single event, not just the topic that was just enqueued -- if a large backlog has built up,
- *   this could run long enough to threaten `AlarmReceiver.onReceive()`'s ANR budget. Issue
- *   #255's Phase 3A closes this by wrapping `onReceive()` in `goAsync()`.
+ * Two consequences of this design are intentional, not oversights, per issue #255's Unified design (decision 7: every event flows through the log; drain-now replaces the old two-path split; total order is preserved by draining everything, across all four topics, in chronological order on every call):
+ * - A process kill mid-drain -- after some [dispatch] calls have already succeeded but before the trailing [DurableEventQueue.commit] runs -- can redeliver already-delivered entries (possibly for a different topic than whichever call triggered this drain) on the next launch. Issue #255's Phase 3C adds Rust-side last-N eventId dedup specifically to absorb this.
+ * - [enqueueAndDrain] below drains the *entire* cross-topic backlog synchronously on every single event, not just the topic that was just enqueued -- if a large backlog has built up, this could run long enough to threaten `AlarmReceiver.onReceive()`'s ANR budget. Issue #255's Phase 3A closes this by wrapping `onReceive()` in `goAsync()`.
  */
 internal fun drainAndDispatch(queue: DurableEventQueue, dispatch: (topic: String, payload: String) -> Boolean): Int {
     val drained = queue.drainAll(pipelineReady = true)
@@ -361,13 +297,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             enqueueAndDrain(context, TOPIC_IMPORT, payload)
         }
 
-        // Every event flows through the log -- there is no separate "dispatch immediately"
-        // path any more. When the pipeline is already up and the right channel is registered,
-        // drainQueuedEvents() below delivers this same entry within the same call, so the net
-        // effect (and latency) matches the old immediate-dispatch path; when it isn't, the
-        // entry simply stays in the log until markAlarmPipelineReady() (or a later event of
-        // any topic) drains it. See drainAndDispatch()'s KDoc for the two deliberate,
-        // forward-referenced (issue #255) consequences of always draining the whole backlog.
+        // Every event flows through the log -- there is no separate "dispatch immediately" path any more. When the pipeline is already up and the right channel is registered, drainQueuedEvents() below delivers this same entry within the same call, so the net effect (and latency) matches the old immediate-dispatch path; when it isn't, the entry simply stays in the log until markAlarmPipelineReady() (or a later event of any topic) drains it. See drainAndDispatch()'s KDoc for the two deliberate, forward-referenced (issue #255) consequences of always draining the whole backlog.
         @Synchronized
         private fun enqueueAndDrain(context: Context, topic: String, payload: JSONObject) {
             val eventId = eventQueue(context).enqueue(topic, payload.toString())
@@ -648,14 +578,9 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
     }
 
     /**
-     * Drains every queued event (all topics, chronological arrival order) and dispatches each
-     * to the Channel matching its topic. A no-op while [alarmPipelineReady] is `false`.
+     * Drains every queued event (all topics, chronological arrival order) and dispatches each to the Channel matching its topic. A no-op while [alarmPipelineReady] is `false`.
      *
-     * This is the single delivery path to Rust: [notifyAlarmFired] and friends always enqueue
-     * first and then call this immediately, so when the pipeline is already up this runs in
-     * the very same call rather than as a separate "replay later" pass. The actual drain/topic
-     * -> outcome bookkeeping lives in [drainAndDispatch]; this just supplies the Android-side
-     * dispatch (Channel lookup + send).
+     * This is the single delivery path to Rust: [notifyAlarmFired] and friends always enqueue first and then call this immediately, so when the pipeline is already up this runs in the very same call rather than as a separate "replay later" pass. The actual drain/topic -> outcome bookkeeping lives in [drainAndDispatch]; this just supplies the Android-side dispatch (Channel lookup + send).
      */
     @Synchronized
     private fun drainQueuedEvents() {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -90,7 +90,13 @@ internal fun migrateLegacyQueues(store: KeyValueStore): Int {
         LEGACY_KEY_PENDING_DISMISS_EVENTS,
         LEGACY_KEY_PENDING_IMPORT_EVENTS,
     )
-    if (legacyKeys.none { store.get(it) != null }) return 0
+    // The pre-migration drain code these queues replace never removed a legacy key once
+    // drained -- it always rewrote the queue back to "[]" instead. So on essentially any
+    // device that's ever used alarms, all four legacy keys already exist by the time this
+    // runs; a plain non-null check would make this fast path never actually trigger. Parsing
+    // each one and checking for a genuinely non-empty array is what actually distinguishes
+    // "has real pending data" from "exists but was already drained to empty".
+    if (legacyKeys.none { hasPendingLegacyEntries(store.get(it)) }) return 0
 
     val envelopes = JSONArray()
     try {
@@ -138,11 +144,34 @@ internal fun migrateLegacyQueues(store: KeyValueStore): Int {
         payload to fallbackBase + index
     }
 
-    if (migratedCount > 0) {
-        store.set(EVENT_LOG_KEY, envelopes.toString())
-    }
-    legacyKeys.forEach { store.remove(it) }
+    // Written as one atomic batch rather than a separate set() + four remove() calls: if the
+    // process were killed between them, the next launch would see the new log already holding
+    // these entries but the legacy keys still present with their original data, re-trigger
+    // migration, and duplicate every entry in the log (each one reported to Rust twice --
+    // e.g. the same alarm fired/dismissed twice). Batching makes that intermediate state
+    // unobservable -- either both the log write and all four removals land, or neither does.
+    val sets = if (migratedCount > 0) mapOf(EVENT_LOG_KEY to envelopes.toString()) else emptyMap()
+    store.batch(sets = sets, removes = legacyKeys.toSet())
     return migratedCount
+}
+
+/**
+ * Whether [raw] (a legacy queue's raw stored value) holds at least one entry worth migrating.
+ * `null` (never set) and a parsed-empty array (`"[]"`, or equivalent with whitespace) both mean
+ * "nothing to migrate" -- the latter matters because the pre-migration drain code always
+ * rewrote a queue back to `"[]"` after draining it rather than removing the key, so a
+ * non-null check alone can't tell "never had anything" apart from "already drained". Malformed
+ * JSON is treated as "has something" so the real per-key parse in [migrateLegacyArray] (which
+ * already tolerates and logs corrupt JSON) is what handles it, rather than this fast-path guard
+ * silently skipping a corrupt-but-non-empty legacy queue.
+ */
+private fun hasPendingLegacyEntries(raw: String?): Boolean {
+    if (raw.isNullOrEmpty()) return false
+    return try {
+        JSONArray(raw).length() > 0
+    } catch (e: Exception) {
+        true
+    }
 }
 
 /**
@@ -199,6 +228,20 @@ private fun migrateLegacyArray(
  * A standalone function (not a method) so it's unit-testable against a real
  * [DurableEventQueue]/in-memory [KeyValueStore] pair, with a fake [dispatch], and no Android
  * framework (Context, Channel) involved at all -- mirrors [migrateLegacyQueues] above.
+ *
+ * Two consequences of this design are intentional, not oversights, per issue #255's Unified
+ * design (decision 7: every event flows through the log; drain-now replaces the old two-path
+ * split; total order is preserved by draining everything, across all four topics, in
+ * chronological order on every call):
+ * - A process kill mid-drain -- after some [dispatch] calls have already succeeded but before
+ *   the trailing [DurableEventQueue.commit] runs -- can redeliver already-delivered entries
+ *   (possibly for a different topic than whichever call triggered this drain) on the next
+ *   launch. Issue #255's Phase 3C adds Rust-side last-N eventId dedup specifically to absorb
+ *   this.
+ * - [enqueueAndDrain] below drains the *entire* cross-topic backlog synchronously on every
+ *   single event, not just the topic that was just enqueued -- if a large backlog has built up,
+ *   this could run long enough to threaten `AlarmReceiver.onReceive()`'s ANR budget. Issue
+ *   #255's Phase 3A closes this by wrapping `onReceive()` in `goAsync()`.
  */
 internal fun drainAndDispatch(queue: DurableEventQueue, dispatch: (topic: String, payload: String) -> Boolean): Int {
     val drained = queue.drainAll(pipelineReady = true)
@@ -323,7 +366,8 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         // drainQueuedEvents() below delivers this same entry within the same call, so the net
         // effect (and latency) matches the old immediate-dispatch path; when it isn't, the
         // entry simply stays in the log until markAlarmPipelineReady() (or a later event of
-        // any topic) drains it.
+        // any topic) drains it. See drainAndDispatch()'s KDoc for the two deliberate,
+        // forward-referenced (issue #255) consequences of always draining the whole backlog.
         @Synchronized
         private fun enqueueAndDrain(context: Context, topic: String, payload: JSONObject) {
             val eventId = eventQueue(context).enqueue(topic, payload.toString())

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/SetAlarmActivity.kt
@@ -78,11 +78,10 @@ class SetAlarmActivity : Activity() {
         // 4. Schedule Native (also persists to SharedPrefs for boot recovery)
         AlarmUtils.scheduleAlarm(this, id, triggerAt, null)
 
-        // 5. Hand off to Rust for real import -- dispatched immediately through the
-        // plugin's Channel if the app is already running and ready, or queued in
-        // SharedPreferences (same convention as the alarm-fired/snooze/dismiss events)
-        // to be drained once the pipeline is ready, since this Activity can be launched
-        // by the OS with the main Tauri process completely cold.
+        // 5. Hand off to Rust for real import -- enqueued into the shared native event log
+        // (same convention as the alarm-fired/snooze/dismiss events) and drained immediately
+        // if the pipeline is already up, or left queued until it becomes ready, since this
+        // Activity can be launched by the OS with the main Tauri process completely cold.
         AlarmManagerPlugin.notifyImportRequested(
             applicationContext,
             id,

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -174,6 +174,74 @@ class AlarmManagerPluginTest {
         assertTrue(DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true).isEmpty())
     }
 
+    @Test
+    fun `treats legacy keys already drained back to an empty array as nothing to migrate`() {
+        // The pre-migration drain code always rewrote a queue back to "[]" after draining it
+        // rather than removing the key -- so on any real device that's ever used alarms, these
+        // keys exist but hold no real data. A plain non-null guard would never fast-path here.
+        store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, "[]")
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, "[]")
+        store.set(LEGACY_KEY_PENDING_DISMISS_EVENTS, "[]")
+        store.set(LEGACY_KEY_PENDING_IMPORT_EVENTS, " [ ] ")
+
+        assertEquals(0, migrateLegacyQueues(store))
+        assertTrue(DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true).isEmpty())
+    }
+
+    @Test
+    fun `still migrates real entries when other legacy keys hold only an empty array`() {
+        store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, "[]")
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 1)).toString())
+
+        val migratedCount = migrateLegacyQueues(store)
+
+        assertEquals(1, migratedCount)
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        assertEquals(listOf(1), drained.map { JSONObject(it.payload).getInt("id") })
+    }
+
+    @Test
+    fun `migration applies the new log write and every legacy key removal as a single atomic batch`() {
+        val recording = RecordingKeyValueStore()
+        recording.seed(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 1)).toString())
+        recording.seed(LEGACY_KEY_PENDING_DISMISS_EVENTS, JSONArray().put(legacyIdOnly(id = 2)).toString())
+
+        val migratedCount = migrateLegacyQueues(recording)
+
+        assertEquals(2, migratedCount)
+        // No direct set()/remove() calls -- everything must go through the one atomic batch(),
+        // so a process kill can never observe the new log written but a legacy key still present.
+        assertEquals(0, recording.directWriteCalls)
+        assertEquals(1, recording.batchCalls.size)
+
+        val (sets, removes) = recording.batchCalls.single()
+        assertEquals(setOf(EVENT_LOG_KEY), sets.keys)
+        assertEquals(
+            setOf(
+                LEGACY_KEY_PENDING_ALARM_EVENTS,
+                LEGACY_KEY_PENDING_SNOOZE_EVENTS,
+                LEGACY_KEY_PENDING_DISMISS_EVENTS,
+                LEGACY_KEY_PENDING_IMPORT_EVENTS,
+            ),
+            removes,
+        )
+    }
+
+    @Test
+    fun `legacy keys holding only invalid entries are still removed via a single batch with nothing to write`() {
+        val recording = RecordingKeyValueStore()
+        recording.seed(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 0)).toString())
+
+        val migratedCount = migrateLegacyQueues(recording)
+
+        assertEquals(0, migratedCount)
+        assertEquals(0, recording.directWriteCalls)
+        assertEquals(1, recording.batchCalls.size)
+        val (sets, removes) = recording.batchCalls.single()
+        assertTrue(sets.isEmpty())
+        assertEquals(4, removes.size)
+    }
+
     // --- drainAndDispatch --------------------------------------------------------------------
 
     @Test

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -15,12 +15,7 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Plain JUnit 4 tests against [InMemoryKeyValueStore], covering the two pieces of logic this
- * plugin's migration to a shared [DurableEventQueue] added: [migrateLegacyQueues] (folding the
- * four legacy per-type queues into the unified log) and [drainAndDispatch] (draining that log
- * in arrival order and routing each entry to the right handler by topic). [DurableEventQueue]'s
- * own drain/commit/corruption-tolerance behaviour is already covered by
- * `plugins/native-bus`'s own test suite and isn't re-tested here.
+ * Plain JUnit 4 tests against [InMemoryKeyValueStore], covering the two pieces of logic this plugin's migration to a shared [DurableEventQueue] added: [migrateLegacyQueues] (folding the four legacy per-type queues into the unified log) and [drainAndDispatch] (draining that log in arrival order and routing each entry to the right handler by topic). [DurableEventQueue]'s own drain/commit/corruption-tolerance behaviour is already covered by `plugins/native-bus`'s own test suite and isn't re-tested here.
  */
 class AlarmManagerPluginTest {
 
@@ -94,8 +89,7 @@ class AlarmManagerPluginTest {
         migrateLegacyQueues(store)
 
         val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
-        // drainAll sorts by publishedAt, so id=2 (actualFiredAt=100) must come first even
-        // though it was appended second in the legacy array.
+        // drainAll sorts by publishedAt, so id=2 (actualFiredAt=100) must come first even though it was appended second in the legacy array.
         assertEquals(listOf(2, 1), drained.map { JSONObject(it.payload).getInt("id") })
     }
 
@@ -176,9 +170,7 @@ class AlarmManagerPluginTest {
 
     @Test
     fun `treats legacy keys already drained back to an empty array as nothing to migrate`() {
-        // The pre-migration drain code always rewrote a queue back to "[]" after draining it
-        // rather than removing the key -- so on any real device that's ever used alarms, these
-        // keys exist but hold no real data. A plain non-null guard would never fast-path here.
+        // The pre-migration drain code always rewrote a queue back to "[]" after draining it rather than removing the key -- so on any real device that's ever used alarms, these keys exist but hold no real data. A plain non-null guard would never fast-path here.
         store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, "[]")
         store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, "[]")
         store.set(LEGACY_KEY_PENDING_DISMISS_EVENTS, "[]")
@@ -209,8 +201,7 @@ class AlarmManagerPluginTest {
         val migratedCount = migrateLegacyQueues(recording)
 
         assertEquals(2, migratedCount)
-        // No direct set()/remove() calls -- everything must go through the one atomic batch(),
-        // so a process kill can never observe the new log written but a legacy key still present.
+        // No direct set()/remove() calls -- everything must go through the one atomic batch(), so a process kill can never observe the new log written but a legacy key still present.
         assertEquals(0, recording.directWriteCalls)
         assertEquals(1, recording.batchCalls.size)
 
@@ -315,9 +306,7 @@ class AlarmManagerPluginTest {
             put("triggerAt", triggerAt)
         }
 
-    // Mirrors DurableEventQueueTest's own writeRawEnvelopes/envelope helpers -- writing the raw
-    // schema directly is the only way to pin publishedAt deterministically, since
-    // DurableEventQueue.enqueue() always stamps it from the wall clock.
+    // Mirrors DurableEventQueueTest's own writeRawEnvelopes/envelope helpers -- writing the raw schema directly is the only way to pin publishedAt deterministically, since DurableEventQueue.enqueue() always stamps it from the wall clock.
     private fun envelope(topic: String, payload: String, eventId: String, publishedAt: Long): JSONObject =
         JSONObject().apply {
             put("v", DurableEventQueue.SCHEMA_VERSION)

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -1,0 +1,268 @@
+// Unit tests for AlarmManagerPlugin's migration and topic-dispatch logic
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.DurableEventQueue
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests against [InMemoryKeyValueStore], covering the two pieces of logic this
+ * plugin's migration to a shared [DurableEventQueue] added: [migrateLegacyQueues] (folding the
+ * four legacy per-type queues into the unified log) and [drainAndDispatch] (draining that log
+ * in arrival order and routing each entry to the right handler by topic). [DurableEventQueue]'s
+ * own drain/commit/corruption-tolerance behaviour is already covered by
+ * `plugins/native-bus`'s own test suite and isn't re-tested here.
+ */
+class AlarmManagerPluginTest {
+
+    private lateinit var store: InMemoryKeyValueStore
+
+    @Before
+    fun setUp() {
+        store = InMemoryKeyValueStore()
+    }
+
+    // --- migrateLegacyQueues ---------------------------------------------------------------
+
+    @Test
+    fun `migrates one entry of each legacy type into the unified log with the correct topic and payload`() {
+        store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, JSONArray().put(legacyFired(id = 1, actualFiredAt = 5_000)).toString())
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 2)).toString())
+        store.set(LEGACY_KEY_PENDING_DISMISS_EVENTS, JSONArray().put(legacyIdOnly(id = 3)).toString())
+        store.set(
+            LEGACY_KEY_PENDING_IMPORT_EVENTS,
+            JSONArray().put(legacyImport(id = 4, hour = 7, minute = 30, label = "Wake up", activeDays = listOf(1, 3, 5), triggerAt = 9_000))
+                .toString(),
+        )
+
+        val migratedCount = migrateLegacyQueues(store)
+        assertEquals(4, migratedCount)
+
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        val byTopic = drained.associateBy { it.topic }
+
+        assertEquals(setOf(TOPIC_FIRED, TOPIC_SNOOZE, TOPIC_DISMISS, TOPIC_IMPORT), byTopic.keys)
+
+        val firedPayload = JSONObject(byTopic.getValue(TOPIC_FIRED).payload)
+        assertEquals(1, firedPayload.getInt("id"))
+        assertEquals(5_000L, firedPayload.getLong("actualFiredAt"))
+
+        assertEquals(2, JSONObject(byTopic.getValue(TOPIC_SNOOZE).payload).getInt("id"))
+        assertEquals(3, JSONObject(byTopic.getValue(TOPIC_DISMISS).payload).getInt("id"))
+
+        val importPayload = JSONObject(byTopic.getValue(TOPIC_IMPORT).payload)
+        assertEquals(4, importPayload.getInt("id"))
+        assertEquals(7, importPayload.getInt("hour"))
+        assertEquals(30, importPayload.getInt("minute"))
+        assertEquals("Wake up", importPayload.getString("label"))
+        assertEquals(9_000L, importPayload.getLong("triggerAt"))
+    }
+
+    @Test
+    fun `removes every legacy key once migration completes`() {
+        store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, JSONArray().put(legacyFired(id = 1, actualFiredAt = 1_000)).toString())
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 2)).toString())
+
+        migrateLegacyQueues(store)
+
+        assertNull(store.get(LEGACY_KEY_PENDING_ALARM_EVENTS))
+        assertNull(store.get(LEGACY_KEY_PENDING_SNOOZE_EVENTS))
+        assertNull(store.get(LEGACY_KEY_PENDING_DISMISS_EVENTS))
+        assertNull(store.get(LEGACY_KEY_PENDING_IMPORT_EVENTS))
+    }
+
+    @Test
+    fun `uses actualFiredAt as the migrated publishedAt for fired events`() {
+        // Seeded out of chronological order -- the later actualFiredAt is appended first.
+        store.set(
+            LEGACY_KEY_PENDING_ALARM_EVENTS,
+            JSONArray()
+                .put(legacyFired(id = 1, actualFiredAt = 200))
+                .put(legacyFired(id = 2, actualFiredAt = 100))
+                .toString(),
+        )
+
+        migrateLegacyQueues(store)
+
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        // drainAll sorts by publishedAt, so id=2 (actualFiredAt=100) must come first even
+        // though it was appended second in the legacy array.
+        assertEquals(listOf(2, 1), drained.map { JSONObject(it.payload).getInt("id") })
+    }
+
+    @Test
+    fun `falls back to original array order for legacy entries with no recorded timestamp`() {
+        store.set(
+            LEGACY_KEY_PENDING_SNOOZE_EVENTS,
+            JSONArray()
+                .put(legacyIdOnly(id = 10))
+                .put(legacyIdOnly(id = 20))
+                .put(legacyIdOnly(id = 30))
+                .toString(),
+        )
+
+        migrateLegacyQueues(store)
+
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        assertEquals(listOf(10, 20, 30), drained.map { JSONObject(it.payload).getInt("id") })
+    }
+
+    @Test
+    fun `migration is a one-time no-op once the legacy keys are already gone`() {
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 1)).toString())
+        assertEquals(1, migrateLegacyQueues(store))
+
+        // A second run (e.g. a later app launch) must not re-migrate or duplicate anything.
+        assertEquals(0, migrateLegacyQueues(store))
+        assertEquals(1, DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true).size)
+    }
+
+    @Test
+    fun `preserves entries already sitting in the unified log before migration runs`() {
+        val preExistingId = DurableEventQueue(store, EVENT_LOG_KEY).enqueue(TOPIC_FIRED, JSONObject().put("id", 99).toString())
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 1)).toString())
+
+        migrateLegacyQueues(store)
+
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        assertEquals(2, drained.size)
+        assertTrue(drained.any { it.eventId == preExistingId })
+    }
+
+    @Test
+    fun `entries with a missing or non-positive id are skipped`() {
+        store.set(
+            LEGACY_KEY_PENDING_SNOOZE_EVENTS,
+            JSONArray()
+                .put(legacyIdOnly(id = 0))
+                .put(JSONObject())
+                .put(legacyIdOnly(id = 5))
+                .toString(),
+        )
+
+        val migratedCount = migrateLegacyQueues(store)
+
+        assertEquals(1, migratedCount)
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        assertEquals(listOf(5), drained.map { JSONObject(it.payload).getInt("id") })
+    }
+
+    @Test
+    fun `a corrupt legacy array is skipped without failing migration of the others`() {
+        store.set(LEGACY_KEY_PENDING_ALARM_EVENTS, "not even json")
+        store.set(LEGACY_KEY_PENDING_SNOOZE_EVENTS, JSONArray().put(legacyIdOnly(id = 7)).toString())
+
+        val migratedCount = migrateLegacyQueues(store)
+
+        assertEquals(1, migratedCount)
+        val drained = DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true)
+        assertEquals(listOf(7), drained.map { JSONObject(it.payload).getInt("id") })
+    }
+
+    @Test
+    fun `does nothing when no legacy keys are present`() {
+        assertEquals(0, migrateLegacyQueues(store))
+        assertTrue(DurableEventQueue(store, EVENT_LOG_KEY).drainAll(pipelineReady = true).isEmpty())
+    }
+
+    // --- drainAndDispatch --------------------------------------------------------------------
+
+    @Test
+    fun `drains events across topics in publishedAt order and dispatches each to the right handler`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        writeRawEnvelopes(
+            envelope(topic = TOPIC_IMPORT, payload = "import-payload", eventId = "id-3", publishedAt = 300),
+            envelope(topic = TOPIC_FIRED, payload = "fired-payload", eventId = "id-1", publishedAt = 100),
+            envelope(topic = TOPIC_SNOOZE, payload = "snooze-payload", eventId = "id-2", publishedAt = 200),
+        )
+
+        val dispatched = mutableListOf<Pair<String, String>>()
+        val handledCount = drainAndDispatch(queue) { topic, payload ->
+            dispatched.add(topic to payload)
+            true
+        }
+
+        assertEquals(3, handledCount)
+        assertEquals(
+            listOf(
+                TOPIC_FIRED to "fired-payload",
+                TOPIC_SNOOZE to "snooze-payload",
+                TOPIC_IMPORT to "import-payload",
+            ),
+            dispatched,
+        )
+    }
+
+    @Test
+    fun `entries the dispatcher declines stay queued for a later retry`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        val deliveredId = queue.enqueue(TOPIC_FIRED, "delivered")
+        val undeliveredId = queue.enqueue(TOPIC_SNOOZE, "undelivered")
+
+        val handledCount = drainAndDispatch(queue) { topic, _ -> topic == TOPIC_FIRED }
+
+        assertEquals(1, handledCount)
+        val remaining = queue.drainAll(pipelineReady = true)
+        assertEquals(listOf(undeliveredId), remaining.map { it.eventId })
+        assertTrue(remaining.none { it.eventId == deliveredId })
+    }
+
+    @Test
+    fun `draining an empty queue dispatches nothing and returns zero`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        var dispatchCalls = 0
+
+        val handledCount = drainAndDispatch(queue) { _, _ -> dispatchCalls++; true }
+
+        assertEquals(0, handledCount)
+        assertEquals(0, dispatchCalls)
+    }
+
+    // --- fixtures ------------------------------------------------------------------------------
+
+    private fun legacyFired(id: Int, actualFiredAt: Long): JSONObject =
+        JSONObject().apply {
+            put("id", id)
+            put("actualFiredAt", actualFiredAt)
+        }
+
+    private fun legacyIdOnly(id: Int): JSONObject = JSONObject().apply { put("id", id) }
+
+    private fun legacyImport(id: Int, hour: Int, minute: Int, label: String, activeDays: List<Int>, triggerAt: Long): JSONObject =
+        JSONObject().apply {
+            put("id", id)
+            put("hour", hour)
+            put("minute", minute)
+            put("label", label)
+            put("activeDays", JSONArray(activeDays))
+            put("triggerAt", triggerAt)
+        }
+
+    // Mirrors DurableEventQueueTest's own writeRawEnvelopes/envelope helpers -- writing the raw
+    // schema directly is the only way to pin publishedAt deterministically, since
+    // DurableEventQueue.enqueue() always stamps it from the wall clock.
+    private fun envelope(topic: String, payload: String, eventId: String, publishedAt: Long): JSONObject =
+        JSONObject().apply {
+            put("v", DurableEventQueue.SCHEMA_VERSION)
+            put("topic", topic)
+            put("payload", payload)
+            put("eventId", eventId)
+            put("publishedAt", publishedAt)
+            put("handledNatively", JSONArray())
+        }
+
+    private fun writeRawEnvelopes(vararg envelopes: JSONObject) {
+        val array = JSONArray()
+        envelopes.forEach { array.put(it) }
+        store.set(EVENT_LOG_KEY, array.toString())
+    }
+}

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/InMemoryKeyValueStore.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/InMemoryKeyValueStore.kt
@@ -1,0 +1,31 @@
+// In-memory KeyValueStore fake for JUnit tests -- no Android framework required
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.KeyValueStore
+
+/**
+ * In-memory [KeyValueStore] fake, so tests don't need SharedPreferences/Robolectric.
+ *
+ * A local copy of `native-bus`'s own test-only fake of the same name
+ * (`ca.liminalhq.threshold.nativebus.InMemoryKeyValueStore`) -- that one lives under
+ * native-bus's `src/test/`, which this module's `implementation(project(...))` dependency
+ * doesn't expose (only a module's `main` source set output is shared that way), so this
+ * plugin's own tests need their own copy of the same trivial fake.
+ */
+class InMemoryKeyValueStore : KeyValueStore {
+    private val values = mutableMapOf<String, String>()
+
+    override fun get(key: String): String? = values[key]
+
+    override fun set(key: String, value: String) {
+        values[key] = value
+    }
+
+    override fun remove(key: String) {
+        values.remove(key)
+    }
+}

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/RecordingKeyValueStore.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/RecordingKeyValueStore.kt
@@ -1,0 +1,53 @@
+// KeyValueStore fake that records batch() vs. direct set()/remove() calls, for JUnit tests
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.KeyValueStore
+
+/**
+ * [KeyValueStore] fake that records every [batch] call (its arguments) separately from direct
+ * [set]/[remove] calls, so a test can assert that a piece of production code went through the
+ * atomic [batch] path rather than issuing separate, unguarded writes -- see
+ * `AlarmManagerPluginTest`'s migration-atomicity test, which exists specifically to catch a
+ * regression back to the two-step "write the new log, then remove the legacy keys" sequence
+ * that could leave a torn state behind if the process died in between.
+ *
+ * Storage itself is delegated to a plain [InMemoryKeyValueStore] -- this class only adds the
+ * call-recording layer on top.
+ */
+class RecordingKeyValueStore : KeyValueStore {
+    private val delegate = InMemoryKeyValueStore()
+
+    /** Arguments of every [batch] call, in call order. */
+    val batchCalls = mutableListOf<Pair<Map<String, String>, Set<String>>>()
+
+    /** Count of direct (non-batched) [set]/[remove] calls. */
+    var directWriteCalls = 0
+        private set
+
+    /** Seeds [key] with [value] without counting as a "direct write" -- for test setup only. */
+    fun seed(key: String, value: String) {
+        delegate.set(key, value)
+    }
+
+    override fun get(key: String): String? = delegate.get(key)
+
+    override fun set(key: String, value: String) {
+        directWriteCalls++
+        delegate.set(key, value)
+    }
+
+    override fun remove(key: String) {
+        directWriteCalls++
+        delegate.remove(key)
+    }
+
+    override fun batch(sets: Map<String, String>, removes: Set<String>) {
+        batchCalls.add(sets to removes)
+        sets.forEach { (key, value) -> delegate.set(key, value) }
+        removes.forEach { delegate.remove(it) }
+    }
+}

--- a/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
+++ b/plugins/native-bus/android/src/main/java/ca/liminalhq/threshold/nativebus/KeyValueStore.kt
@@ -21,6 +21,23 @@ interface KeyValueStore {
 
     /** Removes [key] entirely. A no-op if it was never set. */
     fun remove(key: String)
+
+    /**
+     * Applies every entry in [sets] and removes every key in [removes] as a single atomic
+     * unit, so a caller can never observe a state partway through -- e.g. a new value written
+     * but an old key it's meant to replace not yet removed, if the process dies in between.
+     * Callers that need that all-or-nothing guarantee (see [SharedPreferencesKeyValueStore]'s
+     * override) should use this instead of separate [set]/[remove] calls.
+     *
+     * The default implementation just applies them sequentially via [set]/[remove] -- fine for
+     * simple in-memory fakes with no concurrent reader that could observe a torn state, but not
+     * a real atomicity guarantee. Override this on any [KeyValueStore] backed by real
+     * persistence.
+     */
+    fun batch(sets: Map<String, String> = emptyMap(), removes: Set<String> = emptySet()) {
+        sets.forEach { (key, value) -> set(key, value) }
+        removes.forEach { remove(it) }
+    }
 }
 
 /**
@@ -41,5 +58,12 @@ class SharedPreferencesKeyValueStore(
 
     override fun remove(key: String) {
         prefs.edit().remove(key).apply()
+    }
+
+    override fun batch(sets: Map<String, String>, removes: Set<String>) {
+        val editor = prefs.edit()
+        sets.forEach { (key, value) -> editor.putString(key, value) }
+        removes.forEach { editor.remove(it) }
+        editor.apply()
     }
 }


### PR DESCRIPTION
## What this is

Phase 2A of #255's implementation plan: a behaviour-preserving refactor replacing `AlarmManagerPlugin`'s four independently hand-rolled queue/drain pairs (fired/snooze/dismiss/import, each its own SharedPreferences key) with one `DurableEventQueue` instance from the new `plugins/native-bus` substrate (#294). Rust sees a byte-identical event stream — only the internal Kotlin-side storage/drain mechanism changes.

## What's here

- One `DurableEventQueue` replaces the four queue/drain pairs; the four Channels, Tauri event names, and `alarmPipelineReady`/`markAlarmPipelineReady` gate are all unchanged.
- Drain is now one chronological pass across all topics (true arrival order) instead of the old fixed fired→snooze→dismiss→import order.
- "Immediate dispatch" becomes enqueue + drain-now — one code path instead of the old ready/queued split, per #255's decision that the log should be the only delivery path to Rust.
- A one-time, **atomic** migration (single `SharedPreferences.Editor` transaction) drains any leftover entries from the legacy `AlarmManagerCallbacks` keys into the new log before removing them — production devices have been observed carrying pending events across multiple days, so this can't silently drop data. One-way; noted in `RELEASE_NOTES.md`.
- A code comment documents two intentional, known-and-covered tradeoffs rather than leaving them looking like oversights: possible duplicate redelivery on a crash mid-drain (Phase 3C adds Rust-side eventId dedup for this) and synchronous full-backlog draining inside `AlarmReceiver.onReceive()` (Phase 3A wraps that in `goAsync()`).

## Testing checklist (automated, no device needed)

- [x] 16/16 JUnit (migration correctness, atomic-batch behaviour, topic-dispatch ordering, fixed skip-guard)
- [x] `cargo check --workspace` clean (Rust side untouched, as expected)
- [x] Full `pnpm tauri android build` succeeds end-to-end

## Review status

Reviewed via `/code-review high` twice. First pass found a real migration-atomicity gap (a process kill between writing the new log and clearing the four legacy keys could re-migrate and duplicate events on next launch) and a broken "already migrated" skip-guard that never actually short-circuited on real devices. Both fixed and re-verified. Two other findings (crash-window redelivery, synchronous full-backlog drain) were confirmed as intentional consequences of the design rather than bugs, and documented in-code instead of changed.

Stacked on #294. Part of #255.