### PR TITLE
Publish fired alarms onto NativeEventBus for instant watch-ring

### DIFF
--- a/docs/architecture/255-phase3-payload-contract.md
+++ b/docs/architecture/255-phase3-payload-contract.md
@@ -1,0 +1,61 @@
+<!--
+Copyright 2026 Liminal HQ
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Issue #255 Phase 3 payload contract
+
+Frozen wire shape for the fired→watch-ring fan-out, so the three parallel Phase 3 branches
+(alarm-manager publisher, wear-sync listener, app Rust core) build against identical fields.
+This is a working note for the duration of Phase 3 — its content gets folded into
+`docs/architecture/event-architecture.md` in Phase 5A and this file is deleted then.
+
+## Kotlin: `alarm-manager:native-fired` bus/Channel payload
+
+The existing `{id, actualFiredAt}` payload gains two fields:
+
+```json
+{
+  "id": 123,
+  "actualFiredAt": 1755100800000,
+  "eventId": "b3f1c2a4-...",
+  "handledNatively": ["watch-ring"]
+}
+```
+
+- `eventId` — the `DurableEventQueue` envelope's UUID for this event (stable across the
+  immediate-Channel send and the durable-queue copy of the same event).
+- `handledNatively` — the set of side-effect tags returned by `NativeEventBus.publish()`'s
+  listeners for this event, stamped in at publish time (per the Unified design's "one publish
+  path, two delivery planes" decision). Empty array when no native listener handled it (e.g.
+  wear-sync's provider hasn't registered yet, or the dev toggle disabled fan-out).
+
+## Rust: `AlarmFired` (`apps/threshold/src-tauri/src/alarm/events.rs`)
+
+Gains one field, `#[serde(default)]` so it deserializes cleanly from any payload that predates
+this change (desktop, or a queued pre-Phase-3 event replayed after upgrade):
+
+```rust
+pub handled_natively: Vec<String>,
+```
+
+This is the struct actually broadcast app-wide as `alarm:fired` (confirmed during planning —
+**not** `NativeAlarmFiredPayload`, which is a separate, plugin-local struct in
+`plugins/alarm-manager/src/models.rs` used only to deserialize the raw Kotlin Channel payload
+inside `mobile.rs`). `NativeAlarmFiredPayload` also gains `event_id: Option<String>` and
+`handled_natively: Vec<String>` (`#[serde(default)]` on both) so the tags collected in Kotlin
+survive the hop from the Channel payload into the `AlarmFired` event that `report_alarm_fired`
+constructs and broadcasts.
+
+Neither struct is ts-rs-annotated (confirmed during planning), so adding these fields does not
+trigger `apps/threshold/src/types/alarm.ts` regeneration or its CI drift check.
+
+## Shared constants
+
+- Tag literal for the ring side effect: `"watch-ring"` (exact string, used on both the Kotlin
+  publish side and the Rust gating check).
+- Staleness window: `90_000` (milliseconds) compared against `actualFiredAt`. Applied
+  independently in two places per the Unified design's decision 6: wear-sync's native listener
+  (skip the ring side effect, no tag) and wear-sync's Rust `alarm:fired` listener (skip
+  `send_alarm_ring`, regardless of tag) — the Rust-side guard alone is what fixes the shipped
+  2:30 AM ghost-ring bug retroactively for events queued before this ships.

--- a/docs/architecture/255-phase3-payload-contract.md
+++ b/docs/architecture/255-phase3-payload-contract.md
@@ -5,10 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Issue #255 Phase 3 payload contract
 
-Frozen wire shape for the fired→watch-ring fan-out, so the three parallel Phase 3 branches
-(alarm-manager publisher, wear-sync listener, app Rust core) build against identical fields.
-This is a working note for the duration of Phase 3 — its content gets folded into
-`docs/architecture/event-architecture.md` in Phase 5A and this file is deleted then.
+Frozen wire shape for the fired→watch-ring fan-out, so the three parallel Phase 3 branches (alarm-manager publisher, wear-sync listener, app Rust core) build against identical fields. This is a working note for the duration of Phase 3 — its content gets folded into `docs/architecture/event-architecture.md` in Phase 5A and this file is deleted then.
 
 ## Kotlin: `alarm-manager:native-fired` bus/Channel payload
 
@@ -23,39 +20,22 @@ The existing `{id, actualFiredAt}` payload gains two fields:
 }
 ```
 
-- `eventId` — the `DurableEventQueue` envelope's UUID for this event (stable across the
-  immediate-Channel send and the durable-queue copy of the same event).
-- `handledNatively` — the set of side-effect tags returned by `NativeEventBus.publish()`'s
-  listeners for this event, stamped in at publish time (per the Unified design's "one publish
-  path, two delivery planes" decision). Empty array when no native listener handled it (e.g.
-  wear-sync's provider hasn't registered yet, or the dev toggle disabled fan-out).
+- `eventId` — the `DurableEventQueue` envelope's UUID for this event (stable across the immediate-Channel send and the durable-queue copy of the same event).
+- `handledNatively` — the set of side-effect tags returned by `NativeEventBus.publish()`'s listeners for this event, stamped in at publish time (per the Unified design's "one publish path, two delivery planes" decision). Empty array when no native listener handled it (e.g. wear-sync's provider hasn't registered yet, or the dev toggle disabled fan-out).
 
 ## Rust: `AlarmFired` (`apps/threshold/src-tauri/src/alarm/events.rs`)
 
-Gains one field, `#[serde(default)]` so it deserializes cleanly from any payload that predates
-this change (desktop, or a queued pre-Phase-3 event replayed after upgrade):
+Gains one field, `#[serde(default)]` so it deserializes cleanly from any payload that predates this change (desktop, or a queued pre-Phase-3 event replayed after upgrade):
 
 ```rust
 pub handled_natively: Vec<String>,
 ```
 
-This is the struct actually broadcast app-wide as `alarm:fired` (confirmed during planning —
-**not** `NativeAlarmFiredPayload`, which is a separate, plugin-local struct in
-`plugins/alarm-manager/src/models.rs` used only to deserialize the raw Kotlin Channel payload
-inside `mobile.rs`). `NativeAlarmFiredPayload` also gains `event_id: Option<String>` and
-`handled_natively: Vec<String>` (`#[serde(default)]` on both) so the tags collected in Kotlin
-survive the hop from the Channel payload into the `AlarmFired` event that `report_alarm_fired`
-constructs and broadcasts.
+This is the struct actually broadcast app-wide as `alarm:fired` (confirmed during planning — **not** `NativeAlarmFiredPayload`, which is a separate, plugin-local struct in `plugins/alarm-manager/src/models.rs` used only to deserialize the raw Kotlin Channel payload inside `mobile.rs`). `NativeAlarmFiredPayload` also gains `event_id: Option<String>` and `handled_natively: Vec<String>` (`#[serde(default)]` on both) so the tags collected in Kotlin survive the hop from the Channel payload into the `AlarmFired` event that `report_alarm_fired` constructs and broadcasts.
 
-Neither struct is ts-rs-annotated (confirmed during planning), so adding these fields does not
-trigger `apps/threshold/src/types/alarm.ts` regeneration or its CI drift check.
+Neither struct is ts-rs-annotated (confirmed during planning), so adding these fields does not trigger `apps/threshold/src/types/alarm.ts` regeneration or its CI drift check.
 
 ## Shared constants
 
-- Tag literal for the ring side effect: `"watch-ring"` (exact string, used on both the Kotlin
-  publish side and the Rust gating check).
-- Staleness window: `90_000` (milliseconds) compared against `actualFiredAt`. Applied
-  independently in two places per the Unified design's decision 6: wear-sync's native listener
-  (skip the ring side effect, no tag) and wear-sync's Rust `alarm:fired` listener (skip
-  `send_alarm_ring`, regardless of tag) — the Rust-side guard alone is what fixes the shipped
-  2:30 AM ghost-ring bug retroactively for events queued before this ships.
+- Tag literal for the ring side effect: `"watch-ring"` (exact string, used on both the Kotlin publish side and the Rust gating check).
+- Staleness window: `90_000` (milliseconds) compared against `actualFiredAt`. Applied independently in two places per the Unified design's decision 6: wear-sync's native listener (skip the ring side effect, no tag) and wear-sync's Rust `alarm:fired` listener (skip `send_alarm_ring`, regardless of tag) — the Rust-side guard alone is what fixes the shipped 2:30 AM ghost-ring bug retroactively for events queued before this ships.

