### PR TITLE
Ring the watch natively before Rust boots, plus a dev fan-out toggle

### DIFF
--- a/apps/threshold/package.json
+++ b/apps/threshold/package.json
@@ -41,7 +41,8 @@
 		"tauri-plugin-os-prefs-api": "workspace:*",
 		"tauri-plugin-predictive-back-api": "workspace:*",
 		"tauri-plugin-theme-utils-api": "workspace:*",
-		"tauri-plugin-toast-api": "workspace:*"
+		"tauri-plugin-toast-api": "workspace:*",
+		"tauri-plugin-wear-sync-api": "workspace:*"
 	},
 	"devDependencies": {
 		"@tauri-apps/cli": "^2",

--- a/apps/threshold/src-tauri/capabilities/default.json
+++ b/apps/threshold/src-tauri/capabilities/default.json
@@ -33,6 +33,7 @@
 		"predictive-back:default",
 		"os-prefs:default",
 		"theme-utils:default",
+		"wear-sync:default",
 		"dialog:default",
 		"toast:default",
 		"mcp-bridge:default"

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -93,8 +93,11 @@ const Settings: React.FC = () => {
 		notifications: null,
 	});
 	// Developer toggle for wear-sync's native fired->watch-ring fan-out (issue #255 Phase
-	// 3B) -- defaults to enabled, matching NativeFanOutPrefs' own Kotlin-side default.
-	const [nativeFanOutEnabled, setNativeFanOutEnabledState] = useState<boolean>(true);
+	// 3B). Named and stored in the switch's own sense (disabled, not enabled) so the JSX
+	// below binds `checked` and `onChange` straight through with no inversion -- the
+	// negation lives only at the two points that cross the API boundary, where the
+	// underlying command is phrased as "enabled" instead.
+	const [disableNativeFanOut, setDisableNativeFanOut] = useState<boolean>(false);
 
 	useEffect(() => {
 		setIsMobile(PlatformUtils.isMobile());
@@ -108,18 +111,18 @@ const Settings: React.FC = () => {
 			try {
 				const { getNativeFanOutEnabled } = await import('tauri-plugin-wear-sync-api');
 				const { enabled } = await getNativeFanOutEnabled();
-				setNativeFanOutEnabledState(enabled);
+				setDisableNativeFanOut(!enabled);
 			} catch (e) {
 				console.error('Failed to read native watch fan-out toggle:', e);
 			}
 		})();
 	}, [isAndroid]);
 
-	const handleNativeFanOutChange = async (enabled: boolean) => {
-		setNativeFanOutEnabledState(enabled);
+	const handleDisableNativeFanOutChange = async (disabled: boolean) => {
+		setDisableNativeFanOut(disabled);
 		try {
 			const { setNativeFanOutEnabled } = await import('tauri-plugin-wear-sync-api');
-			await setNativeFanOutEnabled(enabled);
+			await setNativeFanOutEnabled(!disabled);
 		} catch (e) {
 			console.error('Failed to set native watch fan-out toggle:', e);
 		}
@@ -512,8 +515,8 @@ const Settings: React.FC = () => {
 					/>
 					<Switch
 						edge="end"
-						checked={!nativeFanOutEnabled}
-						onChange={(e) => handleNativeFanOutChange(!e.target.checked)}
+						checked={disableNativeFanOut}
+						onChange={(e) => handleDisableNativeFanOutChange(e.target.checked)}
 					/>
 				</ListItem>
 			)}

--- a/apps/threshold/src/screens/Settings.tsx
+++ b/apps/threshold/src/screens/Settings.tsx
@@ -92,11 +92,38 @@ const Settings: React.FC = () => {
 		batteryOptimization: null,
 		notifications: null,
 	});
+	// Developer toggle for wear-sync's native fired->watch-ring fan-out (issue #255 Phase
+	// 3B) -- defaults to enabled, matching NativeFanOutPrefs' own Kotlin-side default.
+	const [nativeFanOutEnabled, setNativeFanOutEnabledState] = useState<boolean>(true);
 
 	useEffect(() => {
 		setIsMobile(PlatformUtils.isMobile());
 		setIsAndroid(PlatformUtils.getPlatform() === 'android');
 	}, []);
+
+	useEffect(() => {
+		if (!isAndroid) return;
+
+		(async () => {
+			try {
+				const { getNativeFanOutEnabled } = await import('tauri-plugin-wear-sync-api');
+				const { enabled } = await getNativeFanOutEnabled();
+				setNativeFanOutEnabledState(enabled);
+			} catch (e) {
+				console.error('Failed to read native watch fan-out toggle:', e);
+			}
+		})();
+	}, [isAndroid]);
+
+	const handleNativeFanOutChange = async (enabled: boolean) => {
+		setNativeFanOutEnabledState(enabled);
+		try {
+			const { setNativeFanOutEnabled } = await import('tauri-plugin-wear-sync-api');
+			await setNativeFanOutEnabled(enabled);
+		} catch (e) {
+			console.error('Failed to set native watch fan-out toggle:', e);
+		}
+	};
 
 	// Re-checked on every window focus regain (not just on mount) so both the Alarm Settings
 	// banner and the Developer settings diagnostic clear themselves after the user flips a
@@ -474,6 +501,20 @@ const Settings: React.FC = () => {
 					>
 						<span style={{ fontSize: '1.2rem' }}>⌚</span>
 					</IconButton>
+				</ListItem>
+			)}
+
+			{isAndroid && (
+				<ListItem sx={{ px }}>
+					<ListItemText
+						primary="Disable native watch fan-out"
+						secondary="Force alarm rings through the Rust path instead of the native in-process listener"
+					/>
+					<Switch
+						edge="end"
+						checked={!nativeFanOutEnabled}
+						onChange={(e) => handleNativeFanOutChange(!e.target.checked)}
+					/>
 				</ListItem>
 			)}
 

--- a/plugins/wear-sync/.gitignore
+++ b/plugins/wear-sync/.gitignore
@@ -1,0 +1,17 @@
+/.vs
+.DS_Store
+.Thumbs.db
+*.sublime*
+.idea/
+debug.log
+package-lock.json
+.vscode/settings.json
+yarn.lock
+
+/.tauri
+/target
+Cargo.lock
+node_modules/
+
+dist-js
+dist

--- a/plugins/wear-sync/android/src/main/AndroidManifest.xml
+++ b/plugins/wear-sync/android/src/main/AndroidManifest.xml
@@ -27,5 +27,14 @@
             android:name=".WearSyncService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Issue #255 Phase 3B: guarantees NativeFiredListener is registered before
+             AlarmReceiver.onReceive() can run, even on a cold multi-plugin process start.
+             See WearRingInitProvider's KDoc. Not a real content provider: exported="false"
+             and it has no callers. -->
+        <provider
+            android:name=".WearRingInitProvider"
+            android:authorities="${applicationId}.wearsync-ring-init"
+            android:exported="false" />
     </application>
 </manifest>

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFanOutPrefs.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFanOutPrefs.kt
@@ -1,0 +1,38 @@
+// SharedPreferences-backed developer toggle for wear-sync's native fired->watch-ring fan-out
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.Context
+
+private const val PREFS_NAME = "ThresholdWearSyncDevOptions"
+private const val KEY_NATIVE_FAN_OUT_ENABLED = "native_fan_out_enabled"
+
+/**
+ * Developer-only toggle (issue #255 Phase 3B) letting a tester disable
+ * [NativeFiredListener]'s in-process fired→watch-ring fan-out, so the pre-existing Rust
+ * `alarm:fired` → `send_alarm_ring` path can be exercised in isolation. Defaults to
+ * enabled (`true`) -- the native path is this phase's shipped production behaviour, and
+ * this toggle exists purely to make the older path testable on demand, not as a rollout
+ * kill switch.
+ *
+ * A distinct SharedPreferences file from [WearSyncCache] and [WearSyncEventQueue]'s: this
+ * is developer-only state, not sync data, and keeping it separate means it's trivial to
+ * clear independently (e.g. "reset developer options") without touching cached alarm data.
+ */
+object NativeFanOutPrefs {
+
+    fun isNativeFanOutEnabled(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_NATIVE_FAN_OUT_ENABLED, true)
+    }
+
+    fun setNativeFanOutEnabled(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_NATIVE_FAN_OUT_ENABLED, enabled)
+            .apply()
+    }
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFanOutPrefs.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFanOutPrefs.kt
@@ -21,12 +21,44 @@ private const val KEY_NATIVE_FAN_OUT_ENABLED = "native_fan_out_enabled"
  * A distinct SharedPreferences file from [WearSyncCache] and [WearSyncEventQueue]'s: this
  * is developer-only state, not sync data, and keeping it separate means it's trivial to
  * clear independently (e.g. "reset developer options") without touching cached alarm data.
