### PR TITLE
Carry the watch-ring tag through AlarmFired and dedup redelivered native events

### DIFF
--- a/apps/threshold/src-tauri/src/alarm/events.rs
+++ b/apps/threshold/src-tauri/src/alarm/events.rs
@@ -116,6 +116,13 @@ pub struct AlarmFired {
     /// Whether the phone time format value is explicitly known.
     #[serde(default = "default_is_24_hour_known")]
     pub is_24_hour_known: bool,
+    /// Side-effect tags a native listener already handled at publish time (e.g.
+    /// `"watch-ring"`), per issue #255's Phase 3 payload contract. `#[serde(default)]` so
+    /// this deserializes cleanly from any payload predating this field -- desktop has no
+    /// native bus at all, so its fired events simply never populate this and get an empty
+    /// `Vec` here, which is expected.
+    #[serde(default)]
+    pub handled_natively: Vec<String>,
 }
 
 fn default_snooze_length() -> i32 {
@@ -202,4 +209,48 @@ pub enum SyncReason {
     Initialize,    // App startup
     Reconnect,     // Watch reconnected
     ForceSync,     // User requested
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alarm_fired_defaults_handled_natively_when_absent() {
+        // Shape predating issue #255's Phase 3 -- no `handledNatively` key at all, the
+        // exact case desktop (no native bus) and any pre-upgrade queued event hit.
+        let json = r#"{
+            "id": 7,
+            "triggerAt": 1000,
+            "actualFiredAt": 1005,
+            "label": "Wake up",
+            "revision": 3
+        }"#;
+
+        let event: AlarmFired =
+            serde_json::from_str(json).expect("old-shape payload should deserialize");
+
+        assert!(event.handled_natively.is_empty());
+        // The other pre-existing `#[serde(default = ...)]` fields should still fall back too.
+        assert_eq!(event.snooze_length_minutes, 10);
+        assert!(!event.is_24_hour);
+        assert!(!event.is_24_hour_known);
+    }
+
+    #[test]
+    fn alarm_fired_round_trips_handled_natively_when_present() {
+        let json = r#"{
+            "id": 7,
+            "triggerAt": 1000,
+            "actualFiredAt": 1005,
+            "label": "Wake up",
+            "revision": 3,
+            "handledNatively": ["watch-ring"]
+        }"#;
+
+        let event: AlarmFired =
+            serde_json::from_str(json).expect("new-shape payload should deserialize");
+
+        assert_eq!(event.handled_natively, vec!["watch-ring".to_string()]);
+    }
 }

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -281,11 +281,15 @@ impl AlarmCoordinator {
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
     /// - `actual_fired_at`: wall-clock firing time in epoch milliseconds.
+    /// - `handled_natively`: side-effect tags a native listener already handled at publish
+    ///   time (e.g. `"watch-ring"`), per issue #255's Phase 3 payload contract. Always
+    ///   empty on desktop, which has no native bus.
     pub async fn report_alarm_fired<R: Runtime>(
         &self,
         app: &AppHandle<R>,
         id: i32,
         actual_fired_at: i64,
+        handled_natively: Vec<String>,
     ) -> Result<()> {
         use std::sync::atomic::Ordering;
 
@@ -316,6 +320,7 @@ impl AlarmCoordinator {
             snooze_length_minutes: snooze,
             is_24_hour,
             is_24_hour_known,
+            handled_natively,
         };
         app.emit("alarm:fired", &event)?;
 

--- a/apps/threshold/src-tauri/src/commands.rs
+++ b/apps/threshold/src-tauri/src/commands.rs
@@ -141,6 +141,11 @@ pub async fn snooze_alarm<R: Runtime>(
 /// - `coordinator`: alarm coordinator state.
 /// - `id`: alarm identifier.
 /// - `actual_fired_at`: wall-clock firing time in epoch milliseconds.
+///
+/// This is the TS-invoked path (desktop's tokio-timer firing, or any frontend-driven
+/// report). Desktop has no native bus, so there are no `handledNatively` tags to pass
+/// through -- always an empty `Vec` here, matching `AlarmFired::handled_natively`'s
+/// `#[serde(default)]` fallback.
 pub async fn report_alarm_fired<R: Runtime>(
     app: AppHandle<R>,
     coordinator: State<'_, AlarmCoordinator>,
@@ -148,7 +153,7 @@ pub async fn report_alarm_fired<R: Runtime>(
     actual_fired_at: i64,
 ) -> Result<(), String> {
     coordinator
-        .report_alarm_fired(&app, id, actual_fired_at)
+        .report_alarm_fired(&app, id, actual_fired_at, Vec::new())
         .await
         .map_err(|e| e.to_string())
 }
@@ -199,6 +204,10 @@ pub async fn test_watch_ring<R: Runtime>(app: AppHandle<R>) -> Result<(), String
             .try_state::<TimeFormatKnownState>()
             .map(|s| s.load(Ordering::Relaxed))
             .unwrap_or(false),
+        // Deliberately empty: this command exists to exercise wear-sync's own
+        // `send_alarm_ring` path from the frontend, so it must not carry the
+        // `"watch-ring"` tag that would tell that listener to skip the ring.
+        handled_natively: Vec::new(),
     };
     app.emit("alarm:fired", &event).map_err(|e| e.to_string())
 }

--- a/apps/threshold/src-tauri/src/event_dedup.rs
+++ b/apps/threshold/src-tauri/src/event_dedup.rs
@@ -6,9 +6,9 @@
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
-/// Capacity of the recent-eventId ring buffer -- sized comfortably above the number of
-/// events that could plausibly be redelivered from a single crash-window replay (see
-/// `EventDedup`'s own docs for the failure mode this guards against).
+/// Capacity of the recent-eventId ring buffer -- comfortably above the number of events
+/// that could plausibly repeat within one running process's lifetime (see `EventDedup`'s
+/// own docs for exactly what that covers, and what it doesn't).
 const CAPACITY: usize = 32;
 
 /// A small, shared, last-N `eventId` dedup buffer for the six native event listeners
@@ -16,15 +16,30 @@ const CAPACITY: usize = 32;
 /// `alarm-manager:native-fired`, `alarm-manager:dismiss-requested`,
 /// `alarm-manager:snooze-requested`, `alarm-manager:import-requested`).
 ///
-/// Stage 2's `DurableEventQueue` drain (see `drainAndDispatch` in
+/// **What this catches:** redelivery of the same `eventId` to the *same running process*
+/// -- e.g. two overlapping drain calls racing each other, or any other in-process path
+/// that could hand the same envelope to a listener twice before either drops it as
+/// stale. Without this, a redelivered event re-runs whatever UI/toast paths listen for
+/// these Tauri events app-wide (e.g. a second dismiss/snooze toast for the same action),
+/// and for `wear:alarm:snooze` specifically, a second run recomputes
+/// `snoozed_until = now + minutes` and silently re-anchors the alarm to a later time --
+/// not just a cosmetic double toast.
+///
+/// **What this does NOT catch (known limitation, tracked under issue #255 for a
+/// follow-up):** the buffer lives only in memory, created empty on every launch via
+/// `app.manage()`. Stage 2's `DurableEventQueue` drain (see `drainAndDispatch` in
 /// `plugins/alarm-manager/android/.../AlarmManagerPlugin.kt`, not part of this crate)
-/// commits successfully-delivered entries only *after* Channel delivery succeeds -- a
+/// commits a successfully-delivered entry only *after* Channel delivery succeeds -- a
 /// deliberate design decision, already reviewed -- so a crash in the narrow window
-/// between a successful delivery and the trailing commit can redeliver the same event
-/// on the next drain. The `"watch-ring"` tag in `AlarmFired::handled_natively` already
-/// prevents a double watch *ring* for the fired case specifically, but without this
-/// buffer a redelivered event would still re-run whatever UI/toast paths listen for
-/// these Tauri events app-wide (e.g. a second dismiss/snooze toast for the same action).
+/// between that successful delivery and the trailing commit can redeliver the same
+/// event on the *next launch*. But that crash necessarily takes down the very process
+/// holding this buffer, so the redelivered event lands in a brand-new, empty
+/// `EventDedup` that has never seen its `eventId` -- structurally unable to catch its
+/// own crash-and-restart case. The `"watch-ring"` tag in `AlarmFired::handled_natively`
+/// is what actually prevents a double watch *ring* across a restart; closing the
+/// broader gap would mean persisting dedup state (e.g. a small SQLite table via this
+/// app's existing `tauri-plugin-sql` migrations, the way `AlarmCoordinator` already owns
+/// durable state) rather than an in-memory buffer -- deliberately not built here.
 ///
 /// Events with no `eventId` (payloads predating this change, or any source that doesn't
 /// carry one yet) always report as "not a duplicate" -- there is nothing to key a dedup

--- a/apps/threshold/src-tauri/src/event_dedup.rs
+++ b/apps/threshold/src-tauri/src/event_dedup.rs
@@ -6,10 +6,29 @@
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
-/// Capacity of the recent-eventId ring buffer -- comfortably above the number of events
-/// that could plausibly repeat within one running process's lifetime (see `EventDedup`'s
-/// own docs for exactly what that covers, and what it doesn't).
-const CAPACITY: usize = 32;
+/// Capacity of the recent-eventId ring buffer.
+///
+/// This is deliberately generous rather than "just enough for the common case": a PR #300
+/// review noted that `WearSyncPlugin.drainQueuedMessages()` (Kotlin, `plugins/wear-sync/
+/// android/.../WearSyncPlugin.kt`) has no lock around its own peek-then-deliver-then-commit
+/// sequence, so two overlapping calls to it (e.g. a watch message arriving mid-drain, or
+/// `setWatchMessageHandler`/`markWatchPipelineReady` racing an in-flight `onWatchMessage`
+/// drain) can both peek the same not-yet-committed batch and each redeliver every message
+/// in it to Rust before either commits. When that happens, a buffer sized to "the common
+/// case" risks the earliest entries in a large-enough batch being evicted before their
+/// duplicate copy arrives from the second drain, which would be accepted as a fresh
+/// "first occurrence" -- the exact failure this buffer exists to prevent.
+///
+/// Raising this number is only a mitigation, not the fix: it raises the size of backlog
+/// needed to lose the race, it doesn't remove the race. The real fix belongs in
+/// `drainQueuedMessages()` itself -- serializing its peek+deliver+commit sequence (e.g.
+/// `@Synchronized`, mirroring `NativeEventLog`'s existing use of the same annotation in that
+/// module) so a second overlapping call can't observe the same uncommitted batch the first
+/// one is still delivering, the same "peek-then-deliver-then-commit-only-what-succeeded"
+/// principle already applied one layer down in `WearSyncEventQueue`/`DurableEventQueue`.
+/// That change is Kotlin-side and out of scope for this crate; this constant is kept large
+/// so this buffer stays a meaningful backstop in the meantime.
+const CAPACITY: usize = 256;
 
 /// A small, shared, last-N `eventId` dedup buffer for the six native event listeners
 /// wired up in `lib.rs` (`wear:alarm:dismiss`, `wear:alarm:snooze`,
@@ -132,6 +151,30 @@ mod tests {
         assert!(!dedup.is_duplicate(Some("0")));
         // The most recently seen id from the initial fill hasn't been evicted yet.
         assert!(dedup.is_duplicate(Some(&(CAPACITY - 1).to_string())));
+    }
+
+    /// Regression test for the PR #300 review scenario: two overlapping
+    /// `WearSyncPlugin.drainQueuedMessages()` calls (Kotlin, out of scope for this crate)
+    /// can each peek the same not-yet-committed batch and redeliver every message in it.
+    /// As long as the redelivered batch is no larger than `CAPACITY`, the second copy of
+    /// every id is still caught as a duplicate even when other distinct ids are woven in
+    /// between the two copies -- simulating the two drains' deliveries interleaving on
+    /// their way to Rust rather than arriving back-to-back.
+    #[test]
+    fn interleaved_redelivery_of_a_large_overlapping_batch_is_still_caught() {
+        let dedup = EventDedup::new();
+        let batch: Vec<String> = (0..CAPACITY).map(|i| format!("batch-{i}")).collect();
+
+        // First "drain" delivers the whole batch.
+        for id in &batch {
+            assert!(!dedup.is_duplicate(Some(id)));
+        }
+        // Second "drain" (which raced the first and peeked the same uncommitted batch)
+        // redelivers every id in the same order -- each one must still read as a
+        // duplicate, since the batch didn't exceed CAPACITY.
+        for id in &batch {
+            assert!(dedup.is_duplicate(Some(id)));
+        }
     }
 
     #[test]

--- a/apps/threshold/src-tauri/src/event_dedup.rs
+++ b/apps/threshold/src-tauri/src/event_dedup.rs
@@ -1,0 +1,130 @@
+// Bounded recent-eventId dedup shared across the native event listeners in lib.rs
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+/// Capacity of the recent-eventId ring buffer -- sized comfortably above the number of
+/// events that could plausibly be redelivered from a single crash-window replay (see
+/// `EventDedup`'s own docs for the failure mode this guards against).
+const CAPACITY: usize = 32;
+
+/// A small, shared, last-N `eventId` dedup buffer for the six native event listeners
+/// wired up in `lib.rs` (`wear:alarm:dismiss`, `wear:alarm:snooze`,
+/// `alarm-manager:native-fired`, `alarm-manager:dismiss-requested`,
+/// `alarm-manager:snooze-requested`, `alarm-manager:import-requested`).
+///
+/// Stage 2's `DurableEventQueue` drain (see `drainAndDispatch` in
+/// `plugins/alarm-manager/android/.../AlarmManagerPlugin.kt`, not part of this crate)
+/// commits successfully-delivered entries only *after* Channel delivery succeeds -- a
+/// deliberate design decision, already reviewed -- so a crash in the narrow window
+/// between a successful delivery and the trailing commit can redeliver the same event
+/// on the next drain. The `"watch-ring"` tag in `AlarmFired::handled_natively` already
+/// prevents a double watch *ring* for the fired case specifically, but without this
+/// buffer a redelivered event would still re-run whatever UI/toast paths listen for
+/// these Tauri events app-wide (e.g. a second dismiss/snooze toast for the same action).
+///
+/// Events with no `eventId` (payloads predating this change, or any source that doesn't
+/// carry one yet) always report as "not a duplicate" -- there is nothing to key a dedup
+/// check on, so they are let through rather than dropped or misclassified.
+pub struct EventDedup {
+    recent: Mutex<VecDeque<String>>,
+}
+
+impl EventDedup {
+    /// Creates an empty dedup buffer.
+    pub fn new() -> Self {
+        Self {
+            recent: Mutex::new(VecDeque::with_capacity(CAPACITY)),
+        }
+    }
+
+    /// Checks whether `event_id` has already been seen and records it if not.
+    ///
+    /// Returns `true` when this is a duplicate (already seen within the buffer's
+    /// window, so the caller should treat it as a no-op) and `false` otherwise --
+    /// including whenever `event_id` is `None`, which is never treated as a duplicate
+    /// of anything.
+    pub fn is_duplicate(&self, event_id: Option<&str>) -> bool {
+        let Some(event_id) = event_id else {
+            return false;
+        };
+
+        // A poisoned lock (a panic while held elsewhere) shouldn't take dedup down with
+        // it -- recover the inner buffer and carry on, same as `AlarmCoordinator`'s own
+        // approach to non-critical shared state elsewhere in this crate.
+        let mut recent = self
+            .recent
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if recent.iter().any(|seen| seen == event_id) {
+            return true;
+        }
+
+        if recent.len() >= CAPACITY {
+            recent.pop_front();
+        }
+        recent.push_back(event_id.to_string());
+        false
+    }
+}
+
+impl Default for EventDedup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_occurrence_is_not_a_duplicate() {
+        let dedup = EventDedup::new();
+        assert!(!dedup.is_duplicate(Some("a")));
+    }
+
+    #[test]
+    fn second_occurrence_of_the_same_id_is_a_duplicate() {
+        let dedup = EventDedup::new();
+        assert!(!dedup.is_duplicate(Some("a")));
+        assert!(dedup.is_duplicate(Some("a")));
+    }
+
+    #[test]
+    fn distinct_ids_are_each_seen_as_new() {
+        let dedup = EventDedup::new();
+        assert!(!dedup.is_duplicate(Some("a")));
+        assert!(!dedup.is_duplicate(Some("b")));
+        assert!(dedup.is_duplicate(Some("a")));
+        assert!(dedup.is_duplicate(Some("b")));
+    }
+
+    #[test]
+    fn buffer_evicts_oldest_entry_past_capacity() {
+        let dedup = EventDedup::new();
+        for i in 0..CAPACITY {
+            assert!(!dedup.is_duplicate(Some(&i.to_string())));
+        }
+        // Buffer is now exactly full (ids "0".."CAPACITY - 1"). One more distinct id
+        // pushes out the oldest entry ("0").
+        assert!(!dedup.is_duplicate(Some("overflow")));
+        // "0" was evicted, so it's treated as new again rather than a duplicate.
+        assert!(!dedup.is_duplicate(Some("0")));
+        // The most recently seen id from the initial fill hasn't been evicted yet.
+        assert!(dedup.is_duplicate(Some(&(CAPACITY - 1).to_string())));
+    }
+
+    #[test]
+    fn missing_event_id_is_never_a_duplicate() {
+        let dedup = EventDedup::new();
+        assert!(!dedup.is_duplicate(None));
+        assert!(!dedup.is_duplicate(None));
+        // Doesn't pollute the buffer either -- a real id afterwards is still fresh.
+        assert!(!dedup.is_duplicate(Some("a")));
+    }
+}

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -78,7 +78,24 @@ fn configure_linux_env() {
     );
 }
 