--- a/docs/architecture/255-phase3-payload-contract.md
+++ b/docs/architecture/255-phase3-payload-contract.md
@@ -16,10 +16,10 @@ The existing `{id, actualFiredAt}` payload gains two fields:
 
 ```json
 {
-  "id": 123,
-  "actualFiredAt": 1755100800000,
-  "eventId": "b3f1c2a4-...",
-  "handledNatively": ["watch-ring"]
+	"id": 123,
+	"actualFiredAt": 1755100800000,
+	"eventId": "b3f1c2a4-...",
+	"handledNatively": ["watch-ring"]
 }
 ```
 

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -171,38 +171,40 @@ private fun migrateLegacyArray(
 }
 
 /**
- * Drains every entry in [queue] (across every topic, in chronological [DurableEventQueue.Envelope.publishedAt] order) and hands each one to [dispatch], which attempts delivery for the given topic/payload and returns whether it succeeded. Only successfully-dispatched entries are committed (removed) from [queue] -- anything [dispatch] returns `false` for stays queued for a later retry, mirroring the pre-migration per-type drain/replay behaviour. Returns the number of entries actually dispatched.
+ * Drains every entry in [queue] (across every topic, in chronological [DurableEventQueue.Envelope.publishedAt] order) and hands each one to [dispatch], which attempts delivery for the given topic/payload and returns whether it succeeded. Each successfully-dispatched entry is committed (removed) from [queue] **immediately**, one at a time, rather than accumulated into a batch and committed once after the whole loop finishes -- see below for why. Anything [dispatch] returns `false` for stays queued for a later retry, mirroring the pre-migration per-type drain/replay behaviour. Returns the number of entries actually dispatched.
  *
  * A standalone function (not a method) so it's unit-testable against a real [DurableEventQueue]/in-memory [KeyValueStore] pair, with a fake [dispatch], and no Android framework (Context, Channel) involved at all -- mirrors [migrateLegacyQueues] above.
  *
  * Two consequences of this design are intentional, not oversights, per issue #255's Unified design (decision 7: every event flows through the log; drain-now replaces the old two-path split; total order is preserved by draining everything, across all four topics, in chronological order on every call):
- * - A process kill mid-drain -- after some [dispatch] calls have already succeeded but before the trailing [DurableEventQueue.commit] runs -- can redeliver already-delivered entries (possibly for a different topic than whichever call triggered this drain) on the next launch. Issue #255's Phase 3C adds Rust-side last-N eventId dedup specifically to absorb this.
+ * - A process kill mid-drain -- after [dispatch] has returned `true` for some entry but before that entry's own [DurableEventQueue.commit] call runs -- can still redeliver *that one* entry on the next launch. Committing per-item (rather than batching every commit until the loop finishes) narrows this window from "every entry dispatched so far in this drain" down to "at most the single entry in flight at the moment of the crash" -- per Phase 3C's review, the in-memory `EventDedup` buffer Rust maintains for exactly this case is itself wiped by the same crash, so it cannot help across a restart; shrinking the window on this side is the most effective mitigation available without persisted cross-restart dedup state (tracked separately, not solved here).
  * - [enqueueAndDrain] below drains the *entire* cross-topic backlog synchronously on every single event, not just the topic that was just enqueued -- if a large backlog has built up, this could run long enough to threaten `AlarmReceiver.onReceive()`'s ANR budget. Issue #255's Phase 3A closes this by wrapping `onReceive()` in `goAsync()`.
  */
 internal fun drainAndDispatch(queue: DurableEventQueue, dispatch: (topic: String, payload: String) -> Boolean): Int {
     val drained = queue.drainAll(pipelineReady = true)
     if (drained.isEmpty()) return 0
 
-    val handledEventIds = mutableSetOf<String>()
+    var handledCount = 0
     for (envelope in drained) {
         if (dispatch(envelope.topic, enrichPayloadForDispatch(envelope))) {
-            handledEventIds.add(envelope.eventId)
+            queue.commit(setOf(envelope.eventId))
+            handledCount++
         }
     }
-    if (handledEventIds.isNotEmpty()) queue.commit(handledEventIds)
-    return handledEventIds.size
+    return handledCount
 }
 
 /**
  * Returns [envelope]'s payload as-is, except for [TOPIC_FIRED] where it's enriched with
- * `eventId`/`handledNatively` before dispatch -- per
- * docs/architecture/255-phase3-payload-contract.md, these are the two fields Rust's
- * `NativeAlarmFiredPayload` needs to carry the tags `AlarmReceiver.kt`'s `publishAlarmFiredToBus`
- * collected (e.g. `"watch-ring"`) and the envelope's own stable ID through to the
- * `alarm-manager:native-fired` Tauri event, whether this is the immediate post-enqueue drain or
- * a later retry of the same queued entry. Only [TOPIC_FIRED] gains these fields -- the contract
- * only specifies them for the fired event, and the other three topics' Rust payload structs
- * don't declare them.
+ * `eventId` before dispatch -- per docs/architecture/255-phase3-payload-contract.md, this is the
+ * one field Rust's `NativeAlarmFiredPayload` needs that genuinely can't be known until
+ * [DurableEventQueue.enqueue] returns it, so it can't be baked into the payload upfront the way
+ * `handledNatively` is (see [notifyAlarmFired], which writes `handledNatively` directly into the
+ * payload it builds -- by the time [enrichPayloadForDispatch] runs, it's already sitting in
+ * [envelope]'s own payload JSON, so there's nothing left for this function to add for it).
+ * Carries the envelope's own stable ID through to the `alarm-manager:native-fired` Tauri event,
+ * whether this is the immediate post-enqueue drain or a later retry of the same queued entry.
+ * Only [TOPIC_FIRED] gains this field -- the contract only specifies it for the fired event, and
+ * the other three topics' Rust payload structs don't declare it.
  *
  * [envelope.payload][DurableEventQueue.Envelope.payload] is always caller-constructed JSON (see
  * [notifyAlarmFired]), so re-parsing it here should never fail in practice -- the `catch` exists
@@ -213,7 +215,6 @@ internal fun enrichPayloadForDispatch(envelope: DurableEventQueue.Envelope): Str
     return try {
         JSONObject(envelope.payload).apply {
             put("eventId", envelope.eventId)
-            put("handledNatively", JSONArray(envelope.handledNatively.toList()))
         }.toString()
     } catch (e: Exception) {
         Log.w(TAG, "Failed to enrich fired-event payload for eventId ${envelope.eventId}, dispatching unenriched", e)
@@ -279,17 +280,31 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         var instance: AlarmManagerPlugin? = null
             private set
 
+        /**
+         * @param firedPayload the shared `{id, actualFiredAt}` payload -- built exactly once by
+         *   the caller (see `AlarmReceiver.recordAndPublishFiredEvent`'s KDoc) and reused here
+         *   rather than re-derived from separate `id`/`actualFiredAt` args, so there's a single
+         *   source of truth for this shape (docs/architecture/255-phase3-payload-contract.md)
+         *   instead of two independent hand-built copies risking silent divergence. Not mutated
+         *   in place -- [handledNatively] is written into a fresh copy -- since the caller may
+         *   still reuse the original for the `NativeEventBus` publish, which must stay exactly
+         *   `{id, actualFiredAt}` per the bus's own contract.
+         * @param handledNatively written directly into the persisted/dispatched payload here
+         *   (rather than late-injected at drain time -- see [enrichPayloadForDispatch], which
+         *   only still needs to inject `eventId`) since it's already known as a plain parameter
+         *   at this point. Only `eventId` genuinely can't be known yet: it doesn't exist until
+         *   [DurableEventQueue.enqueue] (called via [enqueueAndDrain] below) returns it.
+         */
         @Synchronized
         fun notifyAlarmFired(
             context: Context,
             alarmId: Int,
-            actualFiredAt: Long = System.currentTimeMillis(),
+            firedPayload: JSONObject,
             handledNatively: Set<String> = emptySet(),
         ) {
             if (alarmId <= 0) return
-            val payload = JSONObject().apply {
-                put("id", alarmId)
-                put("actualFiredAt", actualFiredAt)
+            val payload = JSONObject(firedPayload.toString()).apply {
+                put("handledNatively", JSONArray(handledNatively.toList()))
             }
             enqueueAndDrain(context, TOPIC_FIRED, payload, handledNatively)
         }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -224,7 +224,48 @@ internal fun enrichPayloadForDispatch(envelope: DurableEventQueue.Envelope): Str
 
 private fun keyValueStore(context: Context): KeyValueStore = SharedPreferencesKeyValueStore(context, CALLBACK_PREFS)
 
-private fun eventQueue(context: Context): DurableEventQueue = DurableEventQueue(keyValueStore(context), EVENT_LOG_KEY)
+// Process-wide singleton -- mirrors WearSyncEventQueue.getInstance()'s pattern (see its KDoc)
+// for the same reason: DurableEventQueue's own @Synchronized enqueue/drainAll/commit methods
+// only lock their own instance's monitor, so two independently-constructed instances pointed
+// at the same underlying SharedPreferences key -- as this function used to build fresh on
+// every call, once via notifyAlarmFired/enqueueAndDrain's companion-object call path (reached
+// from AlarmReceiver's background-executor worker thread) and separately via
+// drainQueuedEvents' instance call path (reached from the main thread, e.g.
+// markAlarmPipelineReady) -- provide *no* mutual exclusion against each other. A background
+// enqueue racing a main-thread drain could each read the same pre-write JSON array and then
+// clobber each other's write, including resurrecting an entry the other side had just
+// committed as delivered. Routing every caller through one shared instance makes every
+// enqueue/drainAll/commit call atomic relative to every other, regardless of which thread or
+// which of this plugin's two top-level @Synchronized scopes (Companion vs. instance) it came
+// through.
+@Volatile
+private var sharedEventQueue: DurableEventQueue? = null
+private val eventQueueInitLock = Any()
+
+/**
+ * Returns the process-wide shared [DurableEventQueue] backed by [store], constructing it on
+ * first access (double-checked locking, mirroring wear-sync's `WearSyncEventQueue.getInstance`
+ * shape). [eventQueue] below is the production entry point, supplying the real
+ * Context-backed [SharedPreferencesKeyValueStore]; this Context-free overload exists purely
+ * so tests can exercise the actual singleton-holder logic -- and the concurrency guarantee it
+ * provides -- against an in-memory [KeyValueStore] fake, without needing a real
+ * `android.content.Context` (this module's JUnit tests run on the plain host JVM, no
+ * Robolectric/instrumentation available; see [AlarmManagerPluginTest]).
+ */
+internal fun sharedEventQueueFor(store: KeyValueStore): DurableEventQueue {
+    sharedEventQueue?.let { return it }
+    return synchronized(eventQueueInitLock) {
+        sharedEventQueue ?: DurableEventQueue(store, EVENT_LOG_KEY).also { sharedEventQueue = it }
+    }
+}
+
+/** Test-only: clears the cached singleton so each test starts from a clean slate. */
+internal fun resetSharedEventQueueForTests() {
+    sharedEventQueue = null
+}
+
+private fun eventQueue(context: Context): DurableEventQueue =
+    sharedEventQueueFor(keyValueStore(context.applicationContext))
 
 @InvokeArg
 class ScheduleRequest {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -185,12 +185,40 @@ internal fun drainAndDispatch(queue: DurableEventQueue, dispatch: (topic: String
 
     val handledEventIds = mutableSetOf<String>()
     for (envelope in drained) {
-        if (dispatch(envelope.topic, envelope.payload)) {
+        if (dispatch(envelope.topic, enrichPayloadForDispatch(envelope))) {
             handledEventIds.add(envelope.eventId)
         }
     }
     if (handledEventIds.isNotEmpty()) queue.commit(handledEventIds)
     return handledEventIds.size
+}
+
+/**
+ * Returns [envelope]'s payload as-is, except for [TOPIC_FIRED] where it's enriched with
+ * `eventId`/`handledNatively` before dispatch -- per
+ * docs/architecture/255-phase3-payload-contract.md, these are the two fields Rust's
+ * `NativeAlarmFiredPayload` needs to carry the tags `AlarmReceiver.kt`'s `publishAlarmFiredToBus`
+ * collected (e.g. `"watch-ring"`) and the envelope's own stable ID through to the
+ * `alarm-manager:native-fired` Tauri event, whether this is the immediate post-enqueue drain or
+ * a later retry of the same queued entry. Only [TOPIC_FIRED] gains these fields -- the contract
+ * only specifies them for the fired event, and the other three topics' Rust payload structs
+ * don't declare them.
+ *
+ * [envelope.payload][DurableEventQueue.Envelope.payload] is always caller-constructed JSON (see
+ * [notifyAlarmFired]), so re-parsing it here should never fail in practice -- the `catch` exists
+ * only to fail safe (dispatch the entry unenriched rather than drop it) if it somehow does.
+ */
+internal fun enrichPayloadForDispatch(envelope: DurableEventQueue.Envelope): String {
+    if (envelope.topic != TOPIC_FIRED) return envelope.payload
+    return try {
+        JSONObject(envelope.payload).apply {
+            put("eventId", envelope.eventId)
+            put("handledNatively", JSONArray(envelope.handledNatively.toList()))
+        }.toString()
+    } catch (e: Exception) {
+        Log.w(TAG, "Failed to enrich fired-event payload for eventId ${envelope.eventId}, dispatching unenriched", e)
+        envelope.payload
+    }
 }
 
 private fun keyValueStore(context: Context): KeyValueStore = SharedPreferencesKeyValueStore(context, CALLBACK_PREFS)
@@ -252,13 +280,18 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             private set
 
         @Synchronized
-        fun notifyAlarmFired(context: Context, alarmId: Int, actualFiredAt: Long = System.currentTimeMillis()) {
+        fun notifyAlarmFired(
+            context: Context,
+            alarmId: Int,
+            actualFiredAt: Long = System.currentTimeMillis(),
+            handledNatively: Set<String> = emptySet(),
+        ) {
             if (alarmId <= 0) return
             val payload = JSONObject().apply {
                 put("id", alarmId)
                 put("actualFiredAt", actualFiredAt)
             }
-            enqueueAndDrain(context, TOPIC_FIRED, payload)
+            enqueueAndDrain(context, TOPIC_FIRED, payload, handledNatively)
         }
 
         @Synchronized
@@ -299,8 +332,13 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
         // Every event flows through the log -- there is no separate "dispatch immediately" path any more. When the pipeline is already up and the right channel is registered, drainQueuedEvents() below delivers this same entry within the same call, so the net effect (and latency) matches the old immediate-dispatch path; when it isn't, the entry simply stays in the log until markAlarmPipelineReady() (or a later event of any topic) drains it. See drainAndDispatch()'s KDoc for the two deliberate, forward-referenced (issue #255) consequences of always draining the whole backlog.
         @Synchronized
-        private fun enqueueAndDrain(context: Context, topic: String, payload: JSONObject) {
-            val eventId = eventQueue(context).enqueue(topic, payload.toString())
+        private fun enqueueAndDrain(
+            context: Context,
+            topic: String,
+            payload: JSONObject,
+            handledNatively: Set<String> = emptySet(),
+        ) {
+            val eventId = eventQueue(context).enqueue(topic, payload.toString(), handledNatively)
             NativeEventLog.log(context, TAG, "Enqueued '$topic' event $eventId: $payload")
             instance?.drainQueuedEvents()
         }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
@@ -10,9 +10,25 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.json.JSONObject
 
 class AlarmReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
+        // goAsync() extends Android's short (~10s) broadcast-dispatch ANR budget to cover the
+        // work below -- the NativeEventBus publish and AlarmManagerPlugin.notifyAlarmFired's
+        // queue write are each individually cheap, but this still runs on the main thread and
+        // the margin is worth it. pendingResult.finish() must run on every exit path, including
+        // the early-return guard below, so the try/finally wraps the whole handler.
+        val pendingResult = goAsync()
+        try {
+            handleAlarmBroadcast(context, intent)
+        } finally {
+            pendingResult.finish()
+        }
+    }
+
+    private fun handleAlarmBroadcast(context: Context, intent: Intent) {
         Log.d("AlarmReceiver", "========== ALARM RECEIVER START ==========")
         Log.d("AlarmReceiver", "Alarm Received! Action: ${intent.action}")
         val alarmId = intent.getIntExtra("ALARM_ID", -1)
@@ -23,6 +39,10 @@ class AlarmReceiver : BroadcastReceiver() {
         // Guard: skip alarms that were cancelled or deleted before this broadcast was processed.
         // cancelAlarm() removes the prefs entry atomically with the AlarmManager cancellation, so
         // a missing entry means the alarm is definitively gone even if the broadcast was in-flight.
+        // This runs before the NativeEventBus publish below (not after, despite that publish
+        // otherwise being the very first thing done for a firing alarm) precisely because a
+        // cancelled/deleted alarm must never reach wear-sync's native listener -- publishing
+        // first would let the watch ring for an alarm this receiver is about to disown.
         if (!AlarmUtils.isAlarmLive(context, alarmId)) {
             Log.w("AlarmReceiver", "Alarm $alarmId no longer live — skipping fire (deleted/cancelled)")
             Log.d("AlarmReceiver", "========== ALARM RECEIVER END (skipped) ==========")
@@ -30,7 +50,16 @@ class AlarmReceiver : BroadcastReceiver() {
             return
         }
 
-        AlarmManagerPlugin.notifyAlarmFired(context, alarmId)
+        // Publish onto NativeEventBus first, ahead of everything else this method does for a
+        // confirmed-live alarm, so wear-sync's native listener (registered in the same
+        // already-alive cold process, per issue #255 Phase 3) can ring the watch immediately --
+        // with no dependency on Rust/WebView having booted. See
+        // docs/architecture/255-phase3-payload-contract.md for the frozen payload shape and the
+        // "watch-ring" tag literal.
+        val actualFiredAt = System.currentTimeMillis()
+        val handledNatively = publishAlarmFiredToBus(alarmId, actualFiredAt)
+
+        AlarmManagerPlugin.notifyAlarmFired(context, alarmId, actualFiredAt, handledNatively)
 
         // Start the foreground service for sound/notification
         // The notification's full-screen intent will launch the app with the alarm ID
@@ -53,4 +82,19 @@ class AlarmReceiver : BroadcastReceiver() {
         Log.d("AlarmReceiver", "========== ALARM RECEIVER END ==========")
         NativeEventLog.log(context, "AlarmReceiver", "Started AlarmRingingService for alarm id=$alarmId")
     }
+}
+
+/**
+ * Publishes the fired event on [NativeEventBus] for [alarmId]/[actualFiredAt] and returns the
+ * tags any in-process listeners (e.g. wear-sync's cold-process ring handler) reported handling
+ * it with -- see docs/architecture/255-phase3-payload-contract.md. Factored out of
+ * [AlarmReceiver] so it's unit-testable without a real `BroadcastReceiver` dispatch (`goAsync()`
+ * requires a live Android framework, `onReceive()` itself does not) -- see AlarmReceiverTest.
+ */
+internal fun publishAlarmFiredToBus(alarmId: Int, actualFiredAt: Long): Set<String> {
+    val payload = JSONObject().apply {
+        put("id", alarmId)
+        put("actualFiredAt", actualFiredAt)
+    }
+    return NativeEventBus.publish(TOPIC_FIRED, payload.toString())
 }

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
@@ -34,6 +34,18 @@ class AlarmReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
+        // Captured synchronously here, before goAsync()/the hand-off to backgroundExecutor --
+        // this must reflect the moment Android actually delivered the broadcast, not whenever
+        // the worker thread happens to get around to running handleAlarmBroadcast(). If an
+        // earlier broadcast or a large durable backlog is still being drained on
+        // backgroundExecutor, that hand-off can lag by an arbitrary amount; letting
+        // recordAndPublishFiredEvent's actualFiredAt default (System.currentTimeMillis())
+        // evaluate on the worker thread would then stamp the fired event with the WORKER's
+        // start time, not the broadcast's. wear-sync's NativeFiredListener / Rust's
+        // alarm:fired listener use actualFiredAt for a 90-second staleness check, so a delayed
+        // worker computing its own timestamp here could make a stale, backlogged broadcast look
+        // artificially fresh (or vice versa) and ring the watch incorrectly.
+        val actualFiredAt = System.currentTimeMillis()
         // goAsync() must be called synchronously here, on the main thread, before any hand-off --
         // it captures the current broadcast's PendingResult. The actual work happens on
         // backgroundExecutor below; pendingResult.finish() runs from that thread once it's done
@@ -45,14 +57,14 @@ class AlarmReceiver : BroadcastReceiver() {
         val appContext = context.applicationContext
         backgroundExecutor.execute {
             try {
-                handleAlarmBroadcast(appContext, intent)
+                handleAlarmBroadcast(appContext, intent, actualFiredAt)
             } finally {
                 pendingResult.finish()
             }
         }
     }
 
-    private fun handleAlarmBroadcast(context: Context, intent: Intent) {
+    private fun handleAlarmBroadcast(context: Context, intent: Intent, actualFiredAt: Long) {
         Log.d("AlarmReceiver", "========== ALARM RECEIVER START ==========")
         Log.d("AlarmReceiver", "Alarm Received! Action: ${intent.action}")
         val alarmId = intent.getIntExtra("ALARM_ID", -1)
@@ -82,7 +94,7 @@ class AlarmReceiver : BroadcastReceiver() {
         // starting -- ringing is this app's one job, and a secondary failure here must degrade to
         // "no native fast-ring / no durable record" rather than "the phone never rings at all".
         try {
-            recordAndPublishFiredEvent(alarmId, isLive) { firedPayload ->
+            recordAndPublishFiredEvent(alarmId, isLive, actualFiredAt) { firedPayload ->
                 AlarmManagerPlugin.notifyAlarmFired(context, alarmId, firedPayload)
             }
         } catch (e: Exception) {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmReceiver.kt
@@ -12,19 +12,43 @@ import android.os.Build
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
 import org.json.JSONObject
+import java.util.concurrent.Executors
 
 class AlarmReceiver : BroadcastReceiver() {
+    companion object {
+        // Single background thread for all fired-alarm bookkeeping (NativeEventBus publish,
+        // AlarmManagerPlugin.notifyAlarmFired's durable persist/dispatch) triggered by this
+        // receiver. goAsync() only extends Android's broadcast-dispatch ANR budget when the
+        // actual work genuinely runs off the main thread and pendingResult.finish() is called
+        // from there once it completes -- doing the same work synchronously inside onReceive()
+        // itself, even wrapped in goAsync(), provides no additional protection, since ANR
+        // detection is about how long the *main thread* is blocked, not about when the
+        // framework considers a broadcast "officially dispatched". A single shared executor
+        // (rather than spawning a fresh thread per broadcast) avoids unbounded thread creation
+        // across repeated fires -- alarms don't fire concurrently in any volume that would
+        // need more than one worker, and `AlarmManagerPlugin`'s own methods are `@Synchronized`
+        // regardless. This plugin has no existing coroutines dependency (unlike wear-sync's
+        // `CoroutineScope(Dispatchers.IO)`), so a plain `Executor` avoids adding one just for
+        // this.
+        private val backgroundExecutor = Executors.newSingleThreadExecutor()
+    }
+
     override fun onReceive(context: Context, intent: Intent) {
-        // goAsync() extends Android's short (~10s) broadcast-dispatch ANR budget to cover the
-        // work below -- the NativeEventBus publish and AlarmManagerPlugin.notifyAlarmFired's
-        // queue write are each individually cheap, but this still runs on the main thread and
-        // the margin is worth it. pendingResult.finish() must run on every exit path, including
-        // the early-return guard below, so the try/finally wraps the whole handler.
+        // goAsync() must be called synchronously here, on the main thread, before any hand-off --
+        // it captures the current broadcast's PendingResult. The actual work happens on
+        // backgroundExecutor below; pendingResult.finish() runs from that thread once it's done
+        // (including on the early-return guard and any exception), which is what makes goAsync()
+        // meaningful here rather than a no-op wrapper.
         val pendingResult = goAsync()
-        try {
-            handleAlarmBroadcast(context, intent)
-        } finally {
-            pendingResult.finish()
+        // applicationContext, not the Context onReceive() was handed, so nothing below can end up
+        // holding a reference to a shorter-lived Context across the thread hop.
+        val appContext = context.applicationContext
+        backgroundExecutor.execute {
+            try {
+                handleAlarmBroadcast(appContext, intent)
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 
@@ -39,27 +63,35 @@ class AlarmReceiver : BroadcastReceiver() {
         // Guard: skip alarms that were cancelled or deleted before this broadcast was processed.
         // cancelAlarm() removes the prefs entry atomically with the AlarmManager cancellation, so
         // a missing entry means the alarm is definitively gone even if the broadcast was in-flight.
-        // This runs before the NativeEventBus publish below (not after, despite that publish
-        // otherwise being the very first thing done for a firing alarm) precisely because a
-        // cancelled/deleted alarm must never reach wear-sync's native listener -- publishing
-        // first would let the watch ring for an alarm this receiver is about to disown.
-        if (!AlarmUtils.isAlarmLive(context, alarmId)) {
+        // This runs before recordAndPublishFiredEvent below (not after, despite that otherwise
+        // being the very first thing done for a firing alarm) precisely because a
+        // cancelled/deleted alarm must never reach wear-sync's native listener -- doing it first
+        // would let the watch ring for an alarm this receiver is about to disown.
+        val isLive = AlarmUtils.isAlarmLive(context, alarmId)
+        if (!isLive) {
             Log.w("AlarmReceiver", "Alarm $alarmId no longer live — skipping fire (deleted/cancelled)")
             Log.d("AlarmReceiver", "========== ALARM RECEIVER END (skipped) ==========")
             NativeEventLog.log(context, "AlarmReceiver", "Skipped alarm id=$alarmId (no longer live)")
             return
         }
 
-        // Publish onto NativeEventBus first, ahead of everything else this method does for a
-        // confirmed-live alarm, so wear-sync's native listener (registered in the same
-        // already-alive cold process, per issue #255 Phase 3) can ring the watch immediately --
-        // with no dependency on Rust/WebView having booted. See
-        // docs/architecture/255-phase3-payload-contract.md for the frozen payload shape and the
-        // "watch-ring" tag literal.
-        val actualFiredAt = System.currentTimeMillis()
-        val handledNatively = publishAlarmFiredToBus(alarmId, actualFiredAt)
-
-        AlarmManagerPlugin.notifyAlarmFired(context, alarmId, actualFiredAt, handledNatively)
+        // Record (durably, to Rust) and publish (to NativeEventBus, for wear-sync's fast native
+        // ring) the fired event -- see recordAndPublishFiredEvent's KDoc for why persisting comes
+        // first. Wrapped so a failure anywhere in this bookkeeping (e.g. a SharedPreferences write
+        // failing under storage pressure) can never prevent the actual physical alarm below from
+        // starting -- ringing is this app's one job, and a secondary failure here must degrade to
+        // "no native fast-ring / no durable record" rather than "the phone never rings at all".
+        try {
+            recordAndPublishFiredEvent(alarmId, isLive) { firedPayload ->
+                AlarmManagerPlugin.notifyAlarmFired(context, alarmId, firedPayload)
+            }
+        } catch (e: Exception) {
+            Log.e(
+                "AlarmReceiver",
+                "Failed to record/publish fired event for alarm $alarmId; ringing proceeds regardless",
+                e,
+            )
+        }
 
         // Start the foreground service for sound/notification
         // The notification's full-screen intent will launch the app with the alarm ID
@@ -70,6 +102,10 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("ALARM_SOUND_URI", soundUri)
         }
 
+        // Starting a foreground service from a background thread is fine -- the requirement is
+        // process state (this broadcast's outstanding goAsync() PendingResult keeps the process
+        // in an elevated state, the same background-start exemption alarm-triggered broadcasts
+        // already rely on elsewhere in this codebase), not which thread makes the call.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(serviceIntent)
             Log.d("AlarmReceiver", "Started foreground service (API 26+)")
@@ -85,16 +121,48 @@ class AlarmReceiver : BroadcastReceiver() {
 }
 
 /**
- * Publishes the fired event on [NativeEventBus] for [alarmId]/[actualFiredAt] and returns the
- * tags any in-process listeners (e.g. wear-sync's cold-process ring handler) reported handling
- * it with -- see docs/architecture/255-phase3-payload-contract.md. Factored out of
- * [AlarmReceiver] so it's unit-testable without a real `BroadcastReceiver` dispatch (`goAsync()`
- * requires a live Android framework, `onReceive()` itself does not) -- see AlarmReceiverTest.
+ * Core "alarm fired" bookkeeping, factored out of [AlarmReceiver.handleAlarmBroadcast] so its
+ * one invariant that actually matters -- a non-live alarm (or an invalid id) must never reach
+ * [NativeEventBus] and tell wear-sync's native listener to ring the watch -- is unit-testable
+ * without a live Android framework (`goAsync()`/a real `BroadcastReceiver` dispatch need one,
+ * this function does not; [isLive] is the caller's already-resolved
+ * [AlarmUtils.isAlarmLive] result, a Context call done by the caller). See AlarmReceiverTest.
+ *
+ * Builds the shared `{id, actualFiredAt}` payload exactly once -- the one source of truth for
+ * this shape (see docs/architecture/255-phase3-payload-contract.md) -- and hands it to [persist]
+ * (the durable, Rust-facing side; [AlarmManagerPlugin.notifyAlarmFired] in production) *before*
+ * publishing the same payload on [NativeEventBus]. Durable-persist-first matters because a
+ * process death between the two steps then still leaves Rust with a record that the alarm fired
+ * (degraded to "no fast native ring", i.e. today's pre-Phase-3A behaviour) rather than no record
+ * of the fire at all. One consequence: [persist] necessarily runs before this function knows
+ * what [NativeEventBus.publish] will return, so the payload [persist] receives always carries an
+ * empty `handledNatively` -- [AlarmManagerPlugin.notifyAlarmFired] cannot embed tags this
+ * function hasn't collected yet. This is an accepted, disclosed trade-off of prioritising
+ * durability over the (best-effort) native-ring-dedup hint for this synchronous path.
+ *
+ * A no-op (returns an empty set, calls neither [persist] nor the bus) when [isLive] is `false`
+ * or [alarmId] isn't positive.
  */
-internal fun publishAlarmFiredToBus(alarmId: Int, actualFiredAt: Long): Set<String> {
-    val payload = JSONObject().apply {
+internal fun recordAndPublishFiredEvent(
+    alarmId: Int,
+    isLive: Boolean,
+    actualFiredAt: Long = System.currentTimeMillis(),
+    persist: (JSONObject) -> Unit,
+): Set<String> {
+    if (!isLive || alarmId <= 0) return emptySet()
+    val firedPayload = JSONObject().apply {
         put("id", alarmId)
         put("actualFiredAt", actualFiredAt)
     }
-    return NativeEventBus.publish(TOPIC_FIRED, payload.toString())
+    persist(firedPayload)
+    return publishAlarmFiredToBus(firedPayload)
 }
+
+/**
+ * Publishes [firedPayload] (the shared `{id, actualFiredAt}` shape -- see
+ * [recordAndPublishFiredEvent]) on [NativeEventBus]'s [TOPIC_FIRED] topic and returns the tags
+ * any in-process listeners (e.g. wear-sync's cold-process ring handler) reported handling it
+ * with -- see docs/architecture/255-phase3-payload-contract.md.
+ */
+internal fun publishAlarmFiredToBus(firedPayload: JSONObject): Set<String> =
+    NativeEventBus.publish(TOPIC_FIRED, firedPayload.toString())

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -8,8 +8,10 @@ package com.plugin.alarmmanager
 import ca.liminalhq.threshold.nativebus.DurableEventQueue
 import org.json.JSONArray
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -17,6 +19,8 @@ import org.junit.Test
 
 /**
  * Plain JUnit 4 tests against [InMemoryKeyValueStore], covering the two pieces of logic this plugin's migration to a shared [DurableEventQueue] added: [migrateLegacyQueues] (folding the four legacy per-type queues into the unified log) and [drainAndDispatch] (draining that log in arrival order and routing each entry to the right handler by topic). [DurableEventQueue]'s own drain/commit/corruption-tolerance behaviour is already covered by `plugins/native-bus`'s own test suite and isn't re-tested here.
+ *
+ * Also covers [sharedEventQueueFor] -- the process-wide singleton holder [eventQueue] delegates to, added to fix a PR #298 review finding: `eventQueue(context)` used to construct a brand new [DurableEventQueue] on every call, so two callers (e.g. `AlarmReceiver`'s background executor enqueuing a fired event, and `markAlarmPipelineReady`'s main-thread drain) got their own, entirely independent instances pointed at the same underlying storage -- [DurableEventQueue]'s own `@Synchronized` methods only lock their own instance's monitor, so that provided no mutual exclusion between them at all.
  */
 class AlarmManagerPluginTest {
 
@@ -25,6 +29,15 @@ class AlarmManagerPluginTest {
     @Before
     fun setUp() {
         store = InMemoryKeyValueStore()
+        // sharedEventQueueFor caches its DurableEventQueue in a process-wide (top-level) var --
+        // without resetting it, whichever test runs first would permanently pin every later
+        // test's sharedEventQueueFor(store) call to *that* test's now-stale store instance.
+        resetSharedEventQueueForTests()
+    }
+
+    @After
+    fun tearDown() {
+        resetSharedEventQueueForTests()
     }
 
     // --- migrateLegacyQueues ---------------------------------------------------------------
@@ -316,6 +329,87 @@ class AlarmManagerPluginTest {
         val remaining = queue.drainAll(pipelineReady = true)
         assertEquals(listOf(secondId), remaining.map { it.eventId })
         assertTrue(remaining.none { it.eventId == firstId })
+    }
+
+    // --- sharedEventQueueFor (PR #298 review: background-worker/main-thread queue race) ------
+
+    @Test
+    fun `sharedEventQueueFor returns the same instance on repeated calls against the same store`() {
+        val first = sharedEventQueueFor(store)
+        val second = sharedEventQueueFor(store)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `concurrent callers of sharedEventQueueFor all resolve to one instance, even racing its first construction`() {
+        val threadCount = 16
+        val ready = java.util.concurrent.CyclicBarrier(threadCount)
+        val results = java.util.Collections.synchronizedList(mutableListOf<DurableEventQueue>())
+        val threads = (0 until threadCount).map {
+            Thread {
+                ready.await()
+                results.add(sharedEventQueueFor(store))
+            }
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join(5_000) }
+
+        assertEquals(threadCount, results.size)
+        assertTrue(
+            "every caller must resolve to the exact same DurableEventQueue instance",
+            results.all { it === results[0] },
+        )
+    }
+
+    @Test
+    fun `a background-executor enqueue racing a main-thread drain-commit loop never loses or resurrects an event`() {
+        // Regression test for the exact race PR #298's review flagged: AlarmReceiver's
+        // background-executor worker enqueuing fired events (the "writer" thread below)
+        // concurrently with markAlarmPipelineReady's main-thread drain (the "reader" thread).
+        // Before the fix, eventQueue(context) constructed a brand new DurableEventQueue on
+        // every single call, so these two call sites held entirely independent instances with
+        // no shared lock between them -- DurableEventQueue's own @Synchronized methods only
+        // lock their own instance's monitor. A drain's stale read-then-write could resurrect an
+        // entry the writer had already committed as delivered, or an enqueue could clobber a
+        // concurrent commit outright. Both threads below call sharedEventQueueFor(store)
+        // themselves (not a pre-fetched reference), mirroring exactly how eventQueue(context)
+        // is invoked fresh at each real call site -- so this would catch a regression back to
+        // "one DurableEventQueue per call" just as readily as it catches a broken lock.
+        val eventCount = 500
+        val delivered = java.util.Collections.synchronizedList(mutableListOf<Int>())
+        val writerDone = java.util.concurrent.atomic.AtomicBoolean(false)
+
+        val writer = Thread {
+            for (i in 0 until eventCount) {
+                sharedEventQueueFor(store).enqueue(TOPIC_FIRED, JSONObject().put("id", i).toString())
+            }
+            writerDone.set(true)
+        }
+        val reader = Thread {
+            while (!writerDone.get() || delivered.size < eventCount) {
+                val queue = sharedEventQueueFor(store)
+                val drained = queue.drainAll(pipelineReady = true)
+                for (envelope in drained) {
+                    delivered.add(JSONObject(envelope.payload).getInt("id"))
+                    queue.commit(setOf(envelope.eventId))
+                }
+            }
+        }.apply { isDaemon = true }
+
+        reader.start()
+        writer.start()
+        writer.join(15_000)
+        reader.join(15_000)
+
+        assertEquals("no event should be lost", eventCount, delivered.size)
+        assertEquals(
+            "no event should be delivered/committed twice (a resurrected envelope)",
+            eventCount,
+            delivered.distinct().size,
+        )
+        assertTrue(sharedEventQueueFor(store).drainAll(pipelineReady = true).isEmpty())
     }
 
     // --- enrichPayloadForDispatch (issue #255 Phase 3A) -----------------------------------------

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -286,6 +286,66 @@ class AlarmManagerPluginTest {
         assertEquals(0, dispatchCalls)
     }
 
+    // --- enrichPayloadForDispatch (issue #255 Phase 3A) -----------------------------------------
+
+    @Test
+    fun `enriches a fired-event payload with the envelope's own eventId and handledNatively`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        val basePayload = JSONObject().apply {
+            put("id", 7)
+            put("actualFiredAt", 1_755_100_800_000L)
+        }
+        val eventId = queue.enqueue(TOPIC_FIRED, basePayload.toString(), handledNatively = setOf("watch-ring"))
+
+        val dispatchedPayloads = mutableListOf<String>()
+        drainAndDispatch(queue) { _, payload -> dispatchedPayloads.add(payload); true }
+
+        val enriched = JSONObject(dispatchedPayloads.single())
+        assertEquals(7, enriched.getInt("id"))
+        assertEquals(1_755_100_800_000L, enriched.getLong("actualFiredAt"))
+        assertEquals(eventId, enriched.getString("eventId"))
+        val handledNatively = enriched.getJSONArray("handledNatively")
+        assertEquals(1, handledNatively.length())
+        assertEquals("watch-ring", handledNatively.getString(0))
+    }
+
+    @Test
+    fun `a fired event with no bus tags dispatches with an empty handledNatively array`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        queue.enqueue(TOPIC_FIRED, JSONObject().put("id", 1).toString())
+
+        val dispatchedPayloads = mutableListOf<String>()
+        drainAndDispatch(queue) { _, payload -> dispatchedPayloads.add(payload); true }
+
+        val enriched = JSONObject(dispatchedPayloads.single())
+        assertEquals(0, enriched.getJSONArray("handledNatively").length())
+    }
+
+    @Test
+    fun `non-fired topics are dispatched with their payload unchanged`() {
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        val snoozePayload = JSONObject().put("id", 3).toString()
+        queue.enqueue(TOPIC_SNOOZE, snoozePayload)
+
+        val dispatchedPayloads = mutableListOf<String>()
+        drainAndDispatch(queue) { _, payload -> dispatchedPayloads.add(payload); true }
+
+        assertEquals(snoozePayload, dispatchedPayloads.single())
+    }
+
+    @Test
+    fun `enrichPayloadForDispatch falls back to the unmodified payload if it isn't valid JSON`() {
+        val malformed = DurableEventQueue.Envelope(
+            topic = TOPIC_FIRED,
+            payload = "not json",
+            eventId = "some-id",
+            publishedAt = 0L,
+            handledNatively = emptySet(),
+        )
+
+        assertEquals("not json", enrichPayloadForDispatch(malformed))
+    }
+
     // --- fixtures ------------------------------------------------------------------------------
 
     private fun legacyFired(id: Int, actualFiredAt: Long): JSONObject =

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmManagerPluginTest.kt
@@ -11,6 +11,7 @@ import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 
@@ -286,16 +287,53 @@ class AlarmManagerPluginTest {
         assertEquals(0, dispatchCalls)
     }
 
+    @Test
+    fun `commits each envelope immediately after its own successful dispatch, not batched at the end`() {
+        // Per Phase 3C's review: Rust's in-memory EventDedup buffer is wiped by the same crash
+        // that would cause a redelivery, so it can't protect against a process kill between a
+        // successful Channel delivery and this queue's commit. Committing per-item (rather than
+        // accumulating every commit until the whole drain loop finishes) shrinks that window
+        // from "the rest of the batch" down to "at most the one entry in flight" -- simulated
+        // here by having the second dispatch throw ("crash") and checking that the first
+        // entry's commit had already landed before that happened.
+        val queue = DurableEventQueue(store, EVENT_LOG_KEY)
+        val firstId = queue.enqueue(TOPIC_FIRED, JSONObject().put("id", 1).toString())
+        val secondId = queue.enqueue(TOPIC_SNOOZE, JSONObject().put("id", 2).toString())
+
+        var dispatchCalls = 0
+        try {
+            drainAndDispatch(queue) { _, _ ->
+                dispatchCalls++
+                if (dispatchCalls == 1) true else throw RuntimeException("simulated crash mid-drain")
+            }
+            fail("expected the simulated crash to propagate out of drainAndDispatch")
+        } catch (e: RuntimeException) {
+            assertEquals("simulated crash mid-drain", e.message)
+        }
+
+        // The first envelope's commit already ran before the "crash" on the second, so only the
+        // second -- still in flight at the moment of the crash -- remains queued for retry.
+        val remaining = queue.drainAll(pipelineReady = true)
+        assertEquals(listOf(secondId), remaining.map { it.eventId })
+        assertTrue(remaining.none { it.eventId == firstId })
+    }
+
     // --- enrichPayloadForDispatch (issue #255 Phase 3A) -----------------------------------------
+    // handledNatively is written directly into the payload upfront by notifyAlarmFired (not
+    // late-injected here any more -- see enrichPayloadForDispatch's KDoc), so these tests build
+    // the envelope's payload the same way notifyAlarmFired does: with handledNatively already
+    // baked in. enrichPayloadForDispatch's only remaining job is stamping the envelope's own
+    // eventId on top, without disturbing whatever handledNatively is already sitting there.
 
     @Test
-    fun `enriches a fired-event payload with the envelope's own eventId and handledNatively`() {
+    fun `enriches a fired-event payload with the envelope's own eventId, leaving its pre-baked handledNatively untouched`() {
         val queue = DurableEventQueue(store, EVENT_LOG_KEY)
         val basePayload = JSONObject().apply {
             put("id", 7)
             put("actualFiredAt", 1_755_100_800_000L)
+            put("handledNatively", JSONArray(listOf("watch-ring")))
         }
-        val eventId = queue.enqueue(TOPIC_FIRED, basePayload.toString(), handledNatively = setOf("watch-ring"))
+        val eventId = queue.enqueue(TOPIC_FIRED, basePayload.toString())
 
         val dispatchedPayloads = mutableListOf<String>()
         drainAndDispatch(queue) { _, payload -> dispatchedPayloads.add(payload); true }
@@ -310,9 +348,13 @@ class AlarmManagerPluginTest {
     }
 
     @Test
-    fun `a fired event with no bus tags dispatches with an empty handledNatively array`() {
+    fun `a fired event whose payload already has an empty handledNatively array dispatches with it unchanged`() {
         val queue = DurableEventQueue(store, EVENT_LOG_KEY)
-        queue.enqueue(TOPIC_FIRED, JSONObject().put("id", 1).toString())
+        val basePayload = JSONObject().apply {
+            put("id", 1)
+            put("handledNatively", JSONArray())
+        }
+        queue.enqueue(TOPIC_FIRED, basePayload.toString())
 
         val dispatchedPayloads = mutableListOf<String>()
         drainAndDispatch(queue) { _, payload -> dispatchedPayloads.add(payload); true }

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmReceiverTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmReceiverTest.kt
@@ -1,0 +1,77 @@
+// Unit tests for AlarmReceiver's NativeEventBus publish and tag collection
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests against [publishAlarmFiredToBus], the seam factored out of
+ * [AlarmReceiver.onReceive] so this is testable without a real `BroadcastReceiver`
+ * dispatch/`goAsync()` (which need a live Android framework). Covers issue #255 Phase 3A: the
+ * bus publish happens with the right topic/payload shape, and the tags any listeners report
+ * (e.g. wear-sync's cold-process ring handler returning `"watch-ring"`) are returned so
+ * [AlarmReceiver] can thread them into [AlarmManagerPlugin.notifyAlarmFired]. The far side of
+ * that threading (tags -> enriched Channel/queue payload) is covered separately by
+ * [AlarmManagerPluginTest]'s `enrichPayloadForDispatch` tests.
+ */
+class AlarmReceiverTest {
+
+    @After
+    fun tearDown() {
+        // NativeEventBus is a process-wide singleton; without this, listeners registered by one
+        // test would still be live (and firing) during the next one.
+        NativeEventBus.resetForTests()
+    }
+
+    @Test
+    fun `publishes on the alarm-manager native-fired topic with id and actualFiredAt`() {
+        var receivedTopic: String? = null
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_FIRED) { payload ->
+            receivedTopic = TOPIC_FIRED
+            receivedPayload = payload
+            null
+        }
+
+        publishAlarmFiredToBus(alarmId = 42, actualFiredAt = 1_755_100_800_000L)
+
+        assertEquals(TOPIC_FIRED, receivedTopic)
+        val payload = JSONObject(requireNotNull(receivedPayload))
+        assertEquals(42, payload.getInt("id"))
+        assertEquals(1_755_100_800_000L, payload.getLong("actualFiredAt"))
+    }
+
+    @Test
+    fun `returns the tags reported by listeners for this event`() {
+        NativeEventBus.subscribe(TOPIC_FIRED) { "watch-ring" }
+
+        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+
+        assertEquals(setOf("watch-ring"), tags)
+    }
+
+    @Test
+    fun `returns an empty set when no listener is registered`() {
+        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+
+        assertTrue(tags.isEmpty())
+    }
+
+    @Test
+    fun `collects tags from multiple listeners into one set`() {
+        NativeEventBus.subscribe(TOPIC_FIRED) { "watch-ring" }
+        NativeEventBus.subscribe(TOPIC_FIRED) { "some-other-tag" }
+
+        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+
+        assertEquals(setOf("watch-ring", "some-other-tag"), tags)
+    }
+}

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmReceiverTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/AlarmReceiverTest.kt
@@ -1,4 +1,4 @@
-// Unit tests for AlarmReceiver's NativeEventBus publish and tag collection
+// Unit tests for AlarmReceiver's fired-event bookkeeping and NativeEventBus publish
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
@@ -9,18 +9,17 @@ import ca.liminalhq.threshold.nativebus.NativeEventBus
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Plain JUnit 4 tests against [publishAlarmFiredToBus], the seam factored out of
- * [AlarmReceiver.onReceive] so this is testable without a real `BroadcastReceiver`
- * dispatch/`goAsync()` (which need a live Android framework). Covers issue #255 Phase 3A: the
- * bus publish happens with the right topic/payload shape, and the tags any listeners report
- * (e.g. wear-sync's cold-process ring handler returning `"watch-ring"`) are returned so
- * [AlarmReceiver] can thread them into [AlarmManagerPlugin.notifyAlarmFired]. The far side of
- * that threading (tags -> enriched Channel/queue payload) is covered separately by
- * [AlarmManagerPluginTest]'s `enrichPayloadForDispatch` tests.
+ * Plain JUnit 4 tests against [recordAndPublishFiredEvent] and [publishAlarmFiredToBus], the
+ * seams factored out of [AlarmReceiver.handleAlarmBroadcast] so this is testable without a real
+ * `BroadcastReceiver` dispatch/`goAsync()` (which need a live Android framework). Covers issue
+ * #255 Phase 3A: the guard invariant that a non-live alarm (or an invalid id) never reaches
+ * [NativeEventBus] or the durable persist, that the durable persist runs before the bus publish,
+ * and the bus publish itself (right topic/payload shape, tag collection).
  */
 class AlarmReceiverTest {
 
@@ -31,8 +30,72 @@ class AlarmReceiverTest {
         NativeEventBus.resetForTests()
     }
 
+    // --- recordAndPublishFiredEvent ---------------------------------------------------------
+
     @Test
-    fun `publishes on the alarm-manager native-fired topic with id and actualFiredAt`() {
+    fun `a non-live alarm is never persisted or published to the bus`() {
+        var persistCalled = false
+        var busPublishReceived = false
+        NativeEventBus.subscribe(TOPIC_FIRED) { busPublishReceived = true; null }
+
+        val tags = recordAndPublishFiredEvent(alarmId = 42, isLive = false, actualFiredAt = 100L) {
+            persistCalled = true
+        }
+
+        assertTrue(tags.isEmpty())
+        assertFalse("a cancelled/deleted alarm must not be persisted", persistCalled)
+        assertFalse("a cancelled/deleted alarm must not reach NativeEventBus", busPublishReceived)
+    }
+
+    @Test
+    fun `a non-positive alarm id is never persisted or published even when isLive is true`() {
+        var persistCalled = false
+        var busPublishReceived = false
+        NativeEventBus.subscribe(TOPIC_FIRED) { busPublishReceived = true; null }
+
+        val tags = recordAndPublishFiredEvent(alarmId = 0, isLive = true, actualFiredAt = 100L) {
+            persistCalled = true
+        }
+
+        assertTrue(tags.isEmpty())
+        assertFalse(persistCalled)
+        assertFalse(busPublishReceived)
+    }
+
+    @Test
+    fun `a live alarm is persisted with the shared payload, then published to the bus`() {
+        val persistedPayloads = mutableListOf<JSONObject>()
+        NativeEventBus.subscribe(TOPIC_FIRED) { "watch-ring" }
+
+        val tags = recordAndPublishFiredEvent(alarmId = 42, isLive = true, actualFiredAt = 1_755_100_800_000L) {
+            persistedPayloads.add(it)
+        }
+
+        assertEquals(1, persistedPayloads.size)
+        assertEquals(42, persistedPayloads.single().getInt("id"))
+        assertEquals(1_755_100_800_000L, persistedPayloads.single().getLong("actualFiredAt"))
+        assertEquals(setOf("watch-ring"), tags)
+    }
+
+    @Test
+    fun `persist runs before the bus publish`() {
+        val callOrder = mutableListOf<String>()
+        NativeEventBus.subscribe(TOPIC_FIRED) { callOrder.add("bus-publish"); null }
+
+        recordAndPublishFiredEvent(alarmId = 1, isLive = true, actualFiredAt = 100L) {
+            callOrder.add("persist")
+        }
+
+        // Durable-persist-first: a process death between the two steps then still leaves Rust
+        // with a record the alarm fired, rather than no record at all -- see the KDoc on
+        // recordAndPublishFiredEvent.
+        assertEquals(listOf("persist", "bus-publish"), callOrder)
+    }
+
+    // --- publishAlarmFiredToBus ---------------------------------------------------------------
+
+    @Test
+    fun `publishes on the alarm-manager native-fired topic with the given payload`() {
         var receivedTopic: String? = null
         var receivedPayload: String? = null
         NativeEventBus.subscribe(TOPIC_FIRED) { payload ->
@@ -41,7 +104,11 @@ class AlarmReceiverTest {
             null
         }
 
-        publishAlarmFiredToBus(alarmId = 42, actualFiredAt = 1_755_100_800_000L)
+        val firedPayload = JSONObject().apply {
+            put("id", 42)
+            put("actualFiredAt", 1_755_100_800_000L)
+        }
+        publishAlarmFiredToBus(firedPayload)
 
         assertEquals(TOPIC_FIRED, receivedTopic)
         val payload = JSONObject(requireNotNull(receivedPayload))
@@ -53,14 +120,14 @@ class AlarmReceiverTest {
     fun `returns the tags reported by listeners for this event`() {
         NativeEventBus.subscribe(TOPIC_FIRED) { "watch-ring" }
 
-        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+        val tags = publishAlarmFiredToBus(firedPayload(id = 1, actualFiredAt = 100L))
 
         assertEquals(setOf("watch-ring"), tags)
     }
 
     @Test
     fun `returns an empty set when no listener is registered`() {
-        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+        val tags = publishAlarmFiredToBus(firedPayload(id = 1, actualFiredAt = 100L))
 
         assertTrue(tags.isEmpty())
     }
@@ -70,8 +137,14 @@ class AlarmReceiverTest {
         NativeEventBus.subscribe(TOPIC_FIRED) { "watch-ring" }
         NativeEventBus.subscribe(TOPIC_FIRED) { "some-other-tag" }
 
-        val tags = publishAlarmFiredToBus(alarmId = 1, actualFiredAt = 100L)
+        val tags = publishAlarmFiredToBus(firedPayload(id = 1, actualFiredAt = 100L))
 
         assertEquals(setOf("watch-ring", "some-other-tag"), tags)
     }
+
+    private fun firedPayload(id: Int, actualFiredAt: Long): JSONObject =
+        JSONObject().apply {
+            put("id", id)
+            put("actualFiredAt", actualFiredAt)
+        }
 }

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -71,6 +71,18 @@ pub struct RingEventPayload {
 pub struct NativeAlarmFiredPayload {
     pub id: i32,
     pub actual_fired_at: i64,
+    /// The `DurableEventQueue` envelope's UUID for this event, stable across the immediate
+    /// Channel send and a later retry of the same queued entry (see
+    /// `AlarmManagerPlugin.enrichPayloadForDispatch` on the Kotlin side). `#[serde(default)]`
+    /// so this deserializes cleanly from a payload queued before this field existed.
+    #[serde(default)]
+    pub event_id: Option<String>,
+    /// Side-effect tags `NativeEventBus.publish()`'s listeners reported handling this event
+    /// with before Rust ever saw it (e.g. `"watch-ring"`). `#[serde(default)]` for the same
+    /// pre-upgrade-payload reason as `event_id`. See
+    /// docs/architecture/255-phase3-payload-contract.md for the frozen shape.
+    #[serde(default)]
+    pub handled_natively: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -125,5 +137,46 @@ mod tests {
 
         assert_eq!(imported.active_days, vec![1, 3, 5]);
         assert_eq!(imported.trigger_at, 1783656000000);
+    }
+
+    #[test]
+    fn native_alarm_fired_payload_deserializes_old_two_field_shape_with_serde_defaults() {
+        // Issue #255 Phase 3A added event_id/handled_natively to this struct. A payload sitting
+        // in a device's DurableEventQueue from before the update ships (or emitted by a desktop
+        // build, which never sets them) still carries only the original two fields -- this must
+        // keep deserializing rather than erroring, with the new fields defaulting to
+        // None/empty per docs/architecture/255-phase3-payload-contract.md.
+        let json = r#"{"id": 42, "actualFiredAt": 1755100800000}"#;
+
+        let payload: NativeAlarmFiredPayload =
+            serde_json::from_str(json).expect("should deserialize old-shape payload");
+
+        assert_eq!(payload.id, 42);
+        assert_eq!(payload.actual_fired_at, 1755100800000);
+        assert_eq!(payload.event_id, None);
+        assert!(payload.handled_natively.is_empty());
+    }
+
+    #[test]
+    fn native_alarm_fired_payload_deserializes_new_shape_with_event_id_and_handled_natively() {
+        // Mirrors the exact JSON AlarmManagerPlugin.kt's enrichPayloadForDispatch now sends for
+        // the fired-event Channel/queue payload -- see the frozen contract doc's example.
+        let json = r#"{
+            "id": 123,
+            "actualFiredAt": 1755100800000,
+            "eventId": "b3f1c2a4-0000-0000-0000-000000000000",
+            "handledNatively": ["watch-ring"]
+        }"#;
+
+        let payload: NativeAlarmFiredPayload =
+            serde_json::from_str(json).expect("should deserialize new-shape payload");
+
+        assert_eq!(payload.id, 123);
+        assert_eq!(payload.actual_fired_at, 1755100800000);
+        assert_eq!(
+            payload.event_id,
+            Some("b3f1c2a4-0000-0000-0000-000000000000".to_string())
+        );
+        assert_eq!(payload.handled_natively, vec!["watch-ring".to_string()]);
     }
 }


### PR DESCRIPTION
## What this is

Phase 3A of #255's implementation plan — alarm-manager's publisher side of the fired→watch-ring fan-out, part of the actual fix for #254 (the watch staying silent for ~20s when an alarm fires cold while the phone is in active use, since today the watch ring depends on Rust booting first). `AlarmReceiver` now publishes onto the in-process `NativeEventBus` (#294) the moment an alarm fires, so wear-sync's native listener (#299) can ring the watch immediately, with no dependency on Rust/WebView having booted.

Built against a frozen payload contract (`docs/architecture/255-phase3-payload-contract.md`) shared with the two sibling PRs in this stack.

## What's here

- `AlarmReceiver.onReceive()` genuinely offloads work to a background executor (not just a cosmetic `goAsync()` wrapper — see review notes below) and publishes `alarm-manager:native-fired` on the bus.
- Durability-first ordering: the durable persist happens before the bus publish, so a process death right after firing always leaves Rust with a durable record — the tradeoff being `handledNatively` in the persisted/dispatched payload is essentially always empty in the normal case (documented in code; the watch's own "currently ringing" check is the existing, deliberate backstop for the resulting near-simultaneous-duplicate case, per #255's original design decision 5).
- Per-item queue commits (not one batch commit after a whole drain), shrinking the crash-redelivery window to at most one item.
- The physical alarm ring is protected: persistence/bus-publish failures are caught so `startForegroundService` always runs regardless.
- `NativeAlarmFiredPayload` (Rust) gains `event_id`/`handled_natively`, `#[serde(default)]` for backward compatibility.

## Testing checklist (automated, no device needed)

- [x] Kotlin JUnit 21/21 + 8/8 + 5/5 (alarm-manager, AlarmReceiver, SetAlarmActivity — unaffected)
- [x] `cargo check --workspace` / `cargo test -p tauri-plugin-alarm-manager` 5/5 clean
- [x] Full `pnpm tauri android build` succeeds end-to-end

## Review status

Reviewed via `/code-review high` — multiple rounds given the sensitivity of this path. Found and fixed: `goAsync()` was cosmetic (all work ran synchronously in the same call stack, providing no real ANR protection — now genuinely backgrounded); a durability-ordering gap; duplicate JSON payload construction; a guard-parity gap; and no protection for the physical ring against secondary failures. One design tension (durability-first vs. always-populated dedup tag) was explicitly surfaced and resolved in favour of durability, consistent with #255's own stated tradeoffs.

Stacked on #296. Part of #255.