+ *
+ * [isNativeFanOutEnabled] is read from [NativeFiredListener.handle], which -- per
+ * [ca.liminalhq.threshold.nativebus.NativeEventBus]'s threading contract -- must stay cheap
+ * and non-blocking. A `SharedPreferences` file's *first* access on a cold process can block
+ * on its background XML load, so this class keeps an in-memory [cachedEnabled] on top of the
+ * real store: [warm] (called once by [WearRingInitProvider.onCreate], before
+ * [NativeFiredListener] is even registered) pays that cost up front, off the fired-event
+ * path entirely, so every later [isNativeFanOutEnabled] call -- including the one inside
+ * [NativeFiredListener.handle] -- is a plain volatile-field read.
  */
 object NativeFanOutPrefs {
 
+    // Written once by warm() (main thread, during WearRingInitProvider.onCreate) and by
+    // setNativeFanOutEnabled() (the settings toggle's own IO-dispatcher scope); read from
+    // NativeFiredListener's own coroutine dispatcher. @Volatile makes those writes visible
+    // across threads without needing a lock for what's otherwise a single boolean read.
+    @Volatile
+    private var cachedEnabled: Boolean? = null
+
+    /**
+     * Pre-loads [cachedEnabled] from disk. Must be called once, early -- see the class KDoc
+     * for why this exists and why it has to run before [NativeFiredListener] is registered.
+     * Safe to call more than once (e.g. a future second provider); each call just re-reads
+     * the same file.
+     */
+    fun warm(context: Context) {
+        cachedEnabled = readFromDisk(context)
+    }
+
+    /**
+     * Whether native fan-out is enabled. Served from [cachedEnabled] when available (the
+     * expected path once [warm] has run); falls back to a direct (possibly blocking) disk
+     * read otherwise, purely as a defensive fallback for a caller that reaches this before
+     * [warm] -- not expected to happen given the registration ordering [warm]'s caller
+     * relies on, but safer than crashing or lying about the toggle's value if it somehow did.
+     */
     fun isNativeFanOutEnabled(context: Context): Boolean {
-        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .getBoolean(KEY_NATIVE_FAN_OUT_ENABLED, true)
+        return cachedEnabled ?: readFromDisk(context).also { cachedEnabled = it }
     }
 
     fun setNativeFanOutEnabled(context: Context, enabled: Boolean) {
@@ -34,5 +66,11 @@ object NativeFanOutPrefs {
             .edit()
             .putBoolean(KEY_NATIVE_FAN_OUT_ENABLED, enabled)
             .apply()
+        cachedEnabled = enabled
+    }
+
+    private fun readFromDisk(context: Context): Boolean {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_NATIVE_FAN_OUT_ENABLED, true)
     }
 }

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
@@ -8,12 +8,10 @@ package ca.liminalhq.threshold.wearsync
 import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
-import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import org.json.JSONObject
 
 private const val TAG = "NativeFiredListener"
@@ -31,7 +29,9 @@ internal const val TAG_WATCH_RING = "watch-ring"
 
 // Per the #255 Phase 3 payload contract: a fired event older than this is treated as a
 // stale replay (e.g. a durable-queue entry drained long after the alarm actually rang) and
-// must not ring the watch again.
+// must not ring the watch again. Mirrored independently (no shared source of truth across
+// languages) by `STALENESS_WINDOW_MS`/`is_stale` in wear-sync's own `src/lib.rs` -- if you
+// tune this value, tune that one too.
 internal const val STALENESS_WINDOW_MS = 90_000L
 
 /**
@@ -50,6 +50,16 @@ internal const val STALENESS_WINDOW_MS = 90_000L
  * once it's confirmed delivered -- at-least-once semantics, per the contract doc's decision:
  * stamping the tag after confirmation would risk a crash mid-send leaving the watch silent
  * with no fallback, which is the exact failure this whole design exists to prevent.
+ *
+ * The toggle check specifically has to stay *synchronous* despite that contract, since
+ * [handle]'s return value (whether it claims [TAG_WATCH_RING]) has to reflect whether native
+ * fan-out is actually disabled -- deferring that decision into [scope] would mean returning
+ * the tag optimistically, which would make the Rust-side gate skip its own ring too and drop
+ * the ring entirely whenever the toggle is off. [NativeFanOutPrefs] resolves the tension by
+ * caching the toggle's value in memory, warmed once by [WearRingInitProvider.onCreate] before
+ * this listener is even registered -- see its KDoc -- so by the time [handle] can possibly
+ * run, the "synchronous" check is a plain volatile-field read, not a `SharedPreferences` disk
+ * hit.
  */
 object NativeFiredListener {
 
@@ -115,19 +125,7 @@ object NativeFiredListener {
             is24HourKnown = is24HourKnown,
         )
 
-        val nodeClient = Wearable.getNodeClient(context)
-        val messageClient = Wearable.getMessageClient(context)
-        val nodes = nodeClient.connectedNodes.await()
-        if (nodes.isEmpty()) {
-            Log.d(TAG, "No connected watch nodes — skipping native ring for id=$alarmId")
-            return
-        }
-
-        for (node in nodes) {
-            messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
-            Log.d(TAG, "Sent native alarm ring to watch: ${node.displayName} for id=$alarmId")
-        }
-        NativeEventLog.log(context, TAG, "Sent native watch ring for id=$alarmId to ${nodes.size} node(s)")
+        sendAlarmRingToConnectedNodes(context, payload, TAG)
     }
 }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