+mod event_dedup;
 mod event_logs;
+
+use event_dedup::EventDedup;
+
+/// Looks up the shared `EventDedup` state and checks `event_id` against it -- the
+/// shared last-N dedup used by every native event listener below. Missing state
+/// (shouldn't happen once `run()`'s `setup` has completed) is treated as "not a
+/// duplicate" so a listener degrades gracefully rather than silently dropping events.
+fn is_duplicate_native_event<R: tauri::Runtime>(
+    handle: &tauri::AppHandle<R>,
+    event_id: Option<&str>,
+) -> bool {
+    handle
+        .try_state::<EventDedup>()
+        .map(|dedup| dedup.is_duplicate(event_id))
+        .unwrap_or(false)
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -207,6 +224,10 @@ pub fn run() {
             }).ok();
 
             app.manage(coordinator);
+
+            // Shared last-N eventId dedup for the six native event listeners below --
+            // see `EventDedup`'s docs for the crash-window redelivery it guards against.
+            app.manage(EventDedup::new());
 
             #[cfg(mobile)]
             app.manage(ImportLock(tokio::sync::Mutex::new(())));
@@ -397,11 +418,20 @@ pub fn run() {
             app.handle().listen("wear:alarm:dismiss", move |event| {
                 #[derive(serde::Deserialize)]
                 #[serde(rename_all = "camelCase")]
-                struct WatchDismiss { alarm_id: i32 }
+                struct WatchDismiss {
+                    alarm_id: i32,
+                    #[serde(default)]
+                    event_id: Option<String>,
+                }
 
                 if let Ok(cmd) = serde_json::from_str::<WatchDismiss>(event.payload()) {
                     let handle = dismiss_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, cmd.event_id.as_deref()) {
+                            log::info!("watch: skipping redelivered dismiss for alarm {}", cmd.alarm_id);
+                            return;
+                        }
+
                         // Stop the phone's ringing service first
                         #[cfg(mobile)]
                         if let Err(e) = handle.alarm_manager().stop_ringing() {
@@ -423,11 +453,21 @@ pub fn run() {
             app.handle().listen("wear:alarm:snooze", move |event| {
                 #[derive(serde::Deserialize)]
                 #[serde(rename_all = "camelCase")]
-                struct WatchSnooze { alarm_id: i32, snooze_length_minutes: i64 }
+                struct WatchSnooze {
+                    alarm_id: i32,
+                    snooze_length_minutes: i64,
+                    #[serde(default)]
+                    event_id: Option<String>,
+                }
 
                 if let Ok(cmd) = serde_json::from_str::<WatchSnooze>(event.payload()) {
                     let handle = snooze_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, cmd.event_id.as_deref()) {
+                            log::info!("watch: skipping redelivered snooze for alarm {}", cmd.alarm_id);
+                            return;
+                        }
+
                         // Stop the phone's ringing service first
                         #[cfg(mobile)]
                         if let Err(e) = handle.alarm_manager().stop_ringing() {
@@ -457,14 +497,35 @@ pub fn run() {
                 struct NativeAlarmFired {
                     id: i32,
                     actual_fired_at: i64,
+                    // Both fields land here once alarm-manager's `NativeAlarmFiredPayload`
+                    // (Phase 3A, a sibling branch) gains them per issue #255's Phase 3
+                    // payload contract. `#[serde(default)]` keeps this listener working
+                    // against today's shorter payload in the meantime.
+                    #[serde(default)]
+                    event_id: Option<String>,
+                    #[serde(default)]
+                    handled_natively: Vec<String>,
                 }
 
                 if let Ok(payload) = serde_json::from_str::<NativeAlarmFired>(event.payload()) {
                     let handle = native_alarm_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
+                            log::info!(
+                                "alarm-manager: skipping redelivered native fired for alarm {}",
+                                payload.id
+                            );
+                            return;
+                        }
+
                         if let Some(coord) = handle.try_state::<AlarmCoordinator>() {
                             if let Err(error) = coord
-                                .report_alarm_fired(&handle, payload.id, payload.actual_fired_at)
+                                .report_alarm_fired(
+                                    &handle,
+                                    payload.id,
+                                    payload.actual_fired_at,
+                                    payload.handled_natively,
+                                )
                                 .await
                             {
                                 log::error!(
@@ -484,13 +545,27 @@ pub fn run() {
             let native_dismiss_handle = app.handle().clone();
             app.handle().listen("alarm-manager:dismiss-requested", move |event| {
                 #[derive(serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
                 struct NativeDismissRequested {
                     id: i32,
+                    // Not yet stamped by alarm-manager for this topic as of Stage 2 --
+                    // `#[serde(default)]` so an absent value bypasses dedup entirely
+                    // rather than being treated as a duplicate of anything.
+                    #[serde(default)]
+                    event_id: Option<String>,
                 }
 
                 if let Ok(payload) = serde_json::from_str::<NativeDismissRequested>(event.payload()) {
                     let handle = native_dismiss_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
+                            log::info!(
+                                "alarm-manager: skipping redelivered dismiss-requested for alarm {}",
+                                payload.id
+                            );
+                            return;
+                        }
+
                         if let Some(coord) = handle.try_state::<AlarmCoordinator>() {
                             if let Err(error) = coord.dismiss_alarm(&handle, payload.id).await {
                                 log::error!(
@@ -510,13 +585,27 @@ pub fn run() {
             let native_snooze_handle = app.handle().clone();
             app.handle().listen("alarm-manager:snooze-requested", move |event| {
                 #[derive(serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
                 struct NativeSnoozeRequested {
                     id: i32,
+                    // Not yet stamped by alarm-manager for this topic as of Stage 2 --
+                    // `#[serde(default)]` so an absent value bypasses dedup entirely
+                    // rather than being treated as a duplicate of anything.
+                    #[serde(default)]
+                    event_id: Option<String>,
                 }
 
                 if let Ok(payload) = serde_json::from_str::<NativeSnoozeRequested>(event.payload()) {
                     let handle = native_snooze_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
+                            log::info!(
+                                "alarm-manager: skipping redelivered snooze-requested for alarm {}",
+                                payload.id
+                            );
+                            return;
+                        }
+
                         let minutes = handle
                             .try_state::<SnoozeLengthState>()
                             .map(|s| s.load(std::sync::atomic::Ordering::Relaxed))
@@ -560,11 +649,24 @@ pub fn run() {
                     label: String,
                     active_days: Vec<i32>,
                     trigger_at: i64,
+                    // Not yet stamped by alarm-manager for this topic as of Stage 2 --
+                    // `#[serde(default)]` so an absent value bypasses dedup entirely
+                    // rather than being treated as a duplicate of anything.
+                    #[serde(default)]
+                    event_id: Option<String>,
                 }
 
                 if let Ok(payload) = serde_json::from_str::<ImportRequested>(event.payload()) {
                     let handle = import_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
+                            log::info!(
+                                "alarm-manager: skipping redelivered import-requested for native alarm {}",
+                                payload.id
+                            );
+                            return;
+                        }
+
                         // Always tear down the temporary native alarm SetAlarmActivity
                         // created -- safe even if it already fired, and needs to happen
                         // regardless of whether this import turns into a real Threshold

--- a/apps/threshold/src-tauri/src/lib.rs
+++ b/apps/threshold/src-tauri/src/lib.rs
@@ -83,18 +83,32 @@ mod event_logs;
 
 use event_dedup::EventDedup;
 
-/// Looks up the shared `EventDedup` state and checks `event_id` against it -- the
-/// shared last-N dedup used by every native event listener below. Missing state
-/// (shouldn't happen once `run()`'s `setup` has completed) is treated as "not a
-/// duplicate" so a listener degrades gracefully rather than silently dropping events.
-fn is_duplicate_native_event<R: tauri::Runtime>(
+/// Checks the incoming event's `event_id` against the shared `EventDedup` state (see its
+/// docs for exactly what redelivery scenario this catches -- and the known limitation it
+/// doesn't) and logs a one-line skip notice when it's a duplicate. Shared by all six
+/// native event listeners in `run()`'s `setup` below, which otherwise differ only in the
+/// `source`/`topic` labels and the alarm `id` used in that log line -- each call site
+/// collapses to `if skip_duplicate_native_event(&handle, event_id, "watch", "dismiss", id) { return; }`.
+///
+/// Missing `EventDedup` state (shouldn't happen once `setup` has completed) is treated as
+/// "not a duplicate" so a listener degrades gracefully rather than silently dropping
+/// events.
+fn skip_duplicate_native_event<R: tauri::Runtime>(
     handle: &tauri::AppHandle<R>,
     event_id: Option<&str>,
+    source: &str,
+    topic: &str,
+    id: i32,
 ) -> bool {
-    handle
+    let is_duplicate = handle
         .try_state::<EventDedup>()
         .map(|dedup| dedup.is_duplicate(event_id))
-        .unwrap_or(false)
+        .unwrap_or(false);
+
+    if is_duplicate {
+        log::info!("{source}: skipping redelivered {topic} for alarm {id}");
+    }
+    is_duplicate
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -427,8 +441,7 @@ pub fn run() {
                 if let Ok(cmd) = serde_json::from_str::<WatchDismiss>(event.payload()) {
                     let handle = dismiss_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, cmd.event_id.as_deref()) {
-                            log::info!("watch: skipping redelivered dismiss for alarm {}", cmd.alarm_id);
+                        if skip_duplicate_native_event(&handle, cmd.event_id.as_deref(), "watch", "dismiss", cmd.alarm_id) {
                             return;
                         }
 
@@ -463,8 +476,7 @@ pub fn run() {
                 if let Ok(cmd) = serde_json::from_str::<WatchSnooze>(event.payload()) {
                     let handle = snooze_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, cmd.event_id.as_deref()) {
-                            log::info!("watch: skipping redelivered snooze for alarm {}", cmd.alarm_id);
+                        if skip_duplicate_native_event(&handle, cmd.event_id.as_deref(), "watch", "snooze", cmd.alarm_id) {
                             return;
                         }
 
@@ -510,11 +522,7 @@ pub fn run() {
                 if let Ok(payload) = serde_json::from_str::<NativeAlarmFired>(event.payload()) {
                     let handle = native_alarm_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
-                            log::info!(
-                                "alarm-manager: skipping redelivered native fired for alarm {}",
-                                payload.id
-                            );
+                        if skip_duplicate_native_event(&handle, payload.event_id.as_deref(), "alarm-manager", "native fired", payload.id) {
                             return;
                         }
 
@@ -558,11 +566,7 @@ pub fn run() {
                 if let Ok(payload) = serde_json::from_str::<NativeDismissRequested>(event.payload()) {
                     let handle = native_dismiss_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
-                            log::info!(
-                                "alarm-manager: skipping redelivered dismiss-requested for alarm {}",
-                                payload.id
-                            );
+                        if skip_duplicate_native_event(&handle, payload.event_id.as_deref(), "alarm-manager", "dismiss-requested", payload.id) {
                             return;
                         }
 
@@ -598,11 +602,7 @@ pub fn run() {
                 if let Ok(payload) = serde_json::from_str::<NativeSnoozeRequested>(event.payload()) {
                     let handle = native_snooze_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
-                            log::info!(
-                                "alarm-manager: skipping redelivered snooze-requested for alarm {}",
-                                payload.id
-                            );
+                        if skip_duplicate_native_event(&handle, payload.event_id.as_deref(), "alarm-manager", "snooze-requested", payload.id) {
                             return;
                         }
 
@@ -659,11 +659,7 @@ pub fn run() {
                 if let Ok(payload) = serde_json::from_str::<ImportRequested>(event.payload()) {
                     let handle = import_handle.clone();
                     tauri::async_runtime::spawn(async move {
-                        if is_duplicate_native_event(&handle, payload.event_id.as_deref()) {
-                            log::info!(
-                                "alarm-manager: skipping redelivered import-requested for native alarm {}",
-                                payload.id
-                            );
+                        if skip_duplicate_native_event(&handle, payload.event_id.as_deref(), "alarm-manager", "import-requested", payload.id) {
                             return;
                         }
 


### PR DESCRIPTION
## What this is

Phase 3C of #255's implementation plan — the app-level Rust core plumbing for the fired→watch-ring fan-out. Completes #298's and #299's work: the shared `AlarmFired` event struct that carries the native fan-out's tags app-wide, plus a crash-window dedup so a redelivered queue entry doesn't double-fire UI/toast paths even though the watch-ring tag already prevents a double ring.

Built against the same frozen payload contract as #298 and #299.

## What's here

- `AlarmFired` (the struct actually broadcast app-wide as `alarm:fired`, confirmed during planning — not the plugin-local Channel-deserialization struct) gains `handled_natively: Vec<String>`, `#[serde(default)]` for backward compatibility (desktop has no native bus and simply never populates this).
- `EventDedup`, a last-N (32-entry) eventId ring buffer shared across the six native-event listeners, so a crash-window redelivery doesn't double-process the same event. Its doc comments are explicit about what it does and doesn't protect against (see review notes).
- Six previously-duplicated check-and-skip blocks collapsed into one helper.

## Testing checklist (automated, no device needed)

- [x] `cargo check --workspace` / `cargo test --workspace` — 55 threshold tests + full workspace suite, all green, confirmed again after combining with #298/#299
- [x] `cargo clippy`/`cargo fmt --check` clean (two pre-existing, unrelated clippy failures on `main` in `app-management`/`wear-sync::batch_collector` were confirmed pre-existing, not introduced by this stack)
- [x] Verified the wire format: wear-sync's own local `AlarmFired` copy (#299) and this PR's canonical `AlarmFired` agree exactly on field names and serde attributes

## Review status

Reviewed via `/code-review high`. The most important finding: `EventDedup` is in-memory and gets wiped by the exact same crash that causes the redelivery it's meant to catch, so it can't actually protect against the crash-and-restart case despite the original doc comment implying it could. Doc comments corrected to be accurate about the real (narrower) scope — same-process redelivery only — and a follow-up issue will be filed for persisting dedup state via this app's existing `tauri-plugin-sql` migrations, matching how `AlarmCoordinator` already owns durable state. Not fixed in this PR; the residual risk is bounded (a rare duplicate toast, or in the snooze case a re-anchored `snoozed_until`) and out of scope for #255's core deliverable.

Stacked on #299. Part of #255. Last PR before Stage 4.