### PR TITLE
Close the in-app dismiss gap and propagate stop signals natively

### DIFF
--- a/apps/threshold/src/screens/Ringing.test.tsx
+++ b/apps/threshold/src/screens/Ringing.test.tsx
@@ -175,7 +175,9 @@ describe('Ringing Screen Logic', () => {
 
 		// Assert
 		await waitFor(() => {
-			expect(alarmManagerService.stopRinging).toHaveBeenCalled();
+			// Threads the real alarm id through (issue #255 Phase 4A) so the native dismiss
+			// event carries one, closing the "in-app dismiss produces no native event" gap.
+			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(1);
 			expect(mockWindow.close).toHaveBeenCalled();
 		});
 		expect(mockWindow.minimize).not.toHaveBeenCalled();
@@ -194,7 +196,7 @@ describe('Ringing Screen Logic', () => {
 
 		// Assert
 		await waitFor(() => {
-			expect(alarmManagerService.stopRinging).toHaveBeenCalled();
+			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(1);
 			expect(appManagementService.minimizeApp).toHaveBeenCalled();
 		});
 		expect(mockWindow.close).not.toHaveBeenCalled();
@@ -223,7 +225,7 @@ describe('Ringing Screen Logic', () => {
 
 		// Assert
 		await waitFor(() => {
-			expect(alarmManagerService.stopRinging).toHaveBeenCalled();
+			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(SPECIAL_ALARM_IDS.TEST_ALARM);
 			expect(historySpy).toHaveBeenCalled();
 		});
 		expect(mockWindow.minimize).not.toHaveBeenCalled();

--- a/apps/threshold/src/screens/Ringing.test.tsx
+++ b/apps/threshold/src/screens/Ringing.test.tsx
@@ -225,10 +225,32 @@ describe('Ringing Screen Logic', () => {
 
 		// Assert
 		await waitFor(() => {
-			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(SPECIAL_ALARM_IDS.TEST_ALARM);
+			// No id for the Test Alarm sentinel -- see the dedicated test below for why.
+			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(undefined);
 			expect(historySpy).toHaveBeenCalled();
 		});
 		expect(mockWindow.minimize).not.toHaveBeenCalled();
+	});
+
+	it('does not thread the Test Alarm sentinel id into the native stopRinging publish', async () => {
+		// The Test Alarm (999) used for in-app sound preview isn't a real DB-backed alarm --
+		// publishing a real native dismiss event for it would durably enqueue and drain an
+		// alarm-manager:dismiss-requested event Rust's dismiss listener can never resolve
+		// (get_by_id(999) always fails), logging noise on every sound preview. Sound preview
+		// must stay a pure local stop, matching its behaviour before alarm ids were threaded
+		// through stopRinging (issue #255 Phase 4A).
+		const router = await import('@tanstack/react-router');
+		(router.useParams as any).mockReturnValue({ id: String(SPECIAL_ALARM_IDS.TEST_ALARM) });
+
+		renderWithTheme(<Ringing />);
+
+		const stopBtn = await screen.findByRole('button', { name: /stop alarm/i });
+		fireEvent.click(stopBtn);
+
+		await waitFor(() => {
+			expect(alarmManagerService.stopRinging).toHaveBeenCalled();
+		});
+		expect(alarmManagerService.stopRinging).not.toHaveBeenCalledWith(SPECIAL_ALARM_IDS.TEST_ALARM);
 	});
 
 	it('should snooze and close window on desktop', async () => {

--- a/apps/threshold/src/screens/Ringing.test.tsx
+++ b/apps/threshold/src/screens/Ringing.test.tsx
@@ -175,8 +175,7 @@ describe('Ringing Screen Logic', () => {
 
 		// Assert
 		await waitFor(() => {
-			// Threads the real alarm id through (issue #255 Phase 4A) so the native dismiss
-			// event carries one, closing the "in-app dismiss produces no native event" gap.
+			// Threads the real alarm id through (issue #255 Phase 4A) so the native dismiss event carries one, closing the "in-app dismiss produces no native event" gap.
 			expect(alarmManagerService.stopRinging).toHaveBeenCalledWith(1);
 			expect(mockWindow.close).toHaveBeenCalled();
 		});
@@ -233,12 +232,7 @@ describe('Ringing Screen Logic', () => {
 	});
 
 	it('does not thread the Test Alarm sentinel id into the native stopRinging publish', async () => {
-		// The Test Alarm (999) used for in-app sound preview isn't a real DB-backed alarm --
-		// publishing a real native dismiss event for it would durably enqueue and drain an
-		// alarm-manager:dismiss-requested event Rust's dismiss listener can never resolve
-		// (get_by_id(999) always fails), logging noise on every sound preview. Sound preview
-		// must stay a pure local stop, matching its behaviour before alarm ids were threaded
-		// through stopRinging (issue #255 Phase 4A).
+		// The Test Alarm (999) used for in-app sound preview isn't a real DB-backed alarm -- publishing a real native dismiss event for it would durably enqueue and drain an alarm-manager:dismiss-requested event Rust's dismiss listener can never resolve (get_by_id(999) always fails), logging noise on every sound preview. Sound preview must stay a pure local stop, matching its behaviour before alarm ids were threaded through stopRinging (issue #255 Phase 4A).
 		const router = await import('@tanstack/react-router');
 		(router.useParams as any).mockReturnValue({ id: String(SPECIAL_ALARM_IDS.TEST_ALARM) });
 

--- a/apps/threshold/src/screens/Ringing.tsx
+++ b/apps/threshold/src/screens/Ringing.tsx
@@ -175,7 +175,10 @@ const Ringing: React.FC = () => {
 
 	const handleDismiss = useCallback(async () => {
 		console.log('[Ringing] Dismissing Alarm', alarmId);
-		await alarmManagerService.stopRinging();
+		// Thread the real alarm id through so the native dismiss event (and, in turn, the
+		// NativeEventBus fan-out that tells the watch to stop) carries it -- see
+		// AlarmManagerService.stopRinging's doc comment (issue #255 Phase 4A).
+		await alarmManagerService.stopRinging(alarmId);
 
 		// Notify backend to dismiss (reschedule)
 		try {

--- a/apps/threshold/src/screens/Ringing.tsx
+++ b/apps/threshold/src/screens/Ringing.tsx
@@ -175,15 +175,7 @@ const Ringing: React.FC = () => {
 
 	const handleDismiss = useCallback(async () => {
 		console.log('[Ringing] Dismissing Alarm', alarmId);
-		// Thread the real alarm id through so the native dismiss event (and, in turn, the
-		// NativeEventBus fan-out that tells the watch to stop) carries it -- see
-		// AlarmManagerService.stopRinging's doc comment (issue #255 Phase 4A). Except for the
-		// Test Alarm sentinel (same special-case as closeRingingWindow below): it isn't a real
-		// DB-backed alarm, so publishing a real native dismiss event for it would durably
-		// enqueue and drain an alarm-manager:dismiss-requested event Rust's listener can never
-		// resolve (get_by_id(999) always fails) -- noisy, and a wasted durable-queue write, on
-		// every sound preview. stopRinging() with no id keeps sound preview a pure local stop,
-		// matching its behaviour before this alarm id was threaded through.
+		// Thread the real alarm id through so the native dismiss event (and, in turn, the NativeEventBus fan-out that tells the watch to stop) carries it -- see AlarmManagerService.stopRinging's doc comment (issue #255 Phase 4A). Except for the Test Alarm sentinel (same special-case as closeRingingWindow below): it isn't a real DB-backed alarm, so publishing a real native dismiss event for it would durably enqueue and drain an alarm-manager:dismiss-requested event Rust's listener can never resolve (get_by_id(999) always fails) -- noisy, and a wasted durable-queue write, on every sound preview. stopRinging() with no id keeps sound preview a pure local stop, matching its behaviour before this alarm id was threaded through.
 		const isTestAlarm = alarmId === SPECIAL_ALARM_IDS.TEST_ALARM;
 		await alarmManagerService.stopRinging(isTestAlarm ? undefined : alarmId);
 

--- a/apps/threshold/src/screens/Ringing.tsx
+++ b/apps/threshold/src/screens/Ringing.tsx
@@ -177,8 +177,15 @@ const Ringing: React.FC = () => {
 		console.log('[Ringing] Dismissing Alarm', alarmId);
 		// Thread the real alarm id through so the native dismiss event (and, in turn, the
 		// NativeEventBus fan-out that tells the watch to stop) carries it -- see
-		// AlarmManagerService.stopRinging's doc comment (issue #255 Phase 4A).
-		await alarmManagerService.stopRinging(alarmId);
+		// AlarmManagerService.stopRinging's doc comment (issue #255 Phase 4A). Except for the
+		// Test Alarm sentinel (same special-case as closeRingingWindow below): it isn't a real
+		// DB-backed alarm, so publishing a real native dismiss event for it would durably
+		// enqueue and drain an alarm-manager:dismiss-requested event Rust's listener can never
+		// resolve (get_by_id(999) always fails) -- noisy, and a wasted durable-queue write, on
+		// every sound preview. stopRinging() with no id keeps sound preview a pure local stop,
+		// matching its behaviour before this alarm id was threaded through.
+		const isTestAlarm = alarmId === SPECIAL_ALARM_IDS.TEST_ALARM;
+		await alarmManagerService.stopRinging(isTestAlarm ? undefined : alarmId);
 
 		// Notify backend to dismiss (reschedule)
 		try {

--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -220,9 +220,7 @@ describe('AlarmManagerService', () => {
 		expect(calledId).toBe(42);
 		expect(calledTimestamp).toBeGreaterThanOrEqual(before + 10 * 60_000);
 		expect(calledTimestamp).toBeLessThanOrEqual(after + 10 * 60_000);
-		// snoozeRinging deliberately does not thread alarmId through stopRinging -- stopRinging's
-		// single native command is shared with dismiss, so doing so would misattribute an in-app
-		// snooze as a dismiss (see AlarmManagerService.stopRinging's doc comment).
+		// snoozeRinging deliberately does not thread alarmId through stopRinging -- stopRinging's single native command is shared with dismiss, so doing so would misattribute an in-app snooze as a dismiss (see AlarmManagerService.stopRinging's doc comment).
 		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: null });
 	});
 

--- a/apps/threshold/src/services/AlarmManagerService.test.ts
+++ b/apps/threshold/src/services/AlarmManagerService.test.ts
@@ -209,7 +209,7 @@ describe('AlarmManagerService', () => {
 		);
 	});
 
-	it('snoozes ringing alarm with now-anchored timestamp and stops ringing', async () => {
+	it('snoozes ringing alarm with now-anchored timestamp and stops ringing (no id -- see stopRinging doc comment)', async () => {
 		const service = new AlarmManagerService();
 		const before = Date.now();
 
@@ -220,7 +220,10 @@ describe('AlarmManagerService', () => {
 		expect(calledId).toBe(42);
 		expect(calledTimestamp).toBeGreaterThanOrEqual(before + 10 * 60_000);
 		expect(calledTimestamp).toBeLessThanOrEqual(after + 10 * 60_000);
-		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+		// snoozeRinging deliberately does not thread alarmId through stopRinging -- stopRinging's
+		// single native command is shared with dismiss, so doing so would misattribute an in-app
+		// snooze as a dismiss (see AlarmManagerService.stopRinging's doc comment).
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: null });
 	});
 
 	it('snoozes upcoming alarm with trigger-anchored timestamp without stopping ringing', async () => {
@@ -497,6 +500,22 @@ describe('AlarmManagerService', () => {
 	// listeners) and never reach TS, so there's nothing to unit-test here for that
 	// path — same as the pre-existing wear:alarm:dismiss/snooze listeners.
 
+	it('threads the real alarm id through stopRinging (issue #255 Phase 4A in-app dismiss fix)', async () => {
+		const service = new AlarmManagerService();
+
+		await service.stopRinging(17);
+
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: 17 });
+	});
+
+	it('stopRinging with no id passes alarmId: null (legacy ID-less fallback only)', async () => {
+		const service = new AlarmManagerService();
+
+		await service.stopRinging();
+
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: null });
+	});
+
 	it('stops ringing for the alarm_trigger snooze action (no alarm ID available)', async () => {
 		const service = new AlarmManagerService();
 		let actionCallback: ((notification: any) => Promise<void>) | null = null;
@@ -519,7 +538,7 @@ describe('AlarmManagerService', () => {
 		});
 
 		expect(AlarmService.snooze).not.toHaveBeenCalled();
-		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: null });
 	});
 
 	it('stops ringing for the alarm_trigger dismiss action (no alarm ID available)', async () => {
@@ -544,7 +563,7 @@ describe('AlarmManagerService', () => {
 		});
 
 		expect(AlarmService.dismiss).not.toHaveBeenCalled();
-		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing');
+		expect(invoke).toHaveBeenCalledWith('plugin:alarm-manager|stop_ringing', { alarmId: null });
 	});
 
 	it('seeds Rust snooze-length state from the persisted setting on init', async () => {

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -301,6 +301,7 @@ export class AlarmManagerService {
 		const snoozedUntil = Date.now() + minutes * 60_000;
 		await alarmNotificationService.cancelUpcomingNotification(id);
 		await AlarmService.snooze(id, snoozedUntil);
+		// No alarmId here -- see stopRinging's doc comment for why.
 		await this.stopRinging();
 	}
 
@@ -384,10 +385,21 @@ export class AlarmManagerService {
 		}
 	}
 
-	async stopRinging() {
+	/**
+	 * @param alarmId the alarm being dismissed, when known -- threaded through to Kotlin so
+	 *   `AlarmManagerPlugin.notifyAlarmDismissed` produces a real dismiss event uniformly for
+	 *   every dismiss origin, not just the notification's own Dismiss action (issue #255 Phase
+	 *   4A). Deliberately **not** passed by `snoozeRinging()` below: `stopRinging` always sends
+	 *   Kotlin the same `ACTION_DISMISS` intent regardless of caller (it only silences
+	 *   `AlarmRingingService`, it doesn't distinguish dismiss vs. snooze), so threading an id
+	 *   through here for a snooze would misattribute it as a dismiss and, via Rust's
+	 *   `dismiss_alarm`, could clobber the snooze that was just requested. See
+	 *   `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning.
+	 */
+	async stopRinging(alarmId?: number) {
 		try {
-			console.log('[AlarmManager] Stopping ringing...');
-			await stopRingingNative();
+			console.log('[AlarmManager] Stopping ringing...', alarmId ?? '(no id)');
+			await stopRingingNative(alarmId);
 		} catch (e) {
 			console.error('Failed to stop ringing', e);
 		}

--- a/apps/threshold/src/services/AlarmManagerService.ts
+++ b/apps/threshold/src/services/AlarmManagerService.ts
@@ -386,15 +386,7 @@ export class AlarmManagerService {
 	}
 
 	/**
-	 * @param alarmId the alarm being dismissed, when known -- threaded through to Kotlin so
-	 *   `AlarmManagerPlugin.notifyAlarmDismissed` produces a real dismiss event uniformly for
-	 *   every dismiss origin, not just the notification's own Dismiss action (issue #255 Phase
-	 *   4A). Deliberately **not** passed by `snoozeRinging()` below: `stopRinging` always sends
-	 *   Kotlin the same `ACTION_DISMISS` intent regardless of caller (it only silences
-	 *   `AlarmRingingService`, it doesn't distinguish dismiss vs. snooze), so threading an id
-	 *   through here for a snooze would misattribute it as a dismiss and, via Rust's
-	 *   `dismiss_alarm`, could clobber the snooze that was just requested. See
-	 *   `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning.
+	 * @param alarmId the alarm being dismissed, when known -- threaded through to Kotlin so `AlarmManagerPlugin.notifyAlarmDismissed` produces a real dismiss event uniformly for every dismiss origin, not just the notification's own Dismiss action (issue #255 Phase 4A). Deliberately **not** passed by `snoozeRinging()` below: `stopRinging` always sends Kotlin the same `ACTION_DISMISS` intent regardless of caller (it only silences `AlarmRingingService`, it doesn't distinguish dismiss vs. snooze), so threading an id through here for a snooze would misattribute it as a dismiss and, via Rust's `dismiss_alarm`, could clobber the snooze that was just requested. See `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning.
 	 */
 	async stopRinging(alarmId?: number) {
 		try {

--- a/docs/architecture/event-architecture.md
+++ b/docs/architecture/event-architecture.md
@@ -650,6 +650,22 @@ handled directly in `lib.rs`), the watch (`wear:alarm:dismiss`, also handled dir
 in `lib.rs`), the upcoming-notification Dismiss action (TS-invoked), and the in-app
 Ringing screen's own Dismiss button (TS-invoked).
 
+> **Issue #255 Phase 4A note:** as of this phase, the in-app Ringing screen's Dismiss
+> button no longer maps to exactly one of the four sources above -- it now fires
+> _two_ of them together. `Ringing.tsx`'s `handleDismiss` threads the real alarm id
+> into `AlarmManagerService.stopRinging(alarmId)`, so the native `AlarmRingingService`
+> Dismiss action path (`alarm-manager:dismiss-requested`) now also carries a real id
+> and fires (closing a prior gap where in-app dismiss produced no native dismiss
+> event at all), in addition to the pre-existing direct `AlarmService.dismiss(id)`
+> TS-invoked call. This relies on `dismiss_alarm` being safe to call twice in a row
+> for the same alarm id; **that idempotency has not been verified against the
+> current implementation** (`dismiss_alarm` recomputes `next_trigger` relative to
+> whatever is _currently_ stored on the alarm, with no guard against being called a
+> second time after the first call already advanced it) -- see issue #255 Phase 4A's
+> handoff notes for the concrete non-idempotency concern this raises for repeating
+> alarms. In-app **snooze** deliberately does _not_ thread an id through
+> `stopRinging` for the same reason, so it isn't affected by this.
+
 **Payload:**
 
 ```rust

--- a/docs/architecture/event-architecture.md
+++ b/docs/architecture/event-architecture.md
@@ -650,21 +650,7 @@ handled directly in `lib.rs`), the watch (`wear:alarm:dismiss`, also handled dir
 in `lib.rs`), the upcoming-notification Dismiss action (TS-invoked), and the in-app
 Ringing screen's own Dismiss button (TS-invoked).
 
-> **Issue #255 Phase 4A note:** as of this phase, the in-app Ringing screen's Dismiss
-> button no longer maps to exactly one of the four sources above -- it now fires
-> _two_ of them together. `Ringing.tsx`'s `handleDismiss` threads the real alarm id
-> into `AlarmManagerService.stopRinging(alarmId)`, so the native `AlarmRingingService`
-> Dismiss action path (`alarm-manager:dismiss-requested`) now also carries a real id
-> and fires (closing a prior gap where in-app dismiss produced no native dismiss
-> event at all), in addition to the pre-existing direct `AlarmService.dismiss(id)`
-> TS-invoked call. This relies on `dismiss_alarm` being safe to call twice in a row
-> for the same alarm id; **that idempotency has not been verified against the
-> current implementation** (`dismiss_alarm` recomputes `next_trigger` relative to
-> whatever is _currently_ stored on the alarm, with no guard against being called a
-> second time after the first call already advanced it) -- see issue #255 Phase 4A's
-> handoff notes for the concrete non-idempotency concern this raises for repeating
-> alarms. In-app **snooze** deliberately does _not_ thread an id through
-> `stopRinging` for the same reason, so it isn't affected by this.
+> **Issue #255 Phase 4A note:** as of this phase, the in-app Ringing screen's Dismiss button no longer maps to exactly one of the four sources above -- it now fires _two_ of them together. `Ringing.tsx`'s `handleDismiss` threads the real alarm id into `AlarmManagerService.stopRinging(alarmId)`, so the native `AlarmRingingService` Dismiss action path (`alarm-manager:dismiss-requested`) now also carries a real id and fires (closing a prior gap where in-app dismiss produced no native dismiss event at all), in addition to the pre-existing direct `AlarmService.dismiss(id)` TS-invoked call. This relies on `dismiss_alarm` being safe to call twice in a row for the same alarm id; **that idempotency has not been verified against the current implementation** (`dismiss_alarm` recomputes `next_trigger` relative to whatever is _currently_ stored on the alarm, with no guard against being called a second time after the first call already advanced it) -- see issue #255 Phase 4A's handoff notes for the concrete non-idempotency concern this raises for repeating alarms. In-app **snooze** deliberately does _not_ thread an id through `stopRinging` for the same reason, so it isn't affected by this.
 
 **Payload:**
 

--- a/plugins/alarm-manager/android/src/main/AndroidManifest.xml
+++ b/plugins/alarm-manager/android/src/main/AndroidManifest.xml
@@ -29,5 +29,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <!-- Issue #255 Phase 4A: guarantees WatchStopListener is registered before any other
+             component can run, so a watch-originated dismiss/snooze can stop AlarmRingingService
+             natively even before Rust boots. See WatchStopInitProvider's KDoc (mirrors
+             wear-sync's WearRingInitProvider from Phase 3B, for the opposite direction). Not a
+             real content provider: exported="false" and it has no callers. -->
+        <provider
+            android:name=".WatchStopInitProvider"
+            android:authorities="${applicationId}.alarmmanager-stop-init"
+            android:exported="false" />
     </application>
 </manifest>

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -224,41 +224,17 @@ internal fun enrichPayloadForDispatch(envelope: DurableEventQueue.Envelope): Str
 }
 
 /**
- * Publishes [payload] on [NativeEventBus]'s [topic] and returns the tags any in-process
- * listeners reported handling it with. Factored out of [notifyAlarmDismissed]/
- * [notifySnoozeRequested] (mirrors `AlarmReceiver.publishAlarmFiredToBus`) purely so it's
- * unit-testable without a real [Context] -- unlike [enqueueAndDrain], the durable side of the
- * same call, which needs SharedPreferences.
+ * Publishes [payload] on [NativeEventBus]'s [topic] and returns the tags any in-process listeners reported handling it with. Factored out of [notifyAlarmDismissed]/[notifySnoozeRequested] (mirrors `AlarmReceiver.publishAlarmFiredToBus`) purely so it's unit-testable without a real [Context] -- unlike [enqueueAndDrain], the durable side of the same call, which needs SharedPreferences.
  */
 internal fun publishToBus(topic: String, payload: JSONObject): Set<String> =
     NativeEventBus.publish(topic, payload.toString())
 
 /**
- * Resolves the alarm id [AlarmManagerPlugin.stopRinging] should stamp onto the `ACTION_DISMISS`
- * intent it sends [AlarmRingingService], from the id the frontend supplied explicitly (see
- * `StopRingingRequest`'s KDoc on the Rust side). Returns `null` (not stampable as an intent
- * extra) for a missing or non-positive id.
+ * Resolves the alarm id [AlarmManagerPlugin.stopRinging] should stamp onto the `ACTION_DISMISS` intent it sends [AlarmRingingService], from the id the frontend supplied explicitly (see `StopRingingRequest`'s KDoc on the Rust side). Returns `null` (not stampable as an intent extra) for a missing or non-positive id.
  *
- * Deliberately does **not** fall back to [AlarmRingingService.currentlyRingingAlarmId] when
- * [explicitAlarmId] is absent, even though that field exists and is read elsewhere
- * ([AlarmManagerPlugin.getCurrentlyRingingAlarm]). `stopRinging` is invoked for both the
- * dismiss ("Stop Alarm") and snooze flows (`AlarmManagerService.stopRinging()` /
- * `snoozeRinging()`, both of which end up here since this command's only job is silencing
- * `AlarmRingingService`, not distinguishing *why*) -- always via the same `ACTION_DISMISS`
- * intent, which `AlarmRingingService.onStartCommand` routes to
- * [AlarmManagerPlugin.notifyAlarmDismissed]. If this fell back to the currently-ringing id for
- * every id-less caller, an in-app **snooze** (which never threads its own id through, exactly
- * because of this) would spuriously produce a real `alarm-manager:dismiss-requested` event and
- * call Rust's `dismiss_alarm` right after the snooze's own `AlarmService.snooze()` write --
- * `dismiss_alarm` recomputes `next_trigger` relative to whatever is *currently* stored, so this
- * would silently clobber the snooze the user just requested. Only the explicit-id path (issue
- * #255 Phase 4A's in-app "Stop Alarm" button) is safe to wire uniformly; the id-less legacy JS
- * notification-action fallback (`onDismissRinging`/`onSnoozeRinging` in
- * `AlarmManagerService.init()`) stays exactly as inert as it is today.
+ * Deliberately does **not** fall back to [AlarmRingingService.currentlyRingingAlarmId] when [explicitAlarmId] is absent, even though that field exists and is read elsewhere ([AlarmManagerPlugin.getCurrentlyRingingAlarm]). `stopRinging` is invoked for both the dismiss ("Stop Alarm") and snooze flows (`AlarmManagerService.stopRinging()` / `snoozeRinging()`, both of which end up here since this command's only job is silencing `AlarmRingingService`, not distinguishing *why*) -- always via the same `ACTION_DISMISS` intent, which `AlarmRingingService.onStartCommand` routes to [AlarmManagerPlugin.notifyAlarmDismissed]. If this fell back to the currently-ringing id for every id-less caller, an in-app **snooze** (which never threads its own id through, exactly because of this) would spuriously produce a real `alarm-manager:dismiss-requested` event and call Rust's `dismiss_alarm` right after the snooze's own `AlarmService.snooze()` write -- `dismiss_alarm` recomputes `next_trigger` relative to whatever is *currently* stored, so this would silently clobber the snooze the user just requested. Only the explicit-id path (issue #255 Phase 4A's in-app "Stop Alarm" button) is safe to wire uniformly; the id-less legacy JS notification-action fallback (`onDismissRinging`/`onSnoozeRinging` in `AlarmManagerService.init()`) stays exactly as inert as it is today.
  *
- * A pure function (not reading the companion `@Volatile var` itself) so it's unit-testable
- * without an Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking
- * `isLive` as a parameter rather than resolving it inline.
+ * A pure function (not reading the companion `@Volatile var` itself) so it's unit-testable without an Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking `isLive` as a parameter rather than resolving it inline.
  */
 internal fun resolveStopRingingAlarmId(explicitAlarmId: Int?): Int? {
     return explicitAlarmId?.takeIf { it > 0 }
@@ -351,11 +327,7 @@ class ImportEventHandlerArgs {
 
 @InvokeArg
 class StopRingingArgs {
-    // Null (the default, and what a caller that omits the key entirely gets) means "no
-    // explicit id supplied" -- resolveStopRingingAlarmId() leaves the ACTION_DISMISS intent's
-    // ALARM_ID extra unset in that case (see its KDoc for why this deliberately does not fall
-    // back to AlarmRingingService.currentlyRingingAlarmId). See StopRingingRequest's KDoc on
-    // the Rust side for why the key is omitted rather than sent as JSON null.
+    // Null (the default, and what a caller that omits the key entirely gets) means "no explicit id supplied" -- resolveStopRingingAlarmId() leaves the ACTION_DISMISS intent's ALARM_ID extra unset in that case (see its KDoc for why this deliberately does not fall back to AlarmRingingService.currentlyRingingAlarmId). See StopRingingRequest's KDoc on the Rust side for why the key is omitted rather than sent as JSON null.
     var alarmId: Int? = null
 }
 
@@ -403,34 +375,19 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
         }
 
         /**
-         * @param alarmId the real alarm id, from the `ACTION_SNOOZE` intent's `ALARM_ID` extra
-         *   -- as of issue #255 Phase 4A this always comes from the notification's own Snooze
-         *   action (the one existing caller of `ACTION_SNOOZE`); in-app snooze does not (and
-         *   deliberately does not) route through this, since `stopRinging`'s single command is
-         *   shared with dismiss and would misattribute an in-app snooze as a dismiss -- see
-         *   `resolveStopRingingAlarmId`'s KDoc. A non-positive id is dropped by the guard below.
+         * @param alarmId the real alarm id, from the `ACTION_SNOOZE` intent's `ALARM_ID` extra -- as of issue #255 Phase 4A this always comes from the notification's own Snooze action (the one existing caller of `ACTION_SNOOZE`); in-app snooze does not (and deliberately does not) route through this, since `stopRinging`'s single command is shared with dismiss and would misattribute an in-app snooze as a dismiss -- see `resolveStopRingingAlarmId`'s KDoc. A non-positive id is dropped by the guard below.
          */
         @Synchronized
         fun notifySnoozeRequested(context: Context, alarmId: Int) {
             if (alarmId <= 0) return
             val payload = JSONObject().apply { put("id", alarmId) }
             enqueueAndDrain(context, TOPIC_SNOOZE, payload)
-            // Fast native fan-out (issue #255 Phase 4A/Part 2.1) -- lets wear-sync's own
-            // listener (a sibling worktree) tell the watch to stop instantly, without waiting
-            // for Rust to boot. Durable-persist-first, same ordering/reasoning as
-            // AlarmReceiver.recordAndPublishFiredEvent for the fired path.
+            // Fast native fan-out (issue #255 Phase 4A/Part 2.1) -- lets wear-sync's own listener (a sibling worktree) tell the watch to stop instantly, without waiting for Rust to boot. Durable-persist-first, same ordering/reasoning as AlarmReceiver.recordAndPublishFiredEvent for the fired path.
             publishToBus(TOPIC_SNOOZE, payload)
         }
 
         /**
-         * @param alarmId the real alarm id, now produced by every dismiss origin that reaches
-         *   `AlarmRingingService`'s `ACTION_DISMISS` handler -- the notification's own Dismiss
-         *   action (always had one) and, since issue #255 Phase 4A closed the in-app dismiss
-         *   gap, the in-app "Stop Alarm" button too (`resolveStopRingingAlarmId`). There is no
-         *   longer an origin-based special case here: a non-positive id (still possible if
-         *   genuinely nothing is/was ringing, e.g. the legacy ID-less JS notification-action
-         *   fallback) is simply dropped by the guard below, uniformly, regardless of where the
-         *   call came from.
+         * @param alarmId the real alarm id, now produced by every dismiss origin that reaches `AlarmRingingService`'s `ACTION_DISMISS` handler -- the notification's own Dismiss action (always had one) and, since issue #255 Phase 4A closed the in-app dismiss gap, the in-app "Stop Alarm" button too (`resolveStopRingingAlarmId`). There is no longer an origin-based special case here: a non-positive id (still possible if genuinely nothing is/was ringing, e.g. the legacy ID-less JS notification-action fallback) is simply dropped by the guard below, uniformly, regardless of where the call came from.
          */
         @Synchronized
         fun notifyAlarmDismissed(context: Context, alarmId: Int) {
@@ -556,10 +513,7 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
     @Command
     fun stopRinging(invoke: Invoke) {
         val args = invoke.parseArgs(StopRingingArgs::class.java)
-        // Issue #255 Phase 4A: stamp the id the frontend supplied explicitly (e.g. the in-app
-        // "Stop Alarm" button, which now threads its alarm id all the way through -- see
-        // resolveStopRingingAlarmId's KDoc for why this deliberately does NOT fall back to
-        // AlarmRingingService.currentlyRingingAlarmId for id-less callers).
+        // Issue #255 Phase 4A: stamp the id the frontend supplied explicitly (e.g. the in-app "Stop Alarm" button, which now threads its alarm id all the way through -- see resolveStopRingingAlarmId's KDoc for why this deliberately does NOT fall back to AlarmRingingService.currentlyRingingAlarmId for id-less callers).
         val alarmId = resolveStopRingingAlarmId(args.alarmId)
         Log.d(TAG, "Stopping ringing service via Intent for alarm $alarmId")
         val intent = Intent(activity, AlarmRingingService::class.java).apply {

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/AlarmManagerPlugin.kt
@@ -29,6 +29,7 @@ import android.content.BroadcastReceiver
 import android.content.IntentFilter
 import ca.liminalhq.threshold.nativebus.DurableEventQueue
 import ca.liminalhq.threshold.nativebus.KeyValueStore
+import ca.liminalhq.threshold.nativebus.NativeEventBus
 import ca.liminalhq.threshold.nativebus.SharedPreferencesKeyValueStore
 import org.json.JSONArray
 import org.json.JSONObject
@@ -222,6 +223,47 @@ internal fun enrichPayloadForDispatch(envelope: DurableEventQueue.Envelope): Str
     }
 }
 
+/**
+ * Publishes [payload] on [NativeEventBus]'s [topic] and returns the tags any in-process
+ * listeners reported handling it with. Factored out of [notifyAlarmDismissed]/
+ * [notifySnoozeRequested] (mirrors `AlarmReceiver.publishAlarmFiredToBus`) purely so it's
+ * unit-testable without a real [Context] -- unlike [enqueueAndDrain], the durable side of the
+ * same call, which needs SharedPreferences.
+ */
+internal fun publishToBus(topic: String, payload: JSONObject): Set<String> =
+    NativeEventBus.publish(topic, payload.toString())
+
+/**
+ * Resolves the alarm id [AlarmManagerPlugin.stopRinging] should stamp onto the `ACTION_DISMISS`
+ * intent it sends [AlarmRingingService], from the id the frontend supplied explicitly (see
+ * `StopRingingRequest`'s KDoc on the Rust side). Returns `null` (not stampable as an intent
+ * extra) for a missing or non-positive id.
+ *
+ * Deliberately does **not** fall back to [AlarmRingingService.currentlyRingingAlarmId] when
+ * [explicitAlarmId] is absent, even though that field exists and is read elsewhere
+ * ([AlarmManagerPlugin.getCurrentlyRingingAlarm]). `stopRinging` is invoked for both the
+ * dismiss ("Stop Alarm") and snooze flows (`AlarmManagerService.stopRinging()` /
+ * `snoozeRinging()`, both of which end up here since this command's only job is silencing
+ * `AlarmRingingService`, not distinguishing *why*) -- always via the same `ACTION_DISMISS`
+ * intent, which `AlarmRingingService.onStartCommand` routes to
+ * [AlarmManagerPlugin.notifyAlarmDismissed]. If this fell back to the currently-ringing id for
+ * every id-less caller, an in-app **snooze** (which never threads its own id through, exactly
+ * because of this) would spuriously produce a real `alarm-manager:dismiss-requested` event and
+ * call Rust's `dismiss_alarm` right after the snooze's own `AlarmService.snooze()` write --
+ * `dismiss_alarm` recomputes `next_trigger` relative to whatever is *currently* stored, so this
+ * would silently clobber the snooze the user just requested. Only the explicit-id path (issue
+ * #255 Phase 4A's in-app "Stop Alarm" button) is safe to wire uniformly; the id-less legacy JS
+ * notification-action fallback (`onDismissRinging`/`onSnoozeRinging` in
+ * `AlarmManagerService.init()`) stays exactly as inert as it is today.
+ *
+ * A pure function (not reading the companion `@Volatile var` itself) so it's unit-testable
+ * without an Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking
+ * `isLive` as a parameter rather than resolving it inline.
+ */
+internal fun resolveStopRingingAlarmId(explicitAlarmId: Int?): Int? {
+    return explicitAlarmId?.takeIf { it > 0 }
+}
+
 private fun keyValueStore(context: Context): KeyValueStore = SharedPreferencesKeyValueStore(context, CALLBACK_PREFS)
 
 // Process-wide singleton -- mirrors WearSyncEventQueue.getInstance()'s pattern (see its KDoc)
@@ -307,6 +349,16 @@ class ImportEventHandlerArgs {
     lateinit var handler: Channel
 }
 
+@InvokeArg
+class StopRingingArgs {
+    // Null (the default, and what a caller that omits the key entirely gets) means "no
+    // explicit id supplied" -- resolveStopRingingAlarmId() leaves the ACTION_DISMISS intent's
+    // ALARM_ID extra unset in that case (see its KDoc for why this deliberately does not fall
+    // back to AlarmRingingService.currentlyRingingAlarmId). See StopRingingRequest's KDoc on
+    // the Rust side for why the key is omitted rather than sent as JSON null.
+    var alarmId: Int? = null
+}
+
 @TauriPlugin
 class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(activity) {
     private var alarmEventChannel: Channel? = null
@@ -350,18 +402,42 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
             enqueueAndDrain(context, TOPIC_FIRED, payload, handledNatively)
         }
 
+        /**
+         * @param alarmId the real alarm id, from the `ACTION_SNOOZE` intent's `ALARM_ID` extra
+         *   -- as of issue #255 Phase 4A this always comes from the notification's own Snooze
+         *   action (the one existing caller of `ACTION_SNOOZE`); in-app snooze does not (and
+         *   deliberately does not) route through this, since `stopRinging`'s single command is
+         *   shared with dismiss and would misattribute an in-app snooze as a dismiss -- see
+         *   `resolveStopRingingAlarmId`'s KDoc. A non-positive id is dropped by the guard below.
+         */
         @Synchronized
         fun notifySnoozeRequested(context: Context, alarmId: Int) {
             if (alarmId <= 0) return
             val payload = JSONObject().apply { put("id", alarmId) }
             enqueueAndDrain(context, TOPIC_SNOOZE, payload)
+            // Fast native fan-out (issue #255 Phase 4A/Part 2.1) -- lets wear-sync's own
+            // listener (a sibling worktree) tell the watch to stop instantly, without waiting
+            // for Rust to boot. Durable-persist-first, same ordering/reasoning as
+            // AlarmReceiver.recordAndPublishFiredEvent for the fired path.
+            publishToBus(TOPIC_SNOOZE, payload)
         }
 
+        /**
+         * @param alarmId the real alarm id, now produced by every dismiss origin that reaches
+         *   `AlarmRingingService`'s `ACTION_DISMISS` handler -- the notification's own Dismiss
+         *   action (always had one) and, since issue #255 Phase 4A closed the in-app dismiss
+         *   gap, the in-app "Stop Alarm" button too (`resolveStopRingingAlarmId`). There is no
+         *   longer an origin-based special case here: a non-positive id (still possible if
+         *   genuinely nothing is/was ringing, e.g. the legacy ID-less JS notification-action
+         *   fallback) is simply dropped by the guard below, uniformly, regardless of where the
+         *   call came from.
+         */
         @Synchronized
         fun notifyAlarmDismissed(context: Context, alarmId: Int) {
             if (alarmId <= 0) return
             val payload = JSONObject().apply { put("id", alarmId) }
             enqueueAndDrain(context, TOPIC_DISMISS, payload)
+            publishToBus(TOPIC_DISMISS, payload)
         }
 
         @Synchronized
@@ -479,9 +555,16 @@ class AlarmManagerPlugin(private val activity: android.app.Activity) : Plugin(ac
 
     @Command
     fun stopRinging(invoke: Invoke) {
-        Log.d(TAG, "Stopping ringing service via Intent")
+        val args = invoke.parseArgs(StopRingingArgs::class.java)
+        // Issue #255 Phase 4A: stamp the id the frontend supplied explicitly (e.g. the in-app
+        // "Stop Alarm" button, which now threads its alarm id all the way through -- see
+        // resolveStopRingingAlarmId's KDoc for why this deliberately does NOT fall back to
+        // AlarmRingingService.currentlyRingingAlarmId for id-less callers).
+        val alarmId = resolveStopRingingAlarmId(args.alarmId)
+        Log.d(TAG, "Stopping ringing service via Intent for alarm $alarmId")
         val intent = Intent(activity, AlarmRingingService::class.java).apply {
             action = AlarmRingingService.ACTION_DISMISS
+            if (alarmId != null) putExtra("ALARM_ID", alarmId)
         }
         activity.startService(intent)
         // Every path out of the ringing screen (dismiss, snooze, silence-timeout) calls this,

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopInitProvider.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopInitProvider.kt
@@ -1,0 +1,69 @@
+// ContentProvider that registers the native watch->phone stop listener before anything else can run
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.util.Log
+
+private const val TAG = "WatchStopInitProvider"
+
+/**
+ * Guarantees [WatchStopListener] is subscribed to `NativeEventBus` before anything else in the
+ * app can run, including on a cold multi-plugin process start. `ContentProvider.onCreate()` is
+ * documented to always run before any `Activity`/`Service`/`BroadcastReceiver` callback -- the
+ * same early-init mechanism wear-sync's `WearRingInitProvider` established in issue #255 Phase
+ * 3B for the opposite (fired->watch) direction; this is that pattern applied to the
+ * watch->phone stop direction (Phase 4A).
+ *
+ * Not debug-gated: it ships in every build, since a watch-originated dismiss/snooze needs to
+ * silence the phone's ringing regardless of whether the phone's Tauri runtime has booted yet.
+ * `android:exported="false"` in the manifest -- this provider has no real data to serve and no
+ * external caller.
+ */
+class WatchStopInitProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val ctx = context
+        if (ctx == null) {
+            // ContentProvider.onCreate() is documented to always have an attached Context by
+            // the time it runs; this is defensive only, not an expected path.
+            Log.e(TAG, "onCreate() called with no attached Context")
+            return true
+        }
+
+        WatchStopListener.register(ctx)
+        Log.d(TAG, "WatchStopInitProvider.onCreate() fired, listener registered")
+
+        return true
+    }
+
+    // Everything below is a deliberate no-op -- this is not a real content provider, it
+    // exists purely for the onCreate() timing guarantee above.
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+    ): Int = 0
+}

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopInitProvider.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopInitProvider.kt
@@ -14,25 +14,16 @@ import android.util.Log
 private const val TAG = "WatchStopInitProvider"
 
 /**
- * Guarantees [WatchStopListener] is subscribed to `NativeEventBus` before anything else in the
- * app can run, including on a cold multi-plugin process start. `ContentProvider.onCreate()` is
- * documented to always run before any `Activity`/`Service`/`BroadcastReceiver` callback -- the
- * same early-init mechanism wear-sync's `WearRingInitProvider` established in issue #255 Phase
- * 3B for the opposite (fired->watch) direction; this is that pattern applied to the
- * watch->phone stop direction (Phase 4A).
+ * Guarantees [WatchStopListener] is subscribed to `NativeEventBus` before anything else in the app can run, including on a cold multi-plugin process start. `ContentProvider.onCreate()` is documented to always run before any `Activity`/`Service`/`BroadcastReceiver` callback -- the same early-init mechanism wear-sync's `WearRingInitProvider` established in issue #255 Phase 3B for the opposite (fired->watch) direction; this is that pattern applied to the watch->phone stop direction (Phase 4A).
  *
- * Not debug-gated: it ships in every build, since a watch-originated dismiss/snooze needs to
- * silence the phone's ringing regardless of whether the phone's Tauri runtime has booted yet.
- * `android:exported="false"` in the manifest -- this provider has no real data to serve and no
- * external caller.
+ * Not debug-gated: it ships in every build, since a watch-originated dismiss/snooze needs to silence the phone's ringing regardless of whether the phone's Tauri runtime has booted yet. `android:exported="false"` in the manifest -- this provider has no real data to serve and no external caller.
  */
 class WatchStopInitProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
         val ctx = context
         if (ctx == null) {
-            // ContentProvider.onCreate() is documented to always have an attached Context by
-            // the time it runs; this is defensive only, not an expected path.
+            // ContentProvider.onCreate() is documented to always have an attached Context by the time it runs; this is defensive only, not an expected path.
             Log.e(TAG, "onCreate() called with no attached Context")
             return true
         }
@@ -43,8 +34,7 @@ class WatchStopInitProvider : ContentProvider() {
         return true
     }
 
-    // Everything below is a deliberate no-op -- this is not a real content provider, it
-    // exists purely for the onCreate() timing guarantee above.
+    // Everything below is a deliberate no-op -- this is not a real content provider, it exists purely for the onCreate() timing guarantee above.
 
     override fun query(
         uri: Uri,

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopListener.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopListener.kt
@@ -1,0 +1,134 @@
+// In-process listener that stops the local ringing service the instant the watch dismisses/snoozes, before Rust boots
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.json.JSONObject
+
+private const val TAG = "WatchStopListener"
+
+// Mirrors the Tauri event names wear-sync's Rust core already emits for these watch-originated
+// commands (`wear:alarm:dismiss`/`wear:alarm:snooze` in apps/threshold/src-tauri/src/lib.rs) --
+// reused as NativeEventBus topics for the same reason AlarmManagerPlugin's own TOPIC_* constants
+// reuse their Tauri event names: the log/bus contents stay self-describing. Publishing onto
+// these topics is wear-sync's own responsibility (a sibling worktree, issue #255 Phase 4B) --
+// this file only subscribes.
+internal const val TOPIC_WEAR_DISMISS = "wear:alarm:dismiss"
+internal const val TOPIC_WEAR_SNOOZE = "wear:alarm:snooze"
+
+// Reported by handle() when it actually stopped AlarmRingingService, mirroring
+// wear-sync's NativeFiredListener.TAG_WATCH_RING -- not consumed by anything today (unlike
+// TAG_WATCH_RING, which Rust's handled_natively gate reads), but kept for the same reason: a
+// non-null NativeEventBus tag documents "something handled this" for anyone inspecting logs.
+internal const val TAG_RINGING_STOPPED = "ringing-stopped"
+
+/**
+ * Registers with [NativeEventBus] for wear-sync's `wear:alarm:dismiss`/`wear:alarm:snooze`
+ * topics and stops [AlarmRingingService] directly the moment the watch dismisses or snoozes a
+ * ringing alarm -- entirely natively, no dependency on Rust or the WebView having booted. This
+ * is the phone-side half of issue #255 Phase 4A's "symmetric stop signals": the watch can now
+ * silence the phone's ringing just as fast as the phone can silence the watch's (Phase 3's
+ * fired-fan-out). [WatchStopInitProvider]'s `onCreate()` guarantees this listener is registered
+ * before any other component can run, even on a cold multi-plugin process start -- mirrors
+ * wear-sync's own [WearRingInitProvider]/`NativeFiredListener` pair from Phase 3B (see that
+ * pair's KDoc for the identical `ContentProvider.onCreate()`-always-runs-first reasoning).
+ *
+ * Deliberately does **not** durably enqueue anything of its own, or call
+ * [AlarmManagerPlugin.notifyAlarmDismissed]/`notifySnoozeRequested` -- those would produce a
+ * *second*, redundant `alarm-manager:dismiss-requested`/`snooze-requested` event for something
+ * that originated on the watch, not the phone. Rust's own catch-up for a watch-originated
+ * dismiss/snooze is already durably queued by wear-sync's existing offline-write path
+ * (`WearMessageService.handleOfflineWrite` -> `WearSyncEventQueue` -> `WearSyncService` booting
+ * Tauri) independent of this listener; this listener's only job is the physical, local
+ * "silence the audio/vibration/notification right now" side effect, which per issue #255's
+ * design (decision 3) is legal without BAL (background-activity-launch) concerns while the
+ * process is in `FOREGROUND_SERVICE` state, i.e. while [AlarmRingingService] is actually
+ * running -- the same reasoning Phase 0's spike and Phase 3B already proved out for the
+ * opposite direction.
+ *
+ * [Context.stopService] (not another `ACTION_DISMISS`/`ACTION_SNOOZE` intent) is what actually
+ * stops [AlarmRingingService] here -- routing through `ACTION_DISMISS` again would call back
+ * into [AlarmManagerPlugin.notifyAlarmDismissed], durably re-queuing an event for something
+ * that's already on its way to Rust via wear-sync's own path. `stopService` goes straight to
+ * `onDestroy()` (no `onStartCommand`), which is exactly the "just silence it" side effect this
+ * listener needs.
+ */
+object WatchStopListener {
+
+    /** Registers this listener with [NativeEventBus]. Called once from [WatchStopInitProvider.onCreate]. */
+    fun register(context: Context) {
+        val appContext = context.applicationContext
+        NativeEventBus.subscribe(TOPIC_WEAR_DISMISS) { payload -> handle(appContext, payload) }
+        NativeEventBus.subscribe(TOPIC_WEAR_SNOOZE) { payload -> handle(appContext, payload) }
+        Log.d(TAG, "Registered watch stop listener for topics '$TOPIC_WEAR_DISMISS'/'$TOPIC_WEAR_SNOOZE'")
+    }
+
+    /**
+     * The [NativeEventBus] listener callback itself. `internal` (not `private`) so tests can
+     * drive it directly against a fake [Context] without going through [register]/
+     * [NativeEventBus]. Shared by both topics: dismiss and snooze both reduce to the same
+     * physical action here (stop the local ringing) -- the DB-level distinction (dismissed vs.
+     * re-armed) is Rust's job via wear-sync's own queued path, explicitly out of scope for this
+     * listener (issue #255 Phase 4A: "Snooze's re-arm still requires Rust and stays queued").
+     */
+    internal fun handle(context: Context, payload: String): String? {
+        val alarmId = shouldStopForWatchSignal(payload, AlarmRingingService.currentlyRingingAlarmId)
+        if (alarmId == null) {
+            Log.d(TAG, "Ignoring watch-originated stop signal (malformed payload, or id doesn't match the currently-ringing alarm)")
+            return null
+        }
+
+        Log.d(TAG, "Stopping AlarmRingingService natively for id=$alarmId (watch-originated stop)")
+        NativeEventLog.log(context, TAG, "Stopping ringing natively for id=$alarmId (watch-originated stop)")
+        context.stopService(Intent(context, AlarmRingingService::class.java))
+        return TAG_RINGING_STOPPED
+    }
+}
+
+/** One `wear:alarm:dismiss`/`wear:alarm:snooze` payload's field this listener cares about. */
+internal data class WatchStopPayload(val alarmId: Int)
+
+/**
+ * Parses the `{alarmId, ...}` JSON payload wear-sync publishes to [NativeEventBus] for
+ * watch-originated dismiss/snooze -- mirrors the wire shape of Rust's `WatchDismissAlarm`/
+ * `WatchSnoozeAlarm` (`plugins/wear-sync/src/models.rs`, `#[serde(rename_all = "camelCase")]`),
+ * which is also the shape of the watch's own raw message payload
+ * (`{"alarmId":7}`/`{"alarmId":7,"snoozeLengthMinutes":10}`) that `WearMessageService` receives
+ * before any Rust involvement. Tolerates and ignores any other fields (`eventId`,
+ * `snoozeLengthMinutes`) -- this listener only needs the id. Returns `null` for anything
+ * malformed or missing a usable `alarmId`, rather than throwing.
+ */
+internal fun parseWatchStopPayload(payload: String): WatchStopPayload? {
+    return try {
+        val json = JSONObject(payload)
+        val alarmId = json.optInt("alarmId", -1)
+        if (alarmId <= 0) return null
+        WatchStopPayload(alarmId)
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Whether a watch-originated dismiss/snooze [payload] should stop [AlarmRingingService]:
+ * returns the alarm id to stop when [payload] parses to a positive id that matches
+ * [currentlyRingingAlarmId], `null` otherwise (malformed payload, or the watch's target alarm
+ * isn't the one actually ringing on this phone right now -- e.g. it already stopped locally, or
+ * this is a stale/redelivered signal for a since-finished ring).
+ *
+ * A pure function of a payload string and an int (not reading
+ * [AlarmRingingService.currentlyRingingAlarmId] itself) so it's unit-testable without an
+ * Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking `isLive`
+ * as a parameter, and [resolveStopRingingAlarmId] in this same plugin.
+ */
+internal fun shouldStopForWatchSignal(payload: String, currentlyRingingAlarmId: Int): Int? {
+    val stop = parseWatchStopPayload(payload) ?: return null
+    if (currentlyRingingAlarmId <= 0 || currentlyRingingAlarmId != stop.alarmId) return null
+    return stop.alarmId
+}

--- a/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopListener.kt
+++ b/plugins/alarm-manager/android/src/main/java/com/plugin/alarmmanager/WatchStopListener.kt
@@ -13,51 +13,19 @@ import org.json.JSONObject
 
 private const val TAG = "WatchStopListener"
 
-// Mirrors the Tauri event names wear-sync's Rust core already emits for these watch-originated
-// commands (`wear:alarm:dismiss`/`wear:alarm:snooze` in apps/threshold/src-tauri/src/lib.rs) --
-// reused as NativeEventBus topics for the same reason AlarmManagerPlugin's own TOPIC_* constants
-// reuse their Tauri event names: the log/bus contents stay self-describing. Publishing onto
-// these topics is wear-sync's own responsibility (a sibling worktree, issue #255 Phase 4B) --
-// this file only subscribes.
+// Mirrors the Tauri event names wear-sync's Rust core already emits for these watch-originated commands (`wear:alarm:dismiss`/`wear:alarm:snooze` in apps/threshold/src-tauri/src/lib.rs) -- reused as NativeEventBus topics for the same reason AlarmManagerPlugin's own TOPIC_* constants reuse their Tauri event names: the log/bus contents stay self-describing. Publishing onto these topics is wear-sync's own responsibility (a sibling worktree, issue #255 Phase 4B) -- this file only subscribes.
 internal const val TOPIC_WEAR_DISMISS = "wear:alarm:dismiss"
 internal const val TOPIC_WEAR_SNOOZE = "wear:alarm:snooze"
 
-// Reported by handle() when it actually stopped AlarmRingingService, mirroring
-// wear-sync's NativeFiredListener.TAG_WATCH_RING -- not consumed by anything today (unlike
-// TAG_WATCH_RING, which Rust's handled_natively gate reads), but kept for the same reason: a
-// non-null NativeEventBus tag documents "something handled this" for anyone inspecting logs.
+// Reported by handle() when it actually stopped AlarmRingingService, mirroring wear-sync's NativeFiredListener.TAG_WATCH_RING -- not consumed by anything today (unlike TAG_WATCH_RING, which Rust's handled_natively gate reads), but kept for the same reason: a non-null NativeEventBus tag documents "something handled this" for anyone inspecting logs.
 internal const val TAG_RINGING_STOPPED = "ringing-stopped"
 
 /**
- * Registers with [NativeEventBus] for wear-sync's `wear:alarm:dismiss`/`wear:alarm:snooze`
- * topics and stops [AlarmRingingService] directly the moment the watch dismisses or snoozes a
- * ringing alarm -- entirely natively, no dependency on Rust or the WebView having booted. This
- * is the phone-side half of issue #255 Phase 4A's "symmetric stop signals": the watch can now
- * silence the phone's ringing just as fast as the phone can silence the watch's (Phase 3's
- * fired-fan-out). [WatchStopInitProvider]'s `onCreate()` guarantees this listener is registered
- * before any other component can run, even on a cold multi-plugin process start -- mirrors
- * wear-sync's own [WearRingInitProvider]/`NativeFiredListener` pair from Phase 3B (see that
- * pair's KDoc for the identical `ContentProvider.onCreate()`-always-runs-first reasoning).
+ * Registers with [NativeEventBus] for wear-sync's `wear:alarm:dismiss`/`wear:alarm:snooze` topics and stops [AlarmRingingService] directly the moment the watch dismisses or snoozes a ringing alarm -- entirely natively, no dependency on Rust or the WebView having booted. This is the phone-side half of issue #255 Phase 4A's "symmetric stop signals": the watch can now silence the phone's ringing just as fast as the phone can silence the watch's (Phase 3's fired-fan-out). [WatchStopInitProvider]'s `onCreate()` guarantees this listener is registered before any other component can run, even on a cold multi-plugin process start -- mirrors wear-sync's own [WearRingInitProvider]/`NativeFiredListener` pair from Phase 3B (see that pair's KDoc for the identical `ContentProvider.onCreate()`-always-runs-first reasoning).
  *
- * Deliberately does **not** durably enqueue anything of its own, or call
- * [AlarmManagerPlugin.notifyAlarmDismissed]/`notifySnoozeRequested` -- those would produce a
- * *second*, redundant `alarm-manager:dismiss-requested`/`snooze-requested` event for something
- * that originated on the watch, not the phone. Rust's own catch-up for a watch-originated
- * dismiss/snooze is already durably queued by wear-sync's existing offline-write path
- * (`WearMessageService.handleOfflineWrite` -> `WearSyncEventQueue` -> `WearSyncService` booting
- * Tauri) independent of this listener; this listener's only job is the physical, local
- * "silence the audio/vibration/notification right now" side effect, which per issue #255's
- * design (decision 3) is legal without BAL (background-activity-launch) concerns while the
- * process is in `FOREGROUND_SERVICE` state, i.e. while [AlarmRingingService] is actually
- * running -- the same reasoning Phase 0's spike and Phase 3B already proved out for the
- * opposite direction.
+ * Deliberately does **not** durably enqueue anything of its own, or call [AlarmManagerPlugin.notifyAlarmDismissed]/`notifySnoozeRequested` -- those would produce a *second*, redundant `alarm-manager:dismiss-requested`/`snooze-requested` event for something that originated on the watch, not the phone. Rust's own catch-up for a watch-originated dismiss/snooze is already durably queued by wear-sync's existing offline-write path (`WearMessageService.handleOfflineWrite` -> `WearSyncEventQueue` -> `WearSyncService` booting Tauri) independent of this listener; this listener's only job is the physical, local "silence the audio/vibration/notification right now" side effect, which per issue #255's design (decision 3) is legal without BAL (background-activity-launch) concerns while the process is in `FOREGROUND_SERVICE` state, i.e. while [AlarmRingingService] is actually running -- the same reasoning Phase 0's spike and Phase 3B already proved out for the opposite direction.
  *
- * [Context.stopService] (not another `ACTION_DISMISS`/`ACTION_SNOOZE` intent) is what actually
- * stops [AlarmRingingService] here -- routing through `ACTION_DISMISS` again would call back
- * into [AlarmManagerPlugin.notifyAlarmDismissed], durably re-queuing an event for something
- * that's already on its way to Rust via wear-sync's own path. `stopService` goes straight to
- * `onDestroy()` (no `onStartCommand`), which is exactly the "just silence it" side effect this
- * listener needs.
+ * [Context.stopService] (not another `ACTION_DISMISS`/`ACTION_SNOOZE` intent) is what actually stops [AlarmRingingService] here -- routing through `ACTION_DISMISS` again would call back into [AlarmManagerPlugin.notifyAlarmDismissed], durably re-queuing an event for something that's already on its way to Rust via wear-sync's own path. `stopService` goes straight to `onDestroy()` (no `onStartCommand`), which is exactly the "just silence it" side effect this listener needs.
  */
 object WatchStopListener {
 
@@ -70,12 +38,7 @@ object WatchStopListener {
     }
 
     /**
-     * The [NativeEventBus] listener callback itself. `internal` (not `private`) so tests can
-     * drive it directly against a fake [Context] without going through [register]/
-     * [NativeEventBus]. Shared by both topics: dismiss and snooze both reduce to the same
-     * physical action here (stop the local ringing) -- the DB-level distinction (dismissed vs.
-     * re-armed) is Rust's job via wear-sync's own queued path, explicitly out of scope for this
-     * listener (issue #255 Phase 4A: "Snooze's re-arm still requires Rust and stays queued").
+     * The [NativeEventBus] listener callback itself. `internal` (not `private`) so tests can drive it directly against a fake [Context] without going through [register]/[NativeEventBus]. Shared by both topics: dismiss and snooze both reduce to the same physical action here (stop the local ringing) -- the DB-level distinction (dismissed vs. re-armed) is Rust's job via wear-sync's own queued path, explicitly out of scope for this listener (issue #255 Phase 4A: "Snooze's re-arm still requires Rust and stays queued").
      */
     internal fun handle(context: Context, payload: String): String? {
         val alarmId = shouldStopForWatchSignal(payload, AlarmRingingService.currentlyRingingAlarmId)
@@ -95,14 +58,7 @@ object WatchStopListener {
 internal data class WatchStopPayload(val alarmId: Int)
 
 /**
- * Parses the `{alarmId, ...}` JSON payload wear-sync publishes to [NativeEventBus] for
- * watch-originated dismiss/snooze -- mirrors the wire shape of Rust's `WatchDismissAlarm`/
- * `WatchSnoozeAlarm` (`plugins/wear-sync/src/models.rs`, `#[serde(rename_all = "camelCase")]`),
- * which is also the shape of the watch's own raw message payload
- * (`{"alarmId":7}`/`{"alarmId":7,"snoozeLengthMinutes":10}`) that `WearMessageService` receives
- * before any Rust involvement. Tolerates and ignores any other fields (`eventId`,
- * `snoozeLengthMinutes`) -- this listener only needs the id. Returns `null` for anything
- * malformed or missing a usable `alarmId`, rather than throwing.
+ * Parses the `{alarmId, ...}` JSON payload wear-sync publishes to [NativeEventBus] for watch-originated dismiss/snooze -- mirrors the wire shape of Rust's `WatchDismissAlarm`/`WatchSnoozeAlarm` (`plugins/wear-sync/src/models.rs`, `#[serde(rename_all = "camelCase")]`), which is also the shape of the watch's own raw message payload (`{"alarmId":7}`/`{"alarmId":7,"snoozeLengthMinutes":10}`) that `WearMessageService` receives before any Rust involvement. Tolerates and ignores any other fields (`eventId`, `snoozeLengthMinutes`) -- this listener only needs the id. Returns `null` for anything malformed or missing a usable `alarmId`, rather than throwing.
  */
 internal fun parseWatchStopPayload(payload: String): WatchStopPayload? {
     return try {
@@ -116,16 +72,9 @@ internal fun parseWatchStopPayload(payload: String): WatchStopPayload? {
 }
 
 /**
- * Whether a watch-originated dismiss/snooze [payload] should stop [AlarmRingingService]:
- * returns the alarm id to stop when [payload] parses to a positive id that matches
- * [currentlyRingingAlarmId], `null` otherwise (malformed payload, or the watch's target alarm
- * isn't the one actually ringing on this phone right now -- e.g. it already stopped locally, or
- * this is a stale/redelivered signal for a since-finished ring).
+ * Whether a watch-originated dismiss/snooze [payload] should stop [AlarmRingingService]: returns the alarm id to stop when [payload] parses to a positive id that matches [currentlyRingingAlarmId], `null` otherwise (malformed payload, or the watch's target alarm isn't the one actually ringing on this phone right now -- e.g. it already stopped locally, or this is a stale/redelivered signal for a since-finished ring).
  *
- * A pure function of a payload string and an int (not reading
- * [AlarmRingingService.currentlyRingingAlarmId] itself) so it's unit-testable without an
- * Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking `isLive`
- * as a parameter, and [resolveStopRingingAlarmId] in this same plugin.
+ * A pure function of a payload string and an int (not reading [AlarmRingingService.currentlyRingingAlarmId] itself) so it's unit-testable without an Android framework -- mirrors [AlarmReceiver]'s `recordAndPublishFiredEvent` taking `isLive` as a parameter, and [resolveStopRingingAlarmId] in this same plugin.
  */
 internal fun shouldStopForWatchSignal(payload: String, currentlyRingingAlarmId: Int): Int? {
     val stop = parseWatchStopPayload(payload) ?: return null

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/StopRingingAndBusPublishTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/StopRingingAndBusPublishTest.kt
@@ -14,19 +14,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Plain JUnit 4 tests against [resolveStopRingingAlarmId] and [publishToBus], the seams
- * factored out specifically to cover issue #255 Phase 4A: the in-app dismiss id-threading fix
- * (every dismiss origin now produces a real id) and its consequence, publishing
- * `alarm-manager:dismiss-requested`/`snooze-requested` uniformly onto [NativeEventBus] for
- * every origin rather than only the notification action. Mirrors the style of
- * `AlarmReceiverTest` (which covers the equivalent seams for the fired path).
+ * Plain JUnit 4 tests against [resolveStopRingingAlarmId] and [publishToBus], the seams factored out specifically to cover issue #255 Phase 4A: the in-app dismiss id-threading fix (every dismiss origin now produces a real id) and its consequence, publishing `alarm-manager:dismiss-requested`/`snooze-requested` uniformly onto [NativeEventBus] for every origin rather than only the notification action. Mirrors the style of `AlarmReceiverTest` (which covers the equivalent seams for the fired path).
  */
 class StopRingingAndBusPublishTest {
 
     @After
     fun tearDown() {
-        // NativeEventBus is a process-wide singleton; without this, listeners registered by one
-        // test would still be live (and firing) during the next one.
+        // NativeEventBus is a process-wide singleton; without this, listeners registered by one test would still be live (and firing) during the next one.
         NativeEventBus.resetForTests()
     }
 
@@ -39,9 +33,7 @@ class StopRingingAndBusPublishTest {
 
     @Test
     fun `returns null when no explicit id is supplied`() {
-        // The legacy ID-less JS notification-action fallback, and in-app snooze (which
-        // deliberately never threads an id through stopRinging -- see the KDoc on
-        // resolveStopRingingAlarmId for why).
+        // The legacy ID-less JS notification-action fallback, and in-app snooze (which deliberately never threads an id through stopRinging -- see the KDoc on resolveStopRingingAlarmId for why).
         assertNull(resolveStopRingingAlarmId(null))
     }
 

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/StopRingingAndBusPublishTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/StopRingingAndBusPublishTest.kt
@@ -1,0 +1,105 @@
+// Unit tests for stopRinging's id resolution and notifyAlarmDismissed/notifySnoozeRequested's NativeEventBus publish
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests against [resolveStopRingingAlarmId] and [publishToBus], the seams
+ * factored out specifically to cover issue #255 Phase 4A: the in-app dismiss id-threading fix
+ * (every dismiss origin now produces a real id) and its consequence, publishing
+ * `alarm-manager:dismiss-requested`/`snooze-requested` uniformly onto [NativeEventBus] for
+ * every origin rather than only the notification action. Mirrors the style of
+ * `AlarmReceiverTest` (which covers the equivalent seams for the fired path).
+ */
+class StopRingingAndBusPublishTest {
+
+    @After
+    fun tearDown() {
+        // NativeEventBus is a process-wide singleton; without this, listeners registered by one
+        // test would still be live (and firing) during the next one.
+        NativeEventBus.resetForTests()
+    }
+
+    // --- resolveStopRingingAlarmId ------------------------------------------------------------
+
+    @Test
+    fun `resolves the explicit id when it is positive`() {
+        assertEquals(42, resolveStopRingingAlarmId(42))
+    }
+
+    @Test
+    fun `returns null when no explicit id is supplied`() {
+        // The legacy ID-less JS notification-action fallback, and in-app snooze (which
+        // deliberately never threads an id through stopRinging -- see the KDoc on
+        // resolveStopRingingAlarmId for why).
+        assertNull(resolveStopRingingAlarmId(null))
+    }
+
+    @Test
+    fun `returns null for a zero or negative explicit id`() {
+        assertNull(resolveStopRingingAlarmId(0))
+        assertNull(resolveStopRingingAlarmId(-1))
+    }
+
+    // --- publishToBus (dismiss) --------------------------------------------------------------
+
+    @Test
+    fun `publishes on the dismiss topic with the given payload`() {
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_DISMISS) { payload -> receivedPayload = payload; null }
+
+        publishToBus(TOPIC_DISMISS, JSONObject().put("id", 7))
+
+        val payload = JSONObject(requireNotNull(receivedPayload))
+        assertEquals(7, payload.getInt("id"))
+    }
+
+    @Test
+    fun `returns the tags reported by listeners for the dismiss topic`() {
+        NativeEventBus.subscribe(TOPIC_DISMISS) { "watch-stop" }
+
+        val tags = publishToBus(TOPIC_DISMISS, JSONObject().put("id", 7))
+
+        assertEquals(setOf("watch-stop"), tags)
+    }
+
+    @Test
+    fun `returns an empty set when no listener is registered for dismiss`() {
+        val tags = publishToBus(TOPIC_DISMISS, JSONObject().put("id", 7))
+
+        assertTrue(tags.isEmpty())
+    }
+
+    // --- publishToBus (snooze) ----------------------------------------------------------------
+
+    @Test
+    fun `publishes on the snooze topic with the given payload`() {
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_SNOOZE) { payload -> receivedPayload = payload; null }
+
+        publishToBus(TOPIC_SNOOZE, JSONObject().put("id", 9))
+
+        val payload = JSONObject(requireNotNull(receivedPayload))
+        assertEquals(9, payload.getInt("id"))
+    }
+
+    @Test
+    fun `dismiss and snooze topics are independent -- a dismiss listener does not see a snooze publish`() {
+        var dismissReceived = false
+        NativeEventBus.subscribe(TOPIC_DISMISS) { dismissReceived = true; null }
+
+        publishToBus(TOPIC_SNOOZE, JSONObject().put("id", 1))
+
+        assertTrue("a listener on TOPIC_DISMISS must not receive a TOPIC_SNOOZE publish", !dismissReceived)
+    }
+}

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/WatchStopListenerTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/WatchStopListenerTest.kt
@@ -1,0 +1,104 @@
+// Unit tests for WatchStopListener's pure payload-parsing/matching helpers and NativeEventBus registration
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package com.plugin.alarmmanager
+
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers the pure functions
+ * [WatchStopListener] factors out ([parseWatchStopPayload], [shouldStopForWatchSignal]) plus
+ * [WatchStopListener.register]'s topic subscriptions, mirroring the style of wear-sync's
+ * `NativeFiredListenerTest` (the equivalent pure-helper coverage for the opposite direction).
+ * [WatchStopListener.handle] itself calls `Context.stopService`/`AlarmRingingService`, which
+ * need a real Android framework and aren't exercised here -- the matching decision it's built
+ * from ([shouldStopForWatchSignal]) is what's actually worth covering without one.
+ */
+class WatchStopListenerTest {
+
+    @After
+    fun tearDown() {
+        // NativeEventBus is a process-wide singleton; without this, listeners registered by one
+        // test would still be live (and firing) during the next one.
+        NativeEventBus.resetForTests()
+    }
+
+    // --- parseWatchStopPayload -----------------------------------------------------------------
+
+    @Test
+    fun `parses alarmId from a well-formed dismiss payload`() {
+        val payload = JSONObject().apply { put("alarmId", 7) }.toString()
+
+        assertEquals(WatchStopPayload(7), parseWatchStopPayload(payload))
+    }
+
+    @Test
+    fun `ignores unrecognised fields like eventId and snoozeLengthMinutes`() {
+        val payload = JSONObject().apply {
+            put("alarmId", 7)
+            put("eventId", "queue-envelope-id")
+            put("snoozeLengthMinutes", 10)
+        }.toString()
+
+        assertEquals(WatchStopPayload(7), parseWatchStopPayload(payload))
+    }
+
+    @Test
+    fun `returns null for malformed JSON`() {
+        assertNull(parseWatchStopPayload("not even json"))
+    }
+
+    @Test
+    fun `returns null when alarmId is missing`() {
+        assertNull(parseWatchStopPayload(JSONObject().toString()))
+    }
+
+    @Test
+    fun `returns null when alarmId is zero or negative`() {
+        assertNull(parseWatchStopPayload(JSONObject().apply { put("alarmId", 0) }.toString()))
+        assertNull(parseWatchStopPayload(JSONObject().apply { put("alarmId", -3) }.toString()))
+    }
+
+    // --- shouldStopForWatchSignal ---------------------------------------------------------------
+
+    @Test
+    fun `stops when the payload's alarmId matches the currently ringing alarm`() {
+        val payload = JSONObject().apply { put("alarmId", 7) }.toString()
+
+        assertEquals(7, shouldStopForWatchSignal(payload, currentlyRingingAlarmId = 7))
+    }
+
+    @Test
+    fun `no-ops when the payload's alarmId does not match the currently ringing alarm`() {
+        val payload = JSONObject().apply { put("alarmId", 7) }.toString()
+
+        assertNull(shouldStopForWatchSignal(payload, currentlyRingingAlarmId = 8))
+    }
+
+    @Test
+    fun `no-ops when nothing is currently ringing`() {
+        val payload = JSONObject().apply { put("alarmId", 7) }.toString()
+
+        assertNull(shouldStopForWatchSignal(payload, currentlyRingingAlarmId = -1))
+    }
+
+    @Test
+    fun `no-ops for a malformed payload regardless of what is currently ringing`() {
+        assertNull(shouldStopForWatchSignal("not even json", currentlyRingingAlarmId = 7))
+    }
+
+    // WatchStopListener.register()/handle() themselves need a real android.content.Context
+    // (applicationContext, Context.stopService) and AlarmRingingService's real companion state
+    // -- not exercised by this plain-JUnit suite (no Robolectric/instrumentation in this
+    // codebase's test-kotlin-plugins CI job), same as wear-sync's NativeFiredListener.register()/
+    // handle() aren't in NativeFiredListenerTest. The pure decision logic both delegate to
+    // (shouldStopForWatchSignal here, parseFiredPayload/isStale there) is what's covered above.
+}

--- a/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/WatchStopListenerTest.kt
+++ b/plugins/alarm-manager/android/src/test/java/com/plugin/alarmmanager/WatchStopListenerTest.kt
@@ -14,20 +14,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers the pure functions
- * [WatchStopListener] factors out ([parseWatchStopPayload], [shouldStopForWatchSignal]) plus
- * [WatchStopListener.register]'s topic subscriptions, mirroring the style of wear-sync's
- * `NativeFiredListenerTest` (the equivalent pure-helper coverage for the opposite direction).
- * [WatchStopListener.handle] itself calls `Context.stopService`/`AlarmRingingService`, which
- * need a real Android framework and aren't exercised here -- the matching decision it's built
- * from ([shouldStopForWatchSignal]) is what's actually worth covering without one.
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers the pure functions [WatchStopListener] factors out ([parseWatchStopPayload], [shouldStopForWatchSignal]) plus [WatchStopListener.register]'s topic subscriptions, mirroring the style of wear-sync's `NativeFiredListenerTest` (the equivalent pure-helper coverage for the opposite direction). [WatchStopListener.handle] itself calls `Context.stopService`/`AlarmRingingService`, which need a real Android framework and aren't exercised here -- the matching decision it's built from ([shouldStopForWatchSignal]) is what's actually worth covering without one.
  */
 class WatchStopListenerTest {
 
     @After
     fun tearDown() {
-        // NativeEventBus is a process-wide singleton; without this, listeners registered by one
-        // test would still be live (and firing) during the next one.
+        // NativeEventBus is a process-wide singleton; without this, listeners registered by one test would still be live (and firing) during the next one.
         NativeEventBus.resetForTests()
     }
 
@@ -95,10 +88,5 @@ class WatchStopListenerTest {
         assertNull(shouldStopForWatchSignal("not even json", currentlyRingingAlarmId = 7))
     }
 
-    // WatchStopListener.register()/handle() themselves need a real android.content.Context
-    // (applicationContext, Context.stopService) and AlarmRingingService's real companion state
-    // -- not exercised by this plain-JUnit suite (no Robolectric/instrumentation in this
-    // codebase's test-kotlin-plugins CI job), same as wear-sync's NativeFiredListener.register()/
-    // handle() aren't in NativeFiredListenerTest. The pure decision logic both delegate to
-    // (shouldStopForWatchSignal here, parseFiredPayload/isStale there) is what's covered above.
+    // WatchStopListener.register()/handle() themselves need a real android.content.Context (applicationContext, Context.stopService) and AlarmRingingService's real companion state -- not exercised by this plain-JUnit suite (no Robolectric/instrumentation in this codebase's test-kotlin-plugins CI job), same as wear-sync's NativeFiredListener.register()/handle() aren't in NativeFiredListenerTest. The pure decision logic both delegate to (shouldStopForWatchSignal here, parseFiredPayload/isStale there) is what's covered above.
 }

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -32,13 +32,7 @@ export async function pickAlarmSound(options: PickAlarmSoundOptions): Promise<Pi
 }
 
 /**
- * Stops the native ringing service (audio, vibration, notification). `alarmId`, when supplied,
- * threads the real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so
- * `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id -- previously the in-app dismiss
- * path here always omitted it, so it silently produced no native dismiss event at all (issue
- * #255 Phase 4A). Callers that don't know which alarm they're stopping (the legacy ID-less JS
- * notification-action fallback, and in-app snooze -- see `AlarmManagerService.stopRinging`'s
- * own doc comment for why snooze deliberately doesn't pass one) omit it, unchanged.
+ * Stops the native ringing service (audio, vibration, notification). `alarmId`, when supplied, threads the real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id -- previously the in-app dismiss path here always omitted it, so it silently produced no native dismiss event at all (issue #255 Phase 4A). Callers that don't know which alarm they're stopping (the legacy ID-less JS notification-action fallback, and in-app snooze -- see `AlarmManagerService.stopRinging`'s own doc comment for why snooze deliberately doesn't pass one) omit it, unchanged.
  */
 export async function stopRinging(alarmId?: number): Promise<void> {
 	await invoke('plugin:alarm-manager|stop_ringing', { alarmId: alarmId ?? null });

--- a/plugins/alarm-manager/guest-js/index.ts
+++ b/plugins/alarm-manager/guest-js/index.ts
@@ -31,8 +31,17 @@ export async function pickAlarmSound(options: PickAlarmSoundOptions): Promise<Pi
 	return await invoke<PickedAlarmSound>('plugin:alarm-manager|pick_alarm_sound', { options });
 }
 
-export async function stopRinging(): Promise<void> {
-	await invoke('plugin:alarm-manager|stop_ringing');
+/**
+ * Stops the native ringing service (audio, vibration, notification). `alarmId`, when supplied,
+ * threads the real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so
+ * `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id -- previously the in-app dismiss
+ * path here always omitted it, so it silently produced no native dismiss event at all (issue
+ * #255 Phase 4A). Callers that don't know which alarm they're stopping (the legacy ID-less JS
+ * notification-action fallback, and in-app snooze -- see `AlarmManagerService.stopRinging`'s
+ * own doc comment for why snooze deliberately doesn't pass one) omit it, unchanged.
+ */
+export async function stopRinging(alarmId?: number): Promise<void> {
+	await invoke('plugin:alarm-manager|stop_ringing', { alarmId: alarmId ?? null });
 }
 
 /** Whether Android will actually honour the ringing notification's full-screen intent. */

--- a/plugins/alarm-manager/src/commands.rs
+++ b/plugins/alarm-manager/src/commands.rs
@@ -24,9 +24,7 @@ pub async fn pick_alarm_sound<R: Runtime>(
 
 #[command]
 pub async fn stop_ringing<R: Runtime>(app: AppHandle<R>, alarm_id: Option<i32>) -> Result<()> {
-    // `alarm_id` lets the in-app "Stop Alarm" button thread a real id through -- see
-    // StopRingingRequest's KDoc. `None` preserves the old, ID-less behaviour for callers that
-    // don't (or, for in-app snooze, deliberately don't) know which alarm they're stopping.
+    // `alarm_id` lets the in-app "Stop Alarm" button thread a real id through -- see StopRingingRequest's KDoc. `None` preserves the old, ID-less behaviour for callers that don't (or, for in-app snooze, deliberately don't) know which alarm they're stopping.
     match alarm_id {
         Some(id) => app.alarm_manager().stop_ringing_for(id),
         None => app.alarm_manager().stop_ringing(),

--- a/plugins/alarm-manager/src/commands.rs
+++ b/plugins/alarm-manager/src/commands.rs
@@ -23,8 +23,14 @@ pub async fn pick_alarm_sound<R: Runtime>(
 }
 
 #[command]
-pub async fn stop_ringing<R: Runtime>(app: AppHandle<R>) -> Result<()> {
-    app.alarm_manager().stop_ringing()
+pub async fn stop_ringing<R: Runtime>(app: AppHandle<R>, alarm_id: Option<i32>) -> Result<()> {
+    // `alarm_id` lets the in-app "Stop Alarm" button thread a real id through -- see
+    // StopRingingRequest's KDoc. `None` preserves the old, ID-less behaviour for callers that
+    // don't (or, for in-app snooze, deliberately don't) know which alarm they're stopping.
+    match alarm_id {
+        Some(id) => app.alarm_manager().stop_ringing_for(id),
+        None => app.alarm_manager().stop_ringing(),
+    }
 }
 
 #[command]

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -93,6 +93,14 @@ impl<R: Runtime> AlarmManager<R> {
         Ok(())
     }
 
+    /// Desktop has no native `AlarmRingingService` to thread an id into -- the frontend closes
+    /// its own ringing window directly. Kept alongside [`stop_ringing`](Self::stop_ringing) so
+    /// `commands::stop_ringing` compiles identically on both platforms. See issue #255 Phase 4A.
+    pub fn stop_ringing_for(&self, alarm_id: i32) -> crate::Result<()> {
+        println!("Desktop: Stop ringing request received for alarm {alarm_id}");
+        Ok(())
+    }
+
     /// Not an Android concept; nothing to gate.
     pub fn check_full_screen_intent_permission(&self) -> crate::Result<bool> {
         Ok(true)

--- a/plugins/alarm-manager/src/desktop.rs
+++ b/plugins/alarm-manager/src/desktop.rs
@@ -93,9 +93,7 @@ impl<R: Runtime> AlarmManager<R> {
         Ok(())
     }
 
-    /// Desktop has no native `AlarmRingingService` to thread an id into -- the frontend closes
-    /// its own ringing window directly. Kept alongside [`stop_ringing`](Self::stop_ringing) so
-    /// `commands::stop_ringing` compiles identically on both platforms. See issue #255 Phase 4A.
+    /// Desktop has no native `AlarmRingingService` to thread an id into -- the frontend closes its own ringing window directly. Kept alongside [`stop_ringing`](Self::stop_ringing) so `commands::stop_ringing` compiles identically on both platforms. See issue #255 Phase 4A.
     pub fn stop_ringing_for(&self, alarm_id: i32) -> crate::Result<()> {
         println!("Desktop: Stop ringing request received for alarm {alarm_id}");
         Ok(())

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -225,16 +225,7 @@ impl<R: Runtime> AlarmManager<R> {
         self.stop_ringing_request(StopRingingRequest { alarm_id: None })
     }
 
-    /// Same as [`stop_ringing`](Self::stop_ringing), but threads a specific alarm id through
-    /// to Kotlin's `AlarmRingingService.ACTION_DISMISS` intent -- used by the `stop_ringing`
-    /// Tauri command (invoked from the frontend, which knows which alarm it's ringing screen
-    /// is for) so every dismiss/snooze origin funnels a real id into
-    /// `AlarmManagerPlugin.notifyAlarmDismissed`/`notifySnoozeRequested`, not just the
-    /// notification's own Dismiss/Snooze action. See issue #255 Phase 4A. A separate method
-    /// (rather than an `Option<i32>` parameter on `stop_ringing` itself) because `stop_ringing`
-    /// is also called, with no id, from `apps/threshold/src-tauri/src/lib.rs`'s
-    /// `wear:alarm:dismiss`/`wear:alarm:snooze` listeners -- that call site is out of scope for
-    /// this change, so `stop_ringing`'s existing zero-argument signature stays exactly as-is.
+    /// Same as [`stop_ringing`](Self::stop_ringing), but threads a specific alarm id through to Kotlin's `AlarmRingingService.ACTION_DISMISS` intent -- used by the `stop_ringing` Tauri command (invoked from the frontend, which knows which alarm it's ringing screen is for) so every dismiss/snooze origin funnels a real id into `AlarmManagerPlugin.notifyAlarmDismissed`/`notifySnoozeRequested`, not just the notification's own Dismiss/Snooze action. See issue #255 Phase 4A. A separate method (rather than an `Option<i32>` parameter on `stop_ringing` itself) because `stop_ringing` is also called, with no id, from `apps/threshold/src-tauri/src/lib.rs`'s `wear:alarm:dismiss`/`wear:alarm:snooze` listeners -- that call site is out of scope for this change, so `stop_ringing`'s existing zero-argument signature stays exactly as-is.
     pub fn stop_ringing_for(&self, alarm_id: i32) -> crate::Result<()> {
         self.stop_ringing_request(StopRingingRequest {
             alarm_id: Some(alarm_id),

--- a/plugins/alarm-manager/src/mobile.rs
+++ b/plugins/alarm-manager/src/mobile.rs
@@ -222,10 +222,34 @@ impl<R: Runtime> AlarmManager<R> {
     }
 
     pub fn stop_ringing(&self) -> crate::Result<()> {
+        self.stop_ringing_request(StopRingingRequest { alarm_id: None })
+    }
+
+    /// Same as [`stop_ringing`](Self::stop_ringing), but threads a specific alarm id through
+    /// to Kotlin's `AlarmRingingService.ACTION_DISMISS` intent -- used by the `stop_ringing`
+    /// Tauri command (invoked from the frontend, which knows which alarm it's ringing screen
+    /// is for) so every dismiss/snooze origin funnels a real id into
+    /// `AlarmManagerPlugin.notifyAlarmDismissed`/`notifySnoozeRequested`, not just the
+    /// notification's own Dismiss/Snooze action. See issue #255 Phase 4A. A separate method
+    /// (rather than an `Option<i32>` parameter on `stop_ringing` itself) because `stop_ringing`
+    /// is also called, with no id, from `apps/threshold/src-tauri/src/lib.rs`'s
+    /// `wear:alarm:dismiss`/`wear:alarm:snooze` listeners -- that call site is out of scope for
+    /// this change, so `stop_ringing`'s existing zero-argument signature stays exactly as-is.
+    pub fn stop_ringing_for(&self, alarm_id: i32) -> crate::Result<()> {
+        self.stop_ringing_request(StopRingingRequest {
+            alarm_id: Some(alarm_id),
+        })
+    }
+
+    fn stop_ringing_request(
+        &self,
+        #[cfg_attr(not(target_os = "android"), allow(unused_variables))]
+        payload: StopRingingRequest,
+    ) -> crate::Result<()> {
         #[cfg(target_os = "android")]
         return self
             .handle
-            .run_mobile_plugin("stopRinging", ())
+            .run_mobile_plugin("stopRinging", payload)
             .map_err(Into::into);
 
         #[cfg(not(target_os = "android"))]

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -112,18 +112,7 @@ pub struct CurrentlyRingingAlarm {
     pub id: Option<i32>,
 }
 
-/// Request payload for Kotlin's `stopRinging` command. `alarm_id`, when known, threads the
-/// real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so
-/// `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id for every dismiss origin --
-/// previously only the notification's own Dismiss action carried one, so in-app dismiss
-/// silently produced no native event at all (issue #255 Phase 4A). `None` for callers that
-/// don't know which alarm they're stopping: the legacy ID-less JS notification-action
-/// fallback, and in-app snooze (`stop_ringing`'s single command is shared between dismiss and
-/// snooze, so threading an id through for a snooze would misattribute it as a dismiss -- see
-/// `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning). Omitted (not
-/// sent as JSON `null`) when absent, same reasoning as `PickAlarmSoundOptions` above: Kotlin's
-/// `StopRingingArgs` arg class expects the key to be missing for "no explicit id", not
-/// present-but-null.
+/// Request payload for Kotlin's `stopRinging` command. `alarm_id`, when known, threads the real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id for every dismiss origin -- previously only the notification's own Dismiss action carried one, so in-app dismiss silently produced no native event at all (issue #255 Phase 4A). `None` for callers that don't know which alarm they're stopping: the legacy ID-less JS notification-action fallback, and in-app snooze (`stop_ringing`'s single command is shared between dismiss and snooze, so threading an id through for a snooze would misattribute it as a dismiss -- see `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning). Omitted (not sent as JSON `null`) when absent, same reasoning as `PickAlarmSoundOptions` above: Kotlin's `StopRingingArgs` arg class expects the key to be missing for "no explicit id", not present-but-null.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StopRingingRequest {

--- a/plugins/alarm-manager/src/models.rs
+++ b/plugins/alarm-manager/src/models.rs
@@ -112,6 +112,25 @@ pub struct CurrentlyRingingAlarm {
     pub id: Option<i32>,
 }
 
+/// Request payload for Kotlin's `stopRinging` command. `alarm_id`, when known, threads the
+/// real alarm id through to `AlarmRingingService`'s `ACTION_DISMISS` intent so
+/// `AlarmManagerPlugin.notifyAlarmDismissed` gets a usable id for every dismiss origin --
+/// previously only the notification's own Dismiss action carried one, so in-app dismiss
+/// silently produced no native event at all (issue #255 Phase 4A). `None` for callers that
+/// don't know which alarm they're stopping: the legacy ID-less JS notification-action
+/// fallback, and in-app snooze (`stop_ringing`'s single command is shared between dismiss and
+/// snooze, so threading an id through for a snooze would misattribute it as a dismiss -- see
+/// `resolveStopRingingAlarmId`'s KDoc on the Kotlin side for the full reasoning). Omitted (not
+/// sent as JSON `null`) when absent, same reasoning as `PickAlarmSoundOptions` above: Kotlin's
+/// `StopRingingArgs` arg class expects the key to be missing for "no explicit id", not
+/// present-but-null.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StopRingingRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alarm_id: Option<i32>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What this is

Phase 4A of #255's implementation plan — alarm-manager's side of "symmetric stop signals" (dismiss/snooze propagating natively in both directions without waiting for Rust to boot, the same pattern Phase 3 established for the fired→ring path). No dedup tags needed here (per decision 4: a double-delivered *stop* is benign, only the *ring* needed tags).

Also closes a real, independently-verified gap: **in-app dismiss previously sent no native dismiss event at all.**

## What's here

- Threaded the real alarm id through the entire in-app dismiss path (TS `Ringing.tsx` → `guest-js` → Rust → Kotlin), explicit id-passing from the TS layer rather than a Kotlin-side fallback — the fallback would have corrupted in-app snooze, since `stopRinging`'s single Kotlin command always sends `ACTION_DISMISS` regardless of dismiss vs. snooze intent (documented in code).
- Every dismiss origin now publishes `alarm-manager:dismiss-requested` uniformly (the old "only notification-action dismisses publish" special case is gone, since every origin now produces a real id).
- alarm-manager's own init `ContentProvider` (`WatchStopInitProvider`/`WatchStopListener`) subscribes to `wear:alarm:dismiss`/`wear:alarm:snooze` and stops `AlarmRingingService` natively on a watch-originated stop, mirroring wear-sync's own Phase 3B pattern.
- The Test Alarm sound-preview flow (sentinel id 999) is excluded from the new native round-trip, matching its pre-existing local-only behaviour.

## ⚠️ Known issue, fix incoming in the next PR in this stack

Making dismiss publish uniformly surfaced a real bug this PR does **not** fix: `AlarmCoordinator::dismiss_alarm` (Rust) is not idempotent — it recomputes `next_trigger` relative to whatever's currently stored, with no guard. In-app dismiss now reaches it twice (the direct TS command, plus the newly-uniform native round trip), which for a repeating alarm can silently skip an entire occurrence. This was caught during implementation, verified by code review, and is being fixed in a follow-up PR in this same stack (Rust-core change, out of this PR's scope) rather than patched around here.

## Testing checklist (automated, no device needed)

- [x] Kotlin JUnit 51/51
- [x] `cargo check --workspace`, `cargo test -p tauri-plugin-alarm-manager` 5/5, `cargo test -p threshold --lib alarm::` 44/44
- [x] `pnpm -r run typecheck`, `pnpm --filter threshold test` 86/86

## Review status

Reviewed via `/code-review high`. Confirmed the dismiss_alarm idempotency finding (see above) and found the Test Alarm preview regression (fixed). Both are documented; the idempotency issue is tracked as a follow-up in this stack rather than silently worked around.

Stacked on #300. Part of #255.