@@ -1,0 +1,192 @@
+// In-process listener that rings the watch the instant an alarm fires, before Rust boots
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.Context
+import android.util.Log
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import org.json.JSONObject
+
+private const val TAG = "NativeFiredListener"
+
+// Mirrors alarm-manager's own `internal const val TOPIC_FIRED` (AlarmManagerPlugin.kt) --
+// duplicated rather than shared because the two plugins are separate Gradle modules and
+// this string is frozen by docs/architecture/255-phase3-payload-contract.md, not by a
+// shared Kotlin symbol.
+internal const val TOPIC_FIRED = "alarm-manager:native-fired"
+
+// Exact string per the #255 Phase 3 payload contract -- also referenced by the Rust-side
+// staleness/tag gate in lib.rs's `alarm:fired` listener once Phase 3C's `handled_natively`
+// field lands on the app's `AlarmFired` struct.
+internal const val TAG_WATCH_RING = "watch-ring"
+
+// Per the #255 Phase 3 payload contract: a fired event older than this is treated as a
+// stale replay (e.g. a durable-queue entry drained long after the alarm actually rang) and
+// must not ring the watch again.
+internal const val STALENESS_WINDOW_MS = 90_000L
+
+/**
+ * Registers with [NativeEventBus] for alarm-manager's `alarm-manager:native-fired` topic and
+ * rings the watch directly via Play Services, entirely natively, the moment an alarm fires
+ * cold -- no dependency on Rust or the WebView having booted. This is what actually closes
+ * issue #254 (the watch staying silent for ~20s on a cold fire while the phone is in active
+ * use): [WearRingInitProvider]'s `onCreate()` guarantees this listener is registered before
+ * `AlarmReceiver.onReceive()` can run, even on a cold multi-plugin process start.
+ *
+ * Builds the ring payload entirely from [WearSyncCache] (the last-published alarm snapshot
+ * plus snooze/time-format prefs) -- no Rust involvement needed. See [NativeEventBus]'s KDoc
+ * for the threading contract this object's [handle] function must honour: it does only
+ * cheap, synchronous work inline (parse, staleness check, toggle check) and hands the actual
+ * network I/O off to [scope], returning [TAG_WATCH_RING] once that work is *initiated*, not
+ * once it's confirmed delivered -- at-least-once semantics, per the contract doc's decision:
+ * stamping the tag after confirmation would risk a crash mid-send leaving the watch silent
+ * with no fallback, which is the exact failure this whole design exists to prevent.
+ */
+object NativeFiredListener {
+
+    // A dedicated scope, not WearSyncPlugin's -- this listener can run (and does run, by
+    // design) before any WearSyncPlugin instance exists.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
+    fun register(context: Context) {
+        val appContext = context.applicationContext
+        NativeEventBus.subscribe(TOPIC_FIRED) { payload -> handle(appContext, payload) }
+        Log.d(TAG, "Registered native fired listener for topic '$TOPIC_FIRED'")
+    }
+
+    /**
+     * The [NativeEventBus] listener callback itself. `internal` (not `private`) so tests can
+     * drive it directly against a fake/instrumented [Context] without going through
+     * [register]/[NativeEventBus].
+     */
+    internal fun handle(context: Context, payload: String): String? {
+        val fired = parseFiredPayload(payload)
+        if (fired == null) {
+            Log.w(TAG, "Ignoring malformed '$TOPIC_FIRED' payload")
+            return null
+        }
+
+        if (!NativeFanOutPrefs.isNativeFanOutEnabled(context)) {
+            Log.d(TAG, "Native watch fan-out disabled by developer toggle, skipping id=${fired.id}")
+            return null
+        }
+
+        if (isStale(fired.actualFiredAt, System.currentTimeMillis())) {
+            Log.w(TAG, "Ignoring stale fired event for id=${fired.id}, actualFiredAt=${fired.actualFiredAt}")
+            return null
+        }
+
+        scope.launch {
+            try {
+                ringWatch(context, fired.id)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to ring watch natively for id=${fired.id}", e)
+            }
+        }
+        return TAG_WATCH_RING
+    }
+
+    private suspend fun ringWatch(context: Context, alarmId: Int) {
+        val cached = WearSyncCache.read(context)
+        if (cached == null) {
+            Log.w(TAG, "No cached alarm data available, cannot ring watch natively for id=$alarmId")
+            return
+        }
+        val (alarmsJson, _, snoozeLengthMinutes, is24Hour, is24HourKnown) = cached
+        val label = resolveAlarmLabel(alarmsJson, alarmId)
+
+        val payload = buildAlarmRingPayload(
+            alarmId = alarmId,
+            label = label,
+            hour = null,
+            minute = null,
+            snoozeLengthMinutes = snoozeLengthMinutes,
+            is24Hour = is24Hour,
+            is24HourKnown = is24HourKnown,
+        )
+
+        val nodeClient = Wearable.getNodeClient(context)
+        val messageClient = Wearable.getMessageClient(context)
+        val nodes = nodeClient.connectedNodes.await()
+        if (nodes.isEmpty()) {
+            Log.d(TAG, "No connected watch nodes — skipping native ring for id=$alarmId")
+            return
+        }
+
+        for (node in nodes) {
+            messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
+            Log.d(TAG, "Sent native alarm ring to watch: ${node.displayName} for id=$alarmId")
+        }
+        NativeEventLog.log(context, TAG, "Sent native watch ring for id=$alarmId to ${nodes.size} node(s)")
+    }
+}
+
+/** One `alarm-manager:native-fired` payload's fields this listener cares about. */
+internal data class FiredPayload(val id: Int, val actualFiredAt: Long)
+
+/**
+ * Parses the `{id, actualFiredAt, ...}` JSON payload alarm-manager publishes to
+ * [NativeEventBus] (see docs/architecture/255-phase3-payload-contract.md). Tolerates and
+ * ignores the payload's `eventId`/`handledNatively` fields -- this listener has no use for
+ * either. Returns `null` for anything malformed or missing a usable `id`/`actualFiredAt`
+ * rather than throwing, so a corrupt payload is silently skipped (logged by the caller)
+ * instead of crashing [NativeEventBus.publish]'s caller.
+ */
+internal fun parseFiredPayload(payload: String): FiredPayload? {
+    return try {
+        val json = JSONObject(payload)
+        val id = json.optInt("id", -1)
+        if (id <= 0) return null
+        val actualFiredAt = json.optLong("actualFiredAt", -1L)
+        if (actualFiredAt <= 0L) return null
+        FiredPayload(id, actualFiredAt)
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Whether a fired event timestamped [actualFiredAt] is too old, relative to [now], to still
+ * ring the watch -- per the #255 Phase 3 payload contract's [STALENESS_WINDOW_MS] window. A
+ * pure function of two timestamps so it's unit-testable without any Android framework class.
+ */
+internal fun isStale(actualFiredAt: Long, now: Long, windowMs: Long = STALENESS_WINDOW_MS): Boolean {
+    return now - actualFiredAt > windowMs
+}
+
+/**
+ * Looks up alarm [alarmId]'s label inside [alarmsJson] -- the cached `SyncResponse` FullSync
+ * envelope JSON written by [WearSyncCache.write] (`{"type":"FullSync","currentRevision":…,
+ * "allAlarms":[{"id":…,"label":…},…]}`, see wear-sync's Rust `sync_protocol::SyncResponse`).
+ * Returns `""` (matching `AlarmRingRequest.label`'s own default) if the envelope is
+ * malformed, isn't a `FullSync`, or has no alarm with a matching id -- a missing label
+ * shouldn't stop the watch from ringing.
+ *
+ * A pure function of the raw cached JSON string, not [WearSyncCache] itself, so it's
+ * unit-testable without an Android [Context].
+ */
+internal fun resolveAlarmLabel(alarmsJson: String, alarmId: Int): String {
+    return try {
+        val root = JSONObject(alarmsJson)
+        val allAlarms = root.optJSONArray("allAlarms") ?: return ""
+        for (i in 0 until allAlarms.length()) {
+            val alarm = allAlarms.optJSONObject(i) ?: continue
+            if (alarm.optInt("id", -1) == alarmId) {
+                return alarm.optString("label", "")
+            }
+        }
+        ""
+    } catch (e: Exception) {
+        ""
+    }
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
@@ -1,0 +1,71 @@
+// ContentProvider that registers the native fired->watch-ring listener before anything else can run
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.util.Log
+
+private const val TAG = "WearRingInitProvider"
+
+/**
+ * Guarantees [NativeFiredListener] is subscribed to [NativeEventBus] before anything else in
+ * the app can run, including on a cold multi-plugin process start.
+ * `ContentProvider.onCreate()` is documented to always run before any `Activity`/`Service`/
+ * `BroadcastReceiver` callback -- this is the same Jetpack/WorkManager/Firebase early-init
+ * trick, and the mechanism issue #255's Phase 0 spike
+ * (`feat/255-p0-contentprovider-spike`, see its `BusInitProvider.kt`) proved out on a real
+ * device ahead of this, the production implementation.
+ *
+ * Unlike that spike, this provider is not debug-gated: it ships in every build, since this
+ * is the actual fix for issue #254 (the watch staying silent for ~20s when an alarm fires
+ * cold while the phone is in active use, because the watch ring used to depend on Rust
+ * booting first). `android:exported="false"` in the manifest -- this provider has no real
+ * data to serve and no external caller.
+ */
+class WearRingInitProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val ctx = context
+        if (ctx == null) {
+            // ContentProvider.onCreate() is documented to always have an attached Context by
+            // the time it runs; this is defensive only, not an expected path.
+            Log.e(TAG, "onCreate() called with no attached Context")
+            return true
+        }
+
+        NativeFiredListener.register(ctx)
+        Log.d(TAG, "WearRingInitProvider.onCreate() fired, native fired listener registered")
+
+        return true
+    }
+
+    // Everything below is a deliberate no-op -- this is not a real content provider, it
+    // exists purely for the onCreate() timing guarantee above.
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+    ): Int = 0
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
@@ -39,8 +39,13 @@ class WearRingInitProvider : ContentProvider() {
             return true
         }
 
+        // Warm the fan-out toggle's in-memory cache *before* registering the listener that
+        // reads it -- see NativeFanOutPrefs' class KDoc for why this ordering is what lets
+        // NativeFiredListener.handle() honour NativeEventBus's non-blocking threading
+        // contract despite the toggle check needing to be resolved synchronously.
+        NativeFanOutPrefs.warm(ctx)
         NativeFiredListener.register(ctx)
-        Log.d(TAG, "WearRingInitProvider.onCreate() fired, native fired listener registered")
+        Log.d(TAG, "WearRingInitProvider.onCreate() fired, fan-out toggle warmed, listener registered")
 
         return true
     }

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -27,11 +27,49 @@ import org.json.JSONObject
 private const val TAG = "WearSyncPlugin"
 private const val DATA_PATH_ALARMS = "/threshold/alarms"
 private const val MSG_PATH_SYNC_REQUEST = "/threshold/sync_request"
-private const val MSG_PATH_ALARM_RING = "/threshold/alarm_ring"
+// internal (not private) -- shared with NativeFiredListener, which sends the same
+// alarm_ring message from outside this Activity-bound plugin instance.
+internal const val MSG_PATH_ALARM_RING = "/threshold/alarm_ring"
 private const val MSG_PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
 private const val MSG_PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
 private const val MSG_PATH_LOG_REQUEST = "/threshold/log_request"
 private const val EXTRA_HEADLESS_BOOT = "wear_sync_headless_boot"
+
+/**
+ * Builds the JSON alarm-ring message payload sent to the watch over `MessageClient` at
+ * [MSG_PATH_ALARM_RING]. Shared by [WearSyncPlugin.sendAlarmRing] (the Rust-invoked path,
+ * used once Rust/WebView has booted) and [NativeFiredListener] (the in-process native path,
+ * issue #255 Phase 3B) so the wire format is defined in exactly one place.
+ *
+ * `hour`/`minute` of `null` means "use the device's current time" -- both callers already
+ * pass `null` today (Rust never supplies an explicit time; the native path has no reason to
+ * either), but the parameter is kept so a future caller with a real scheduled time can still
+ * use this helper.
+ */
+internal fun buildAlarmRingPayload(
+    alarmId: Int,
+    label: String,
+    hour: Int?,
+    minute: Int?,
+    snoozeLengthMinutes: Int,
+    is24Hour: Boolean,
+    is24HourKnown: Boolean,
+): ByteArray {
+    val cal = java.util.Calendar.getInstance()
+    val resolvedHour = hour ?: cal.get(java.util.Calendar.HOUR_OF_DAY)
+    val resolvedMinute = minute ?: cal.get(java.util.Calendar.MINUTE)
+
+    val json = JSONObject().apply {
+        put("alarmId", alarmId)
+        put("label", label)
+        put("hour", resolvedHour)
+        put("minute", resolvedMinute)
+        put("snoozeLengthMinutes", snoozeLengthMinutes)
+        put("is24Hour", is24Hour)
+        put("is24HourKnown", is24HourKnown)
+    }
+    return json.toString().toByteArray()
+}
 
 @InvokeArg
 class PublishRequest {
@@ -75,6 +113,11 @@ class AlarmSnoozeRequest {
 @InvokeArg
 class WatchMessageHandlerArgs {
     lateinit var handler: Channel
+}
+
+@InvokeArg
+class SetNativeFanOutEnabledArgs {
+    var enabled: Boolean = true
 }
 
 @TauriPlugin
@@ -178,6 +221,11 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
      * Called from the Rust side when an alarm fires. The watch receives
      * this message via its [DataLayerListenerService] and starts its
      * own [WearRingingService] to show the ringing UI and vibrate.
+     *
+     * Known gap (issue #255): this resolves successfully without ever sending a message
+     * when no watch node is currently connected -- that's a distinct, out-of-scope gap
+     * (watch not paired/connected) from the one Phase 3B's native fan-out
+     * ([NativeFiredListener]) closes (Rust/WebView not booted yet).
      */
     @Command
     fun sendAlarmRing(invoke: Invoke) {
@@ -191,21 +239,15 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                     return@launch
                 }
 
-                // Use current device time if Rust didn't provide explicit hour/minute
-                val cal = java.util.Calendar.getInstance()
-                val hour = args.hour ?: cal.get(java.util.Calendar.HOUR_OF_DAY)
-                val minute = args.minute ?: cal.get(java.util.Calendar.MINUTE)
-
-                val json = JSONObject().apply {
-                    put("alarmId", args.alarmId)
-                    put("label", args.label)
-                    put("hour", hour)
-                    put("minute", minute)
-                    put("snoozeLengthMinutes", args.snoozeLengthMinutes)
-                    put("is24Hour", args.is24Hour)
-                    put("is24HourKnown", args.is24HourKnown)
-                }
-                val payload = json.toString().toByteArray()
+                val payload = buildAlarmRingPayload(
+                    alarmId = args.alarmId,
+                    label = args.label,
+                    hour = args.hour,
+                    minute = args.minute,
+                    snoozeLengthMinutes = args.snoozeLengthMinutes,
+                    is24Hour = args.is24Hour,
+                    is24HourKnown = args.is24HourKnown,
+                )
 
                 for (node in nodes) {
                     messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
@@ -357,6 +399,28 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     /**
+     * Developer toggle (issue #255 Phase 3B): enable or disable [NativeFiredListener]'s
+     * in-process fired→watch-ring fan-out, so a tester can exercise the Rust
+     * `alarm:fired` → `send_alarm_ring` path in isolation. Persisted via
+     * [NativeFanOutPrefs] so it survives process death (the whole point of the native path
+     * is that it can run before this plugin instance even exists).
+     */
+    @Command
+    fun setNativeFanOutEnabled(invoke: Invoke) {
+        val args = invoke.parseArgs(SetNativeFanOutEnabledArgs::class.java)
+        NativeFanOutPrefs.setNativeFanOutEnabled(activity, args.enabled)
+        Log.d(TAG, "Native watch fan-out enabled=${args.enabled}")
+        invoke.resolve()
+    }
+
+    /** Reads the current value of the [setNativeFanOutEnabled] toggle. Defaults to `true`. */
+    @Command
+    fun getNativeFanOutEnabled(invoke: Invoke) {
+        val enabled = NativeFanOutPrefs.isNativeFanOutEnabled(activity)
+        invoke.resolve(JSObject().apply { put("enabled", enabled) })
+    }
+
+    /**
      * Move the host activity to the back of the task stack.
      *
      * Called by [WearSyncService] after cold-booting the Tauri runtime so
@@ -407,6 +471,10 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                 val event = JSObject()
                 event.put("path", message.path)
                 event.put("data", message.data)
+                // Stamped in so a same-process dedup pass on the Rust side (issue #255 Phase
+                // 3C) has something to key watch-originated dismiss/snooze messages on, same
+                // as the fired path's eventId -- see WatchMessage::event_id on the Rust side.
+                event.put("eventId", message.eventId)
                 channel.send(event)
                 delivered.add(message.eventId)
                 Log.d(TAG, "Sent watch message to Rust channel: path=${message.path}")

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -6,6 +6,7 @@
 package ca.liminalhq.threshold.wearsync
 
 import android.app.Activity
+import android.content.Context
 import android.util.Log
 import android.webkit.WebView
 import app.tauri.annotation.Command
@@ -69,6 +70,35 @@ internal fun buildAlarmRingPayload(
         put("is24HourKnown", is24HourKnown)
     }
     return json.toString().toByteArray()
+}
+
+/**
+ * Sends [payload] to every currently connected watch node at [MSG_PATH_ALARM_RING], logging
+ * both to Logcat and [NativeEventLog] under [tag] (the caller's own tag, so diagnostics from
+ * the Rust-invoked path and the native path are still distinguishable). Shared by
+ * [WearSyncPlugin.sendAlarmRing] and [NativeFiredListener] alongside [buildAlarmRingPayload]
+ * so the two callers' "iterate connected nodes, send message" logic can't drift the way it
+ * already had (only one of them was logging to [NativeEventLog]).
+ *
+ * Returns the number of nodes the message was actually sent to (`0` if none connected --
+ * the existing "no watch paired" gap noted on [WearSyncPlugin.sendAlarmRing], not something
+ * either caller treats as an error).
+ */
+internal suspend fun sendAlarmRingToConnectedNodes(context: Context, payload: ByteArray, tag: String): Int {
+    val nodeClient = Wearable.getNodeClient(context)
+    val messageClient = Wearable.getMessageClient(context)
+    val nodes = nodeClient.connectedNodes.await()
+    if (nodes.isEmpty()) {
+        Log.d(tag, "No connected watch nodes — skipping ring notification")
+        return 0
+    }
+
+    for (node in nodes) {
+        messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
+        Log.d(tag, "Sent alarm ring to watch: ${node.displayName}")
+    }
+    NativeEventLog.log(context, tag, "Sent alarm ring to ${nodes.size} node(s)")
+    return nodes.size
 }
 
 @InvokeArg
@@ -232,13 +262,6 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         val args = invoke.parseArgs(AlarmRingRequest::class.java)
         scope.launch {
             try {
-                val nodes = nodeClient.connectedNodes.await()
-                if (nodes.isEmpty()) {
-                    Log.d(TAG, "No connected watch nodes — skipping ring notification")
-                    invoke.resolve()
-                    return@launch
-                }
-
                 val payload = buildAlarmRingPayload(
                     alarmId = args.alarmId,
                     label = args.label,
@@ -248,11 +271,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                     is24Hour = args.is24Hour,
                     is24HourKnown = args.is24HourKnown,
                 )
-
-                for (node in nodes) {
-                    messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
-                    Log.d(TAG, "Sent alarm ring to watch: ${node.displayName}")
-                }
+                sendAlarmRingToConnectedNodes(activity, payload, TAG)
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm ring to watch", e)

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeFiredListenerTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeFiredListenerTest.kt
@@ -1,0 +1,203 @@
+// Unit tests for NativeFiredListener's pure staleness/parsing/payload-construction helpers
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers the pure functions
+ * [NativeFiredListener] (and the shared [buildAlarmRingPayload] helper it calls) factor out
+ * specifically so this staleness/parsing/payload-construction logic is testable independent
+ * of [android.content.Context], [NativeEventBus], and Play Services -- mirrors the style of
+ * [WearSyncEventQueueTest] and native-bus's own `NativeEventBusTest`.
+ */
+class NativeFiredListenerTest {
+
+    // ── parseFiredPayload ────────────────────────────────────────────
+
+    @Test
+    fun `parseFiredPayload reads id and actualFiredAt from a well-formed payload`() {
+        val payload = JSONObject().apply {
+            put("id", 42)
+            put("actualFiredAt", 1_755_100_800_000L)
+        }.toString()
+
+        val result = parseFiredPayload(payload)
+
+        assertEquals(FiredPayload(42, 1_755_100_800_000L), result)
+    }
+
+    @Test
+    fun `parseFiredPayload ignores unrecognised fields like eventId and handledNatively`() {
+        val payload = JSONObject().apply {
+            put("id", 7)
+            put("actualFiredAt", 1000L)
+            put("eventId", "b3f1c2a4-0000-0000-0000-000000000000")
+            put("handledNatively", org.json.JSONArray())
+        }.toString()
+
+        val result = parseFiredPayload(payload)
+
+        assertEquals(FiredPayload(7, 1000L), result)
+    }
+
+    @Test
+    fun `parseFiredPayload returns null for malformed JSON`() {
+        assertNull(parseFiredPayload("not even json"))
+    }
+
+    @Test
+    fun `parseFiredPayload returns null when id is missing`() {
+        val payload = JSONObject().apply { put("actualFiredAt", 1000L) }.toString()
+
+        assertNull(parseFiredPayload(payload))
+    }
+
+    @Test
+    fun `parseFiredPayload returns null when id is zero or negative`() {
+        val payload = JSONObject().apply {
+            put("id", 0)
+            put("actualFiredAt", 1000L)
+        }.toString()
+
+        assertNull(parseFiredPayload(payload))
+    }
+
+    @Test
+    fun `parseFiredPayload returns null when actualFiredAt is missing`() {
+        val payload = JSONObject().apply { put("id", 5) }.toString()
+
+        assertNull(parseFiredPayload(payload))
+    }
+
+    // ── isStale ──────────────────────────────────────────────────────
+
+    @Test
+    fun `isStale is false for an event fired just now`() {
+        assertFalse(isStale(actualFiredAt = 1_000_000L, now = 1_000_000L))
+    }
+
+    @Test
+    fun `isStale is false exactly at the staleness window boundary`() {
+        assertFalse(isStale(actualFiredAt = 0L, now = STALENESS_WINDOW_MS))
+    }
+
+    @Test
+    fun `isStale is true one millisecond past the staleness window`() {
+        assertTrue(isStale(actualFiredAt = 0L, now = STALENESS_WINDOW_MS + 1))
+    }
+
+    @Test
+    fun `isStale is true for a long-past event`() {
+        assertTrue(isStale(actualFiredAt = 0L, now = 60 * 60 * 1000L))
+    }
+
+    // ── resolveAlarmLabel ────────────────────────────────────────────
+
+    @Test
+    fun `resolveAlarmLabel finds the matching alarm's label in a FullSync envelope`() {
+        val alarmsJson = JSONObject().apply {
+            put("type", "FullSync")
+            put("currentRevision", 10)
+            put(
+                "allAlarms",
+                org.json.JSONArray().apply {
+                    put(JSONObject().apply { put("id", 1); put("label", "Wake up") })
+                    put(JSONObject().apply { put("id", 2); put("label", "Gym") })
+                },
+            )
+        }.toString()
+
+        assertEquals("Gym", resolveAlarmLabel(alarmsJson, 2))
+    }
+
+    @Test
+    fun `resolveAlarmLabel returns empty string when no alarm matches the id`() {
+        val alarmsJson = JSONObject().apply {
+            put("type", "FullSync")
+            put("currentRevision", 10)
+            put("allAlarms", org.json.JSONArray().apply { put(JSONObject().apply { put("id", 1); put("label", "Wake up") }) })
+        }.toString()
+
+        assertEquals("", resolveAlarmLabel(alarmsJson, 99))
+    }
+
+    @Test
+    fun `resolveAlarmLabel returns empty string for malformed JSON`() {
+        assertEquals("", resolveAlarmLabel("not even json", 1))
+    }
+
+    @Test
+    fun `resolveAlarmLabel returns empty string when allAlarms is absent`() {
+        val alarmsJson = JSONObject().apply { put("type", "UpToDate"); put("currentRevision", 10) }.toString()
+
+        assertEquals("", resolveAlarmLabel(alarmsJson, 1))
+    }
+
+    @Test
+    fun `resolveAlarmLabel returns empty string when the matching alarm has no label`() {
+        val alarmsJson = JSONObject().apply {
+            put("type", "FullSync")
+            put("currentRevision", 10)
+            put("allAlarms", org.json.JSONArray().apply { put(JSONObject().apply { put("id", 1) }) })
+        }.toString()
+
+        assertEquals("", resolveAlarmLabel(alarmsJson, 1))
+    }
+
+    // ── buildAlarmRingPayload (shared with WearSyncPlugin.sendAlarmRing) ────────────────
+
+    @Test
+    fun `buildAlarmRingPayload includes an explicit hour and minute unchanged`() {
+        val json = JSONObject(
+            String(
+                buildAlarmRingPayload(
+                    alarmId = 3,
+                    label = "Wake up",
+                    hour = 7,
+                    minute = 30,
+                    snoozeLengthMinutes = 5,
+                    is24Hour = true,
+                    is24HourKnown = true,
+                ),
+            ),
+        )
+
+        assertEquals(3, json.getInt("alarmId"))
+        assertEquals("Wake up", json.getString("label"))
+        assertEquals(7, json.getInt("hour"))
+        assertEquals(30, json.getInt("minute"))
+        assertEquals(5, json.getInt("snoozeLengthMinutes"))
+        assertTrue(json.getBoolean("is24Hour"))
+        assertTrue(json.getBoolean("is24HourKnown"))
+    }
+
+    @Test
+    fun `buildAlarmRingPayload falls back to the current device time when hour and minute are null`() {
+        val json = JSONObject(
+            String(
+                buildAlarmRingPayload(
+                    alarmId = 3,
+                    label = "",
+                    hour = null,
+                    minute = null,
+                    snoozeLengthMinutes = 10,
+                    is24Hour = false,
+                    is24HourKnown = false,
+                ),
+            ),
+        )
+
+        val cal = java.util.Calendar.getInstance()
+        // Both resolved within the same test run, so equal to within a minute of drift.
+        assertEquals(cal.get(java.util.Calendar.HOUR_OF_DAY), json.getInt("hour"))
+    }
+}

--- a/plugins/wear-sync/build.rs
+++ b/plugins/wear-sync/build.rs
@@ -11,6 +11,8 @@ const COMMANDS: &[&str] = &[
     "send_alarm_snooze",
     "set_watch_message_handler",
     "mark_watch_pipeline_ready",
+    "get_native_fan_out_enabled",
+    "set_native_fan_out_enabled",
 ];
 
 fn main() {

--- a/plugins/wear-sync/guest-js/index.ts
+++ b/plugins/wear-sync/guest-js/index.ts
@@ -1,0 +1,28 @@
+// Typed TypeScript bindings for the wear-sync plugin's webview-invokable commands
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import { invoke } from '@tauri-apps/api/core';
+
+export interface NativeFanOutEnabledResponse {
+	enabled: boolean;
+}
+
+/**
+ * Reads the "native watch fan-out" developer toggle (issue #255 Phase 3B). Defaults to
+ * `true` (enabled) when nothing has been persisted yet. Android-only in practice -- always
+ * reports `true` on desktop, which has no native fan-out to disable.
+ */
+export async function getNativeFanOutEnabled(): Promise<NativeFanOutEnabledResponse> {
+	return await invoke<NativeFanOutEnabledResponse>('plugin:wear-sync|get_native_fan_out_enabled');
+}
+
+/**
+ * Enables or disables wear-sync's native (in-process, pre-Rust-boot) fired→watch-ring
+ * fan-out, so the older Rust `alarm:fired` → `send_alarm_ring` path can be exercised in
+ * isolation for testing. No-ops on desktop.
+ */
+export async function setNativeFanOutEnabled(enabled: boolean): Promise<void> {
+	await invoke('plugin:wear-sync|set_native_fan_out_enabled', { request: { enabled } });
+}

--- a/plugins/wear-sync/package.json
+++ b/plugins/wear-sync/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "tauri-plugin-wear-sync-api",
+	"version": "0.1.0",
+	"author": "Threshold",
+	"description": "",
+	"type": "module",
+	"types": "./guest-js/index.ts",
+	"main": "./dist-js/index.cjs",
+	"module": "./dist-js/index.js",
+	"exports": {
+		"types": "./guest-js/index.ts",
+		"source": "./guest-js/index.ts",
+		"import": "./dist-js/index.js",
+		"require": "./dist-js/index.cjs",
+		"default": "./dist-js/index.js"
+	},
+	"files": [
+		"dist-js",
+		"README.md"
+	],
+	"scripts": {
+		"build": "rollup -c",
+		"prepublishOnly": "pnpm build",
+		"pretest": "pnpm build",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@tauri-apps/api": "^2.0.0"
+	},
+	"devDependencies": {
+		"@rollup/plugin-typescript": "^12.0.0",
+		"rollup": "^4.9.6",
+		"typescript": "^5.3.3",
+		"tslib": "^2.6.2"
+	}
+}

--- a/plugins/wear-sync/permissions/autogenerated/commands/get_native_fan_out_enabled.toml
+++ b/plugins/wear-sync/permissions/autogenerated/commands/get_native_fan_out_enabled.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-native-fan-out-enabled"
+description = "Enables the get_native_fan_out_enabled command without any pre-configured scope."
+commands.allow = ["get_native_fan_out_enabled"]
+
+[[permission]]
+identifier = "deny-get-native-fan-out-enabled"
+description = "Denies the get_native_fan_out_enabled command without any pre-configured scope."
+commands.deny = ["get_native_fan_out_enabled"]

--- a/plugins/wear-sync/permissions/autogenerated/commands/set_native_fan_out_enabled.toml
+++ b/plugins/wear-sync/permissions/autogenerated/commands/set_native_fan_out_enabled.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-native-fan-out-enabled"
+description = "Enables the set_native_fan_out_enabled command without any pre-configured scope."
+commands.allow = ["set_native_fan_out_enabled"]
+
+[[permission]]
+identifier = "deny-set-native-fan-out-enabled"
+description = "Denies the set_native_fan_out_enabled command without any pre-configured scope."
+commands.deny = ["set_native_fan_out_enabled"]

--- a/plugins/wear-sync/permissions/autogenerated/reference.md
+++ b/plugins/wear-sync/permissions/autogenerated/reference.md
@@ -6,6 +6,8 @@ Default permissions for the wear-sync plugin
 
 - `allow-set-watch-message-handler`
 - `allow-mark-watch-pipeline-ready`
+- `allow-get-native-fan-out-enabled`
+- `allow-set-native-fan-out-enabled`
 
 ## Permission Table
 
@@ -15,6 +17,32 @@ Default permissions for the wear-sync plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`wear-sync:allow-get-native-fan-out-enabled`
+
+</td>
+<td>
+
+Enables the get_native_fan_out_enabled command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wear-sync:deny-get-native-fan-out-enabled`
+
+</td>
+<td>
+
+Denies the get_native_fan_out_enabled command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -168,6 +196,32 @@ Enables the send_alarm_snooze command without any pre-configured scope.
 <td>
 
 Denies the send_alarm_snooze command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wear-sync:allow-set-native-fan-out-enabled`
+
+</td>
+<td>
+
+Enables the set_native_fan_out_enabled command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wear-sync:deny-set-native-fan-out-enabled`
+
+</td>
+<td>
+
+Denies the set_native_fan_out_enabled command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/wear-sync/permissions/default.toml
+++ b/plugins/wear-sync/permissions/default.toml
@@ -1,3 +1,8 @@
 [default]
 description = "Default permissions for the wear-sync plugin"
-permissions = ["allow-set-watch-message-handler", "allow-mark-watch-pipeline-ready"]
+permissions = [
+    "allow-set-watch-message-handler",
+    "allow-mark-watch-pipeline-ready",
+    "allow-get-native-fan-out-enabled",
+    "allow-set-native-fan-out-enabled",
+]

--- a/plugins/wear-sync/permissions/schemas/schema.json
+++ b/plugins/wear-sync/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the get_native_fan_out_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-native-fan-out-enabled",
+          "markdownDescription": "Enables the get_native_fan_out_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_native_fan_out_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-native-fan-out-enabled",
+          "markdownDescription": "Denies the get_native_fan_out_enabled command without any pre-configured scope."
+        },
+        {
           "description": "Enables the mark_watch_pipeline_ready command without any pre-configured scope.",
           "type": "string",
           "const": "allow-mark-watch-pipeline-ready",
@@ -367,6 +379,18 @@
           "markdownDescription": "Denies the send_alarm_snooze command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_native_fan_out_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-native-fan-out-enabled",
+          "markdownDescription": "Enables the set_native_fan_out_enabled command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_native_fan_out_enabled command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-native-fan-out-enabled",
+          "markdownDescription": "Denies the set_native_fan_out_enabled command without any pre-configured scope."
+        },
+        {
           "description": "Enables the set_watch_message_handler command without any pre-configured scope.",
           "type": "string",
           "const": "allow-set-watch-message-handler",
@@ -379,10 +403,10 @@
           "markdownDescription": "Denies the set_watch_message_handler command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`",
+          "description": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`\n- `allow-get-native-fan-out-enabled`\n- `allow-set-native-fan-out-enabled`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`"
+          "markdownDescription": "Default permissions for the wear-sync plugin\n#### This default permission set includes:\n\n- `allow-set-watch-message-handler`\n- `allow-mark-watch-pipeline-ready`\n- `allow-get-native-fan-out-enabled`\n- `allow-set-native-fan-out-enabled`"
         }
       ]
     }

--- a/plugins/wear-sync/rollup.config.js
+++ b/plugins/wear-sync/rollup.config.js
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { cwd } from 'node:process';
+import typescript from '@rollup/plugin-typescript';
+
+const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'));
+
+export default {
+	input: 'guest-js/index.ts',
+	output: [
+		{
+			file: pkg.exports.import,
+			format: 'esm',
+		},
+		{
+			file: pkg.exports.require,
+			format: 'cjs',
+		},
+	],
+	plugins: [
+		typescript({
+			declaration: true,
+			declarationDir: dirname(pkg.exports.import),
+		}),
+	],
+	external: [
+		/^@tauri-apps\/api/,
+		...Object.keys(pkg.dependencies || {}),
+		...Object.keys(pkg.peerDependencies || {}),
+	],
+};

--- a/plugins/wear-sync/src/commands.rs
+++ b/plugins/wear-sync/src/commands.rs
@@ -1,0 +1,31 @@
+// Tauri command handlers exposed to the webview
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use tauri::{command, AppHandle, Runtime};
+
+use crate::error::Result;
+use crate::models::{NativeFanOutEnabledResponse, SetNativeFanOutEnabledRequest};
+use crate::WearSyncExt;
+
+/// Enable or disable wear-sync's native (in-process) fired→watch-ring fan-out -- a
+/// developer-only toggle (issue #255 Phase 3B) for exercising the Rust `alarm:fired` →
+/// `send_alarm_ring` path in isolation. No-ops on desktop, which has no native fan-out
+/// concept in the first place.
+#[command]
+pub(crate) async fn set_native_fan_out_enabled<R: Runtime>(
+    app: AppHandle<R>,
+    request: SetNativeFanOutEnabledRequest,
+) -> Result<()> {
+    app.wear_sync().set_native_fan_out_enabled(request.enabled)
+}
+
+/// Reads the current value of the native fan-out developer toggle. Defaults to `true`
+/// (native fan-out enabled) when nothing has been persisted yet.
+#[command]
+pub(crate) async fn get_native_fan_out_enabled<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<NativeFanOutEnabledResponse> {
+    app.wear_sync().get_native_fan_out_enabled()
+}

--- a/plugins/wear-sync/src/desktop.rs
+++ b/plugins/wear-sync/src/desktop.rs
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::models::{
-    AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, PublishRequest, SyncRequest,
+    AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, NativeFanOutEnabledResponse,
+    PublishRequest, SyncRequest,
 };
 use tauri::{plugin::PluginApi, AppHandle, Runtime};
 
@@ -53,5 +54,21 @@ impl<R: Runtime> WearSync<R> {
     pub async fn request_watch_logs(&self) -> crate::Result<bool> {
         log::debug!("wear-sync: desktop stub — request_watch_logs (no-op)");
         Ok(false)
+    }
+
+    /// Desktop has no native (in-process, pre-Rust-boot) fan-out concept at all -- there's
+    /// no cold-start gap to close in the first place, since the whole app is one process
+    /// with no separate native plugin layer. Accepts and silently discards the toggle so
+    /// the command still exists (and no-ops sensibly) on desktop rather than erroring.
+    pub fn set_native_fan_out_enabled(&self, enabled: bool) -> crate::Result<()> {
+        let _ = enabled;
+        log::debug!("wear-sync: desktop stub — set_native_fan_out_enabled (no-op)");
+        Ok(())
+    }
+
+    /// Always reports enabled on desktop -- see [Self::set_native_fan_out_enabled].
+    pub fn get_native_fan_out_enabled(&self) -> crate::Result<NativeFanOutEnabledResponse> {
+        log::debug!("wear-sync: desktop stub — get_native_fan_out_enabled (no-op)");
+        Ok(NativeFanOutEnabledResponse { enabled: true })
     }
 }

--- a/plugins/wear-sync/src/lib.rs
+++ b/plugins/wear-sync/src/lib.rs
@@ -11,6 +11,7 @@ use tauri::{
 };
 
 mod batch_collector;
+mod commands;
 #[allow(dead_code)]
 mod conflict_detector;
 #[cfg(desktop)]
@@ -41,6 +42,48 @@ use publisher::{ChannelPublisher, PublishCommand, WearSyncPublisher};
 
 const BATCH_DEBOUNCE_MS: u64 = 500;
 
+// Per docs/architecture/255-phase3-payload-contract.md's shared constants.
+const WATCH_RING_TAG: &str = "watch-ring";
+const STALENESS_WINDOW_MS: i64 = 90_000;
+
+/// Milliseconds since the Unix epoch, right now. A tiny wrapper so the staleness check
+/// below doesn't need a `chrono` dependency this crate doesn't otherwise have.
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Whether a fired event timestamped `actual_fired_at` is too old, relative to `now_ms`, to
+/// still be worth ringing the watch for -- per the #255 Phase 3 payload contract's
+/// [STALENESS_WINDOW_MS] window. Mirrors `NativeFiredListener.isStale` on the Kotlin side;
+/// the two checks are applied independently (see [should_skip_native_watch_ring]'s doc).
+fn is_stale(actual_fired_at: i64, now_ms: i64) -> bool {
+    now_ms.saturating_sub(actual_fired_at) > STALENESS_WINDOW_MS
+}
+
+/// Whether this `alarm:fired` listener should skip calling `send_alarm_ring` for the given
+/// event -- per issue #255 Phase 3's Unified design (decision 6). True when either:
+/// - `handled_natively` already contains [WATCH_RING_TAG], meaning wear-sync's own Kotlin
+///   `NativeFiredListener` already rang the watch in-process before Rust ever saw this
+///   event, so ringing again here would double-ring it; or
+/// - the event itself is stale (see [is_stale]) -- a durable-queue entry drained long after
+///   the alarm actually rang must not ring the watch at all, regardless of who would have
+///   handled it. This half of the check, on its own, is what retroactively fixes the
+///   shipped "2:30 AM ghost ring" bug, even for events queued before this change ships.
+///
+/// A pure function of the three fields it needs (not the whole `AlarmFired` event) so it's
+/// unit-testable without constructing a full event or touching Tauri at all.
+fn should_skip_native_watch_ring(
+    handled_natively: &[String],
+    actual_fired_at: i64,
+    now_ms: i64,
+) -> bool {
+    handled_natively.iter().any(|tag| tag == WATCH_RING_TAG) || is_stale(actual_fired_at, now_ms)
+}
+
 /// Extension trait for accessing the wear-sync APIs from any Tauri manager.
 pub trait WearSyncExt<R: Runtime> {
     fn wear_sync(&self) -> &WearSync<R>;
@@ -55,6 +98,10 @@ impl<R: Runtime, T: Manager<R>> WearSyncExt<R> for T {
 /// Initialises the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("wear-sync")
+        .invoke_handler(tauri::generate_handler![
+            commands::get_native_fan_out_enabled,
+            commands::set_native_fan_out_enabled,
+        ])
         .setup(|app, api| {
             // Initialise platform backend
             #[cfg(mobile)]
@@ -119,6 +166,24 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             app.listen("alarm:fired", move |event| {
                 match serde_json::from_str::<AlarmFired>(event.payload()) {
                     Ok(fired) => {
+                        // Issue #255 Phase 3B gate: skip this path entirely when the native
+                        // (in-process, pre-Rust-boot) listener already rang the watch for
+                        // this exact event, or when the event is too old to be worth ringing
+                        // for at all -- see should_skip_native_watch_ring's doc.
+                        if should_skip_native_watch_ring(
+                            &fired.handled_natively,
+                            fired.actual_fired_at,
+                            now_ms(),
+                        ) {
+                            log::info!(
+                                "wear-sync: skipping send_alarm_ring for id={} (handled_natively={:?}, actual_fired_at={})",
+                                fired.id,
+                                fired.handled_natively,
+                                fired.actual_fired_at
+                            );
+                            return;
+                        }
+
                         let app = ring_app.clone();
                         tauri::async_runtime::spawn(async move {
                             let wear_sync = app.state::<WearSync<R>>();
@@ -393,7 +458,11 @@ fn handle_watch_message<R: Runtime>(app: &AppHandle<R>, msg: WatchMessage) {
             }
         },
         "/threshold/alarm_dismiss" => match serde_json::from_str::<WatchDismissAlarm>(&msg.data) {
-            Ok(dismiss_cmd) => {
+            Ok(mut dismiss_cmd) => {
+                // event_id isn't part of the watch's own JSON payload -- it's the queue
+                // envelope's id, threaded in here from WatchMessage so a same-process dedup
+                // pass (issue #255 Phase 3C) has something to key on for this topic too.
+                dismiss_cmd.event_id = msg.event_id.clone();
                 log::info!("wear-sync: watch dismiss alarm {}", dismiss_cmd.alarm_id);
                 if let Err(error) = app.emit("wear:alarm:dismiss", &dismiss_cmd) {
                     log::error!("wear-sync: failed to emit wear:alarm:dismiss event: {error}");
@@ -404,7 +473,9 @@ fn handle_watch_message<R: Runtime>(app: &AppHandle<R>, msg: WatchMessage) {
             }
         },
         "/threshold/alarm_snooze" => match serde_json::from_str::<WatchSnoozeAlarm>(&msg.data) {
-            Ok(snooze_cmd) => {
+            Ok(mut snooze_cmd) => {
+                // See the alarm_dismiss arm above -- same reasoning for threading event_id in.
+                snooze_cmd.event_id = msg.event_id.clone();
                 log::info!(
                     "wear-sync: watch snooze alarm {} for {} min",
                     snooze_cmd.alarm_id,
@@ -456,6 +527,64 @@ mod tests {
     use crate::models::SyncReason;
     use crate::publisher::WearSyncPublisher;
     use std::sync::{Arc, Mutex};
+
+    // ── should_skip_native_watch_ring / is_stale (issue #255 Phase 3B gate) ─────────────
+
+    #[test]
+    fn skips_when_handled_natively_contains_the_watch_ring_tag() {
+        let handled = vec!["watch-ring".to_string()];
+        assert!(should_skip_native_watch_ring(&handled, 1_000, 1_000));
+    }
+
+    #[test]
+    fn skips_when_handled_natively_contains_the_watch_ring_tag_alongside_others() {
+        let handled = vec!["something-else".to_string(), "watch-ring".to_string()];
+        assert!(should_skip_native_watch_ring(&handled, 1_000, 1_000));
+    }
+
+    #[test]
+    fn does_not_skip_when_handled_natively_is_empty_and_event_is_fresh() {
+        let handled: Vec<String> = vec![];
+        assert!(!should_skip_native_watch_ring(&handled, 1_000, 1_000));
+    }
+
+    #[test]
+    fn does_not_skip_for_an_unrelated_tag_and_a_fresh_event() {
+        let handled = vec!["something-else".to_string()];
+        assert!(!should_skip_native_watch_ring(&handled, 1_000, 1_000));
+    }
+
+    #[test]
+    fn skips_a_stale_event_even_with_no_native_tag() {
+        let handled: Vec<String> = vec![];
+        // Fired at t=0, "now" is well past the 90s staleness window.
+        assert!(should_skip_native_watch_ring(
+            &handled,
+            0,
+            STALENESS_WINDOW_MS + 1
+        ));
+    }
+
+    #[test]
+    fn is_stale_is_false_exactly_at_the_window_boundary() {
+        assert!(!is_stale(0, STALENESS_WINDOW_MS));
+    }
+
+    #[test]
+    fn is_stale_is_true_one_millisecond_past_the_window() {
+        assert!(is_stale(0, STALENESS_WINDOW_MS + 1));
+    }
+
+    #[test]
+    fn is_stale_is_false_for_an_event_fired_in_the_past_within_the_window() {
+        assert!(!is_stale(1_000, 1_000 + STALENESS_WINDOW_MS - 1));
+    }
+
+    #[test]
+    fn is_stale_does_not_panic_on_a_future_actual_fired_at() {
+        // Clock skew edge case: actual_fired_at slightly ahead of "now" must not underflow.
+        assert!(!is_stale(2_000, 1_000));
+    }
 
     #[derive(Clone, Debug)]
     #[allow(dead_code)]

--- a/plugins/wear-sync/src/lib.rs
+++ b/plugins/wear-sync/src/lib.rs
@@ -42,7 +42,10 @@ use publisher::{ChannelPublisher, PublishCommand, WearSyncPublisher};
 
 const BATCH_DEBOUNCE_MS: u64 = 500;
 
-// Per docs/architecture/255-phase3-payload-contract.md's shared constants.
+// Per docs/architecture/255-phase3-payload-contract.md's shared constants. Mirrored
+// independently (no shared source of truth across languages) by `STALENESS_WINDOW_MS` in
+// wear-sync's own Kotlin `NativeFiredListener.kt` -- if you tune this value, tune that one
+// too.
 const WATCH_RING_TAG: &str = "watch-ring";
 const STALENESS_WINDOW_MS: i64 = 90_000;
 
@@ -326,6 +329,62 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             Ok(())
         })
         .build()
+}
+
+/// Mirrors `plugins/alarm-manager/src/lib.rs`'s own `acl_tests` module (added there after
+/// issue #195, a prior silent-ACL-denial bug): asserts every webview-invoked command has a
+/// matching `allow-*` permission in `permissions/default.toml`, so a command that's wired
+/// into `generate_handler!` but not the ACL doesn't silently no-op at runtime the way #195
+/// did. wear-sync had no webview commands at all before issue #255 Phase 3B added the
+/// native fan-out developer toggle; this module exists specifically so any *future* webview
+/// command added to this plugin gets the same automated check for free.
+#[cfg(test)]
+mod acl_tests {
+    // Mirrors the command list passed to `generate_handler!` in `init()` above -- kept as a
+    // separate literal because macro invocations aren't readable at test time. If you
+    // add/remove a webview command, update both lists.
+    const WEBVIEW_COMMANDS: &[&str] = &["get_native_fan_out_enabled", "set_native_fan_out_enabled"];
+
+    const DEFAULT_TOML: &str = include_str!("../permissions/default.toml");
+
+    #[test]
+    fn every_webview_command_has_a_default_permission() {
+        for command in WEBVIEW_COMMANDS {
+            let permission = format!("allow-{}", command.replace('_', "-"));
+            assert!(
+                DEFAULT_TOML.contains(&permission),
+                "command `{command}` is webview-invokable but `permissions/default.toml` \
+                 is missing `{permission}` — it will be silently ACL-denied at runtime"
+            );
+        }
+    }
+
+    #[test]
+    fn rust_internal_commands_are_not_webview_invokable() {
+        // These `build.rs` `COMMANDS` entries are only ever reached via `run_mobile_plugin`
+        // from Rust's own code (either this plugin's own setup/listener code, or the app
+        // crate calling through `WearSyncExt`), never from the webview -- they must not
+        // reappear in `generate_handler!`/`WEBVIEW_COMMANDS`. Per
+        // `docs/plugins/command-conventions.md`, listing a Rust-internal command in
+        // `COMMANDS` doesn't need an ACL permission (that list only feeds permission *stub
+        // generation*, not the ACL check itself), so this predates issue #255 Phase 3B and
+        // isn't something this PR needs to fix -- just not regress.
+        for internal in [
+            "publish_to_watch",
+            "request_sync_from_watch",
+            "send_alarm_ring",
+            "send_alarm_dismiss",
+            "send_alarm_snooze",
+            "set_watch_message_handler",
+            "mark_watch_pipeline_ready",
+        ] {
+            assert!(
+                !WEBVIEW_COMMANDS.contains(&internal),
+                "`{internal}` is Rust-internal (via run_mobile_plugin) and must not be \
+                 exposed as a webview command"
+            );
+        }
+    }
 }
 
 /// Spawn a background task that receives publish commands from the

--- a/plugins/wear-sync/src/mobile.rs
+++ b/plugins/wear-sync/src/mobile.rs
@@ -6,8 +6,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::models::{
-    AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, PublishRequest, SyncRequest,
-    WatchMessage,
+    AlarmDismissRequest, AlarmRingRequest, AlarmSnoozeRequest, NativeFanOutEnabledResponse,
+    PublishRequest, SetNativeFanOutEnabledRequest, SyncRequest, WatchMessage,
 };
 #[cfg(target_os = "android")]
 use tauri::plugin::PluginHandle;
@@ -231,6 +231,41 @@ impl<R: Runtime> WearSync<R> {
         #[cfg(target_os = "android")]
         self.handle
             .run_mobile_plugin("markWatchPipelineReady", ())
+            .map_err(Into::into)
+    }
+
+    /// Enable or disable the native fired→watch-ring fan-out developer toggle
+    /// ([NativeFiredListener] on the Kotlin side, issue #255 Phase 3B).
+    pub fn set_native_fan_out_enabled(&self, enabled: bool) -> crate::Result<()> {
+        #[cfg(not(target_os = "android"))]
+        {
+            let _ = enabled;
+            log::debug!("wear-sync: set_native_fan_out_enabled no-op on non-Android mobile target");
+            return Ok(());
+        }
+
+        #[cfg(target_os = "android")]
+        self.handle
+            .run_mobile_plugin(
+                "setNativeFanOutEnabled",
+                SetNativeFanOutEnabledRequest { enabled },
+            )
+            .map_err(Into::into)
+    }
+
+    /// Reads the current value of the native fan-out developer toggle. Defaults to `true`
+    /// (enabled) on Android when nothing has been persisted yet; always reports `true` on
+    /// non-Android mobile targets, since there's no native fan-out to disable there.
+    pub fn get_native_fan_out_enabled(&self) -> crate::Result<NativeFanOutEnabledResponse> {
+        #[cfg(not(target_os = "android"))]
+        {
+            log::debug!("wear-sync: get_native_fan_out_enabled no-op on non-Android mobile target");
+            return Ok(NativeFanOutEnabledResponse { enabled: true });
+        }
+
+        #[cfg(target_os = "android")]
+        self.handle
+            .run_mobile_plugin("getNativeFanOutEnabled", ())
             .map_err(Into::into)
     }
 }

--- a/plugins/wear-sync/src/models.rs
+++ b/plugins/wear-sync/src/models.rs
@@ -74,9 +74,17 @@ pub struct SyncRequest {
 
 /// Watch message received from Kotlin via the JNI-backed Channel.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WatchMessage {
     pub path: String,
     pub data: String,
+    /// The `WearSyncEventQueue`/`DurableEventQueue` envelope's UUID this message was queued
+    /// under (see `WearSyncPlugin.drainQueuedMessages`, which now stamps it in alongside
+    /// `path`/`data`). `#[serde(default)]` so this deserializes cleanly from any payload that
+    /// predates this field. `None` is possible in principle (e.g. a future call site that
+    /// doesn't go through the queue) but not expected in practice today.
+    #[serde(default)]
+    pub event_id: Option<String>,
 }
 
 /// Watch-originated alarm save command.
@@ -108,6 +116,14 @@ pub struct WatchSyncRequest {
 #[serde(rename_all = "camelCase")]
 pub struct WatchDismissAlarm {
     pub alarm_id: i32,
+    /// Threaded through from `WatchMessage::event_id` by `handle_watch_message` (not parsed
+    /// from the watch's own JSON payload, which never includes it) so a same-process dedup
+    /// pass keyed on event id (issue #255 Phase 3C) has something to key on for
+    /// watch-originated dismisses too, not just the fired path. `#[serde(default)]` so this
+    /// still deserializes cleanly on its own from the watch's raw payload before the id is
+    /// attached.
+    #[serde(default)]
+    pub event_id: Option<String>,
 }
 
 /// Watch-originated alarm snooze command.
@@ -116,11 +132,19 @@ pub struct WatchDismissAlarm {
 pub struct WatchSnoozeAlarm {
     pub alarm_id: i32,
     pub snooze_length_minutes: i32,
+    /// See [WatchDismissAlarm::event_id] -- same threading, same reasoning.
+    #[serde(default)]
+    pub event_id: Option<String>,
 }
 
 // ── Phone → Watch message types (Rust → Kotlin) ─────────────────────
 
 /// Payload for the alarm:fired event (from alarm coordinator).
+///
+/// This is wear-sync's own local copy of the wire shape the app crate's
+/// `apps/threshold/src-tauri/src/alarm/events.rs::AlarmFired` broadcasts as `alarm:fired` --
+/// a separate Rust type in a separate crate, not a shared import, so it carries the same
+/// fields by convention rather than by the compiler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AlarmFired {
@@ -138,6 +162,13 @@ pub struct AlarmFired {
     /// Whether the phone time format value is explicitly known.
     #[serde(default = "default_is_24_hour_known")]
     pub is_24_hour_known: bool,
+    /// Side-effect tags already handled natively (Kotlin) for this event, per issue #255's
+    /// Phase 3 payload contract -- e.g. `["watch-ring"]` when wear-sync's own
+    /// `NativeFiredListener` (Kotlin) already rang the watch in-process before Rust ever saw
+    /// this event. `#[serde(default)]` so this deserializes cleanly from any payload that
+    /// predates this field (desktop, or a queued pre-Phase-3 event replayed after upgrade).
+    #[serde(default)]
+    pub handled_natively: Vec<String>,
 }
 
 fn default_snooze_length() -> i32 {
@@ -185,4 +216,81 @@ pub struct AlarmDismissRequest {
 pub struct AlarmSnoozeRequest {
     pub alarm_id: i32,
     pub snooze_length_minutes: i32,
+}
+
+// ── Native fan-out developer toggle (issue #255 Phase 3B) ───────────
+
+/// Request to set the "disable native watch fan-out" developer toggle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetNativeFanOutEnabledRequest {
+    pub enabled: bool,
+}
+
+/// Response from reading the "disable native watch fan-out" developer toggle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeFanOutEnabledResponse {
+    pub enabled: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── WatchMessage / WatchDismissAlarm / WatchSnoozeAlarm event_id threading ──────────
+
+    #[test]
+    fn watch_message_deserialises_event_id_from_camel_case_key() {
+        let json = r#"{"path":"/threshold/alarm_dismiss","data":"{}","eventId":"abc-123"}"#;
+        let msg: WatchMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.event_id, Some("abc-123".to_string()));
+    }
+
+    #[test]
+    fn watch_message_event_id_defaults_to_none_when_absent() {
+        // Mirrors a payload that predates this field (or any future caller that doesn't
+        // stamp one) -- must still deserialize cleanly rather than erroring.
+        let json = r#"{"path":"/threshold/sync_request","data":"0"}"#;
+        let msg: WatchMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.event_id, None);
+    }
+
+    #[test]
+    fn watch_dismiss_alarm_deserialises_from_the_watch_own_payload_with_no_event_id() {
+        // The watch's own JSON payload never includes eventId -- that's threaded in
+        // separately by handle_watch_message from the outer WatchMessage envelope.
+        let json = r#"{"alarmId":7}"#;
+        let cmd: WatchDismissAlarm = serde_json::from_str(json).unwrap();
+        assert_eq!(cmd.alarm_id, 7);
+        assert_eq!(cmd.event_id, None);
+    }
+
+    #[test]
+    fn watch_dismiss_alarm_event_id_round_trips_once_set() {
+        let mut cmd: WatchDismissAlarm = serde_json::from_str(r#"{"alarmId":7}"#).unwrap();
+        cmd.event_id = Some("queue-envelope-id".to_string());
+
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"eventId\":\"queue-envelope-id\""));
+    }
+
+    #[test]
+    fn watch_snooze_alarm_deserialises_from_the_watch_own_payload_with_no_event_id() {
+        let json = r#"{"alarmId":7,"snoozeLengthMinutes":10}"#;
+        let cmd: WatchSnoozeAlarm = serde_json::from_str(json).unwrap();
+        assert_eq!(cmd.alarm_id, 7);
+        assert_eq!(cmd.snooze_length_minutes, 10);
+        assert_eq!(cmd.event_id, None);
+    }
+
+    #[test]
+    fn watch_snooze_alarm_event_id_round_trips_once_set() {
+        let mut cmd: WatchSnoozeAlarm =
+            serde_json::from_str(r#"{"alarmId":7,"snoozeLengthMinutes":10}"#).unwrap();
+        cmd.event_id = Some("queue-envelope-id".to_string());
+
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"eventId\":\"queue-envelope-id\""));
+    }
 }

--- a/plugins/wear-sync/tsconfig.json
+++ b/plugins/wear-sync/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"skipLibCheck": true,
+		"strict": true,
+		"noUnusedLocals": true,
+		"noImplicitAny": true,
+		"noEmit": true
+	},
+	"include": ["guest-js/*.ts"],
+	"exclude": ["dist-js", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       tauri-plugin-toast-api:
         specifier: workspace:*
         version: link:../../plugins/toast
+      tauri-plugin-wear-sync-api:
+        specifier: workspace:*
+        version: link:../../plugins/wear-sync
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2
@@ -244,6 +247,25 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.9.1
+    devDependencies:
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+      rollup:
+        specifier: ^4.9.6
+        version: 4.55.1
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+
+  plugins/wear-sync:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2.0.0
+        version: 2.10.1
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^12.0.0


### PR DESCRIPTION
## What this is

Phase 3B of #255's implementation plan — wear-sync's listener side of the fired→watch-ring fan-out. This is the piece that actually closes #254: a production `ContentProvider` (`WearRingInitProvider`, always-on, not debug-gated — distinct from the earlier throwaway spike in #293) registers a native listener before any Activity/Service/BroadcastReceiver callback can run, even on a cold multi-plugin process start. When alarm-manager (#298) publishes a fired event, this listener rings the watch directly via Play Services, entirely natively, with no dependency on Rust/WebView having booted.

Built against the same frozen payload contract as #298 and #300.

## What's here

- `NativeFiredListener` — skips (no tag) if the event is stale (>90s) or the dev toggle disables fan-out; otherwise builds the ring payload from `WearSyncCache` and sends it, returning `"watch-ring"` after initiating (not confirming) the send, per #255's at-least-once design decision.
- `WearSyncPlugin.sendAlarmRing`'s payload construction and connected-nodes send loop are now shared helpers used by both the Rust-invoked path and the new native listener.
- Rust-side staleness/tag gate on wear-sync's own `alarm:fired` listener — the staleness half alone retroactively fixes the shipped "2:30 AM ghost ring" bug for events queued before this ships.
- A "Disable native watch fan-out" developer toggle, end-to-end (Kotlin command → Rust → guest-js → a Settings screen switch), as cheap insurance while dogfooding.
- `event_id` threaded through watch-originated dismiss/snooze (`WatchDismissAlarm`/`WatchSnoozeAlarm`) so those topics can also participate in the dedup mechanism #300 builds — found and fixed independently while implementing this (mirrors a bug flagged in alarm-manager's own queue dispatch).

## Testing checklist (automated, no device needed)

- [x] 48 wear-sync Rust tests (incl. 2 new ACL parity tests), `cargo clippy -D warnings` and `cargo fmt --check` clean
- [x] `pnpm -r run typecheck`, 83 frontend tests
- [x] Full Kotlin rebuild (`testDebugUnitTest`/`assembleDebug`/`assembleRelease`) — 30 tests pass; confirmed the provider is present in both debug and release merged manifests (genuinely always-on)

## Review status

Reviewed via `/code-review high`. The dominant first-pass finding ("this feature is unreachable, nothing publishes to the bus") was an expected cross-branch artifact of reviewing this worktree in isolation — resolved once combined with #298. Real fixes applied: a synchronous SharedPreferences read on the listener's hot path (now a pre-warmed in-memory cache, with the reasoning for not simply deferring it documented — deferring would have broken the toggle's synchronous gating of the returned tag); a duplicated Play Services send loop consolidated into the shared helper; a double-negative UI toggle simplified; and an ACL parity test added, mirroring alarm-manager's existing pattern from a prior silent-ACL-denial incident (#195).

Stacked on #298. Part of #255.