### PR TITLE
Propagate dismiss/snooze natively in both directions (wear-sync)

### DIFF
--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
@@ -125,7 +125,7 @@ object NativeFiredListener {
             is24HourKnown = is24HourKnown,
         )
 
-        sendAlarmRingToConnectedNodes(context, payload, TAG)
+        sendWatchMessageToConnectedNodes(context, MSG_PATH_ALARM_RING, payload, TAG, "alarm ring")
     }
 }
 

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
@@ -9,8 +9,6 @@ import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -64,14 +62,13 @@ internal const val STALENESS_WINDOW_MS = 90_000L
 object NativeFiredListener {
 
     // A dedicated scope, not WearSyncPlugin's -- this listener can run (and does run, by
-    // design) before any WearSyncPlugin instance exists.
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // design) before any WearSyncPlugin instance exists. See NativeListenerSupport's KDoc for
+    // why this and the registration below are factored out rather than hand-rolled here.
+    private val scope: CoroutineScope = NativeListenerSupport.ioScope()
 
     /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
     fun register(context: Context) {
-        val appContext = context.applicationContext
-        NativeEventBus.subscribe(TOPIC_FIRED) { payload -> handle(appContext, payload) }
-        Log.d(TAG, "Registered native fired listener for topic '$TOPIC_FIRED'")
+        NativeListenerSupport.subscribe(context, TAG, TOPIC_FIRED, ::handle)
     }
 
     /**

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeFiredListener.kt
@@ -8,8 +8,6 @@ package ca.liminalhq.threshold.wearsync
 import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 private const val TAG = "NativeFiredListener"
@@ -44,27 +42,23 @@ internal const val STALENESS_WINDOW_MS = 90_000L
  * plus snooze/time-format prefs) -- no Rust involvement needed. See [NativeEventBus]'s KDoc
  * for the threading contract this object's [handle] function must honour: it does only
  * cheap, synchronous work inline (parse, staleness check, toggle check) and hands the actual
- * network I/O off to [scope], returning [TAG_WATCH_RING] once that work is *initiated*, not
- * once it's confirmed delivered -- at-least-once semantics, per the contract doc's decision:
- * stamping the tag after confirmation would risk a crash mid-send leaving the watch silent
- * with no fallback, which is the exact failure this whole design exists to prevent.
+ * network I/O off to [NativeAlarmSerialExecutor], returning [TAG_WATCH_RING] once that work is
+ * *submitted*, not once it's confirmed delivered -- at-least-once semantics, per the contract
+ * doc's decision: stamping the tag after confirmation would risk a crash mid-send leaving the
+ * watch silent with no fallback, which is the exact failure this whole design exists to
+ * prevent.
  *
  * The toggle check specifically has to stay *synchronous* despite that contract, since
  * [handle]'s return value (whether it claims [TAG_WATCH_RING]) has to reflect whether native
- * fan-out is actually disabled -- deferring that decision into [scope] would mean returning
- * the tag optimistically, which would make the Rust-side gate skip its own ring too and drop
- * the ring entirely whenever the toggle is off. [NativeFanOutPrefs] resolves the tension by
- * caching the toggle's value in memory, warmed once by [WearRingInitProvider.onCreate] before
+ * fan-out is actually disabled -- deferring that decision into the submitted task would mean
+ * returning the tag optimistically, which would make the Rust-side gate skip its own ring too
+ * and drop the ring entirely whenever the toggle is off. [NativeFanOutPrefs] resolves the
+ * tension by caching the toggle's value in memory, warmed once by [WearRingInitProvider.onCreate] before
  * this listener is even registered -- see its KDoc -- so by the time [handle] can possibly
  * run, the "synchronous" check is a plain volatile-field read, not a `SharedPreferences` disk
  * hit.
  */
 object NativeFiredListener {
-
-    // A dedicated scope, not WearSyncPlugin's -- this listener can run (and does run, by
-    // design) before any WearSyncPlugin instance exists. See NativeListenerSupport's KDoc for
-    // why this and the registration below are factored out rather than hand-rolled here.
-    private val scope: CoroutineScope = NativeListenerSupport.ioScope()
 
     /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
     fun register(context: Context) {
@@ -93,7 +87,11 @@ object NativeFiredListener {
             return null
         }
 
-        scope.launch {
+        // Submitted through the per-alarm-id serial queue (issue #255 Phase 4B code review),
+        // not a plain scope.launch(Dispatchers.IO) -- see NativeAlarmSerialExecutor's KDoc for
+        // why routing both this send and NativeStopListener's dismiss/snooze send for the same
+        // id through one shared queue is what keeps this one strictly ordered ahead of it.
+        NativeAlarmSerialExecutor.submit(fired.id) {
             try {
                 ringWatch(context, fired.id)
             } catch (e: Exception) {

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeListenerSupport.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeListenerSupport.kt
@@ -1,4 +1,4 @@
-// Shared "dedicated IO scope + NativeEventBus subscription" boilerplate for in-process listeners
+// Shared NativeEventBus subscription boilerplate, plus the per-alarm-id serial task queue in-process listeners send through
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
@@ -8,26 +8,25 @@ package ca.liminalhq.threshold.wearsync
 import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+private const val TAG = "NativeAlarmSerialExecutor"
 
 /**
  * Factors out the shape [NativeFiredListener] (issue #255 Phase 3B) and [NativeStopListener]
- * (Phase 4B) were duplicating verbatim: a dedicated [CoroutineScope] for a listener's async
- * work, plus the "subscribe to a topic and log the registration" pair each listener's own
- * `register()` repeated once per topic (issue #255 Phase 4B code review). Any future
- * `NativeEventBus` listener built on this same pattern should use both helpers below rather
- * than hand-rolling either again.
+ * (Phase 4B) were duplicating verbatim: the "subscribe to a topic and log the registration"
+ * pair each listener's own `register()` repeated once per topic (issue #255 Phase 4B code
+ * review). Any future `NativeEventBus` listener built on this same pattern should use
+ * [subscribe] rather than hand-rolling it again. Async work itself (previously each listener's
+ * own dedicated [CoroutineScope], now routed through [NativeAlarmSerialExecutor] instead) is
+ * covered separately below -- see its own KDoc.
  */
 internal object NativeListenerSupport {
-
-    /**
-     * Builds a fresh dedicated [CoroutineScope] for a listener's async work -- never
-     * [WearSyncPlugin]'s own scope, since these listeners can run (and are designed to run)
-     * before any [WearSyncPlugin] instance exists.
-     */
-    fun ioScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Subscribes [handler] to [topic] on [NativeEventBus], passing [context]'s application
@@ -39,5 +38,83 @@ internal object NativeListenerSupport {
         val appContext = context.applicationContext
         NativeEventBus.subscribe(topic) { payload -> handler(appContext, payload) }
         Log.d(tag, "Registered native listener for topic '$topic'")
+    }
+}
+
+/**
+ * Per-alarm-id serial task queues used to keep [NativeFiredListener]'s ring send and
+ * [NativeStopListener]'s dismiss/snooze send correctly ordered for the SAME alarm id (issue
+ * #255 Phase 4B code review). Both listeners used to launch their actual Play Services send on
+ * their own dedicated `Dispatchers.IO`-backed [CoroutineScope], independently of one another --
+ * with no shared serialization, a stop send launched immediately after a fired send could be
+ * scheduled onto a different `Dispatchers.IO` worker thread and complete first (during the
+ * fired send's cache read, node discovery, or the Play Services call itself), so the watch
+ * would see "stop" before "fired", safely no-op the early stop, then start ringing anyway once
+ * "fired" finally arrives.
+ *
+ * A plain `CoroutineDispatcher.limitedParallelism(1)` is *not* sufficient here, despite being
+ * the usual kotlinx.coroutines idiom for a serial executor: it only limits how many coroutine
+ * bodies may be *actively running* on that dispatcher at once, not the order full tasks
+ * complete in. A task that suspends partway through (e.g. the `await()` calls inside
+ * [sendWatchMessageToConnectedNodes]) frees up its "slot" while suspended, so a second task
+ * dispatched afterwards can run to completion *during* that suspension and finish first --
+ * exactly the interleaving this needs to prevent, not just literal thread-parallelism.
+ *
+ * [submit] instead runs each alarm id's tasks through a dedicated single-consumer [Channel]:
+ * offering a task ([Channel.trySend], which for an unlimited-capacity channel always succeeds
+ * synchronously on the calling thread) is what actually establishes the ordering, and a single
+ * background coroutine per alarm id drains the channel with `for (task in channel)`, `await`ing
+ * each task's full completion -- suspension points included -- before receiving the next. As
+ * long as the fired handler's [submit] call happens (in wall-clock/call order) before the stop
+ * handler's -- true here, since a user can only dismiss/snooze an alarm that has already fired
+ * -- the fired task is offered first and the stop task cannot start, let alone finish, ahead of
+ * it, regardless of which one's send happens to suspend longer.
+ *
+ * Deliberately scoped per alarm id, not one queue for every alarm: unrelated alarms' native
+ * sends must never block on each other just because they happen to be in flight at the same
+ * time.
+ *
+ * Neither the channel map nor its per-id consumer coroutines are ever torn down. Alarm ids are
+ * a small, bounded set (a user's actual alarms), so this is a handful of long-lived queue/
+ * coroutine pairs for the life of the process, not an unbounded leak.
+ */
+internal object NativeAlarmSerialExecutor {
+
+    private val queues = ConcurrentHashMap<Int, Channel<suspend () -> Unit>>()
+
+    /**
+     * Submits [block] to run for [alarmId], strictly after any block already submitted for the
+     * same [alarmId] has fully finished (including its own suspension points) and strictly
+     * before any block submitted for [alarmId] afterwards. Unrelated alarm ids run fully
+     * independently of one another and of this call, which returns immediately without waiting
+     * for [block] to run.
+     */
+    fun submit(alarmId: Int, block: suspend () -> Unit) {
+        val channel = queues.getOrPut(alarmId) { startQueue() }
+        val offered = channel.trySend(block).isSuccess
+        check(offered) { "Unexpected failure offering onto an unlimited-capacity channel" }
+    }
+
+    /**
+     * Starts a fresh unlimited-capacity [Channel] plus the single background coroutine that
+     * drains it -- always one consumer per channel, so items are only ever processed one at a
+     * time, strictly in the order [submit] offered them.
+     */
+    private fun startQueue(): Channel<suspend () -> Unit> {
+        val channel = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            for (task in channel) {
+                try {
+                    task()
+                } catch (e: Throwable) {
+                    // Callers (NativeFiredListener/NativeStopListener) already catch their own
+                    // Exceptions and log them -- this is defensive only, so one caller's bug
+                    // can't cancel this coroutine and silently stop draining this alarm id's
+                    // queue for the rest of the process.
+                    Log.e(TAG, "Unhandled exception in a NativeAlarmSerialExecutor task", e)
+                }
+            }
+        }
+        return channel
     }
 }

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeListenerSupport.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeListenerSupport.kt
@@ -1,0 +1,43 @@
+// Shared "dedicated IO scope + NativeEventBus subscription" boilerplate for in-process listeners
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.Context
+import android.util.Log
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Factors out the shape [NativeFiredListener] (issue #255 Phase 3B) and [NativeStopListener]
+ * (Phase 4B) were duplicating verbatim: a dedicated [CoroutineScope] for a listener's async
+ * work, plus the "subscribe to a topic and log the registration" pair each listener's own
+ * `register()` repeated once per topic (issue #255 Phase 4B code review). Any future
+ * `NativeEventBus` listener built on this same pattern should use both helpers below rather
+ * than hand-rolling either again.
+ */
+internal object NativeListenerSupport {
+
+    /**
+     * Builds a fresh dedicated [CoroutineScope] for a listener's async work -- never
+     * [WearSyncPlugin]'s own scope, since these listeners can run (and are designed to run)
+     * before any [WearSyncPlugin] instance exists.
+     */
+    fun ioScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Subscribes [handler] to [topic] on [NativeEventBus], passing [context]'s application
+     * context through (never the raw [context] itself, in case it's an `Activity` or other
+     * short-lived component), and logs the registration under [tag]. See [NativeEventBus]'s
+     * own KDoc for the threading contract [handler] must honour.
+     */
+    fun subscribe(context: Context, tag: String, topic: String, handler: (Context, String) -> String?) {
+        val appContext = context.applicationContext
+        NativeEventBus.subscribe(topic) { payload -> handler(appContext, payload) }
+        Log.d(tag, "Registered native listener for topic '$topic'")
+    }
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
@@ -9,8 +9,6 @@ import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -22,10 +20,6 @@ private const val TAG = "NativeStopListener"
 // two plugins are separate Gradle modules with no shared Kotlin symbol between them.
 internal const val TOPIC_DISMISS_REQUESTED = "alarm-manager:dismiss-requested"
 internal const val TOPIC_SNOOZE_REQUESTED = "alarm-manager:snooze-requested"
-
-// Fallback used only when no cached snooze length is available (see handleSnooze) -- matches
-// AlarmSnoozeRequest.snoozeLengthMinutes's own default in WearSyncPlugin.kt.
-private const val DEFAULT_SNOOZE_LENGTH_MINUTES = 10
 
 /**
  * Registers with [NativeEventBus] for alarm-manager's `alarm-manager:dismiss-requested` and
@@ -53,61 +47,69 @@ private const val DEFAULT_SNOOZE_LENGTH_MINUTES = 10
 object NativeStopListener {
 
     // A dedicated scope, not WearSyncPlugin's -- same reasoning as NativeFiredListener's: this
-    // listener can run (and does run, by design) before any WearSyncPlugin instance exists.
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // listener can run (and does run, by design) before any WearSyncPlugin instance exists. See
+    // NativeListenerSupport's KDoc for why this and the registration below are factored out
+    // rather than hand-rolled here.
+    private val scope: CoroutineScope = NativeListenerSupport.ioScope()
 
     /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
     fun register(context: Context) {
-        val appContext = context.applicationContext
-        NativeEventBus.subscribe(TOPIC_DISMISS_REQUESTED) { payload -> handleDismiss(appContext, payload) }
-        NativeEventBus.subscribe(TOPIC_SNOOZE_REQUESTED) { payload -> handleSnooze(appContext, payload) }
-        Log.d(
-            TAG,
-            "Registered native stop listener for topics '$TOPIC_DISMISS_REQUESTED', '$TOPIC_SNOOZE_REQUESTED'",
-        )
+        NativeListenerSupport.subscribe(context, TAG, TOPIC_DISMISS_REQUESTED, ::handleDismiss)
+        NativeListenerSupport.subscribe(context, TAG, TOPIC_SNOOZE_REQUESTED, ::handleSnooze)
     }
 
     /**
      * The [NativeEventBus] listener callback for [TOPIC_DISMISS_REQUESTED]. `internal` (not
-     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle].
+     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle]. Thin
+     * wrapper around [handleStop] -- see its KDoc for why dismiss/snooze share one
+     * parse/launch/send/catch shape here.
      */
-    internal fun handleDismiss(context: Context, payload: String): String? {
-        val alarmId = parseIdPayload(payload)
-        if (alarmId == null) {
-            Log.w(TAG, "Ignoring malformed '$TOPIC_DISMISS_REQUESTED' payload")
-            return null
+    internal fun handleDismiss(context: Context, payload: String): String? =
+        handleStop(context, payload, TOPIC_DISMISS_REQUESTED, MSG_PATH_ALARM_DISMISS, "alarm dismiss") { _, alarmId ->
+            buildAlarmDismissPayload(alarmId)
         }
-
-        scope.launch {
-            try {
-                val messagePayload = buildAlarmDismissPayload(alarmId)
-                sendWatchMessageToConnectedNodes(context, MSG_PATH_ALARM_DISMISS, messagePayload, TAG, "alarm dismiss")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to send dismiss to watch natively for id=$alarmId", e)
-            }
-        }
-        return null
-    }
 
     /**
      * The [NativeEventBus] listener callback for [TOPIC_SNOOZE_REQUESTED]. `internal` (not
-     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle].
+     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle]. Thin
+     * wrapper around [handleStop] -- see its KDoc for why dismiss/snooze share one
+     * parse/launch/send/catch shape here.
      */
-    internal fun handleSnooze(context: Context, payload: String): String? {
+    internal fun handleSnooze(context: Context, payload: String): String? =
+        handleStop(context, payload, TOPIC_SNOOZE_REQUESTED, MSG_PATH_ALARM_SNOOZE, "alarm snooze") { ctx, alarmId ->
+            val cached = WearSyncCache.read(ctx)
+            val snoozeLengthMinutes = cached?.third ?: DEFAULT_SNOOZE_LENGTH_MINUTES
+            buildAlarmSnoozePayload(alarmId, snoozeLengthMinutes)
+        }
+
+    /**
+     * The shape [handleDismiss] and [handleSnooze] were duplicating verbatim (issue #255 Phase
+     * 4B code review): parse [payload]'s `{id}`, log and bail on anything malformed, otherwise
+     * launch onto [scope] to build the wire payload (via [buildMessagePayload], the one part
+     * that actually differs between dismiss and snooze -- dismiss needs only the id, snooze
+     * also needs the cached snooze length) and send it at [msgPath] via
+     * [sendWatchMessageToConnectedNodes], logging any failure under [logLabel].
+     */
+    private fun handleStop(
+        context: Context,
+        payload: String,
+        topic: String,
+        msgPath: String,
+        logLabel: String,
+        buildMessagePayload: (Context, Int) -> ByteArray,
+    ): String? {
         val alarmId = parseIdPayload(payload)
         if (alarmId == null) {
-            Log.w(TAG, "Ignoring malformed '$TOPIC_SNOOZE_REQUESTED' payload")
+            Log.w(TAG, "Ignoring malformed '$topic' payload")
             return null
         }
 
         scope.launch {
             try {
-                val cached = WearSyncCache.read(context)
-                val snoozeLengthMinutes = cached?.third ?: DEFAULT_SNOOZE_LENGTH_MINUTES
-                val messagePayload = buildAlarmSnoozePayload(alarmId, snoozeLengthMinutes)
-                sendWatchMessageToConnectedNodes(context, MSG_PATH_ALARM_SNOOZE, messagePayload, TAG, "alarm snooze")
+                val messagePayload = buildMessagePayload(context, alarmId)
+                sendWatchMessageToConnectedNodes(context, msgPath, messagePayload, TAG, logLabel)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to send snooze to watch natively for id=$alarmId", e)
+                Log.e(TAG, "Failed to send $logLabel to watch natively for id=$alarmId", e)
             }
         }
         return null

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
@@ -8,8 +8,6 @@ package ca.liminalhq.threshold.wearsync
 import android.content.Context
 import android.util.Log
 import ca.liminalhq.threshold.nativebus.NativeEventBus
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 private const val TAG = "NativeStopListener"
@@ -46,12 +44,6 @@ internal const val TOPIC_SNOOZE_REQUESTED = "alarm-manager:snooze-requested"
  */
 object NativeStopListener {
 
-    // A dedicated scope, not WearSyncPlugin's -- same reasoning as NativeFiredListener's: this
-    // listener can run (and does run, by design) before any WearSyncPlugin instance exists. See
-    // NativeListenerSupport's KDoc for why this and the registration below are factored out
-    // rather than hand-rolled here.
-    private val scope: CoroutineScope = NativeListenerSupport.ioScope()
-
     /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
     fun register(context: Context) {
         NativeListenerSupport.subscribe(context, TAG, TOPIC_DISMISS_REQUESTED, ::handleDismiss)
@@ -85,10 +77,10 @@ object NativeStopListener {
     /**
      * The shape [handleDismiss] and [handleSnooze] were duplicating verbatim (issue #255 Phase
      * 4B code review): parse [payload]'s `{id}`, log and bail on anything malformed, otherwise
-     * launch onto [scope] to build the wire payload (via [buildMessagePayload], the one part
-     * that actually differs between dismiss and snooze -- dismiss needs only the id, snooze
-     * also needs the cached snooze length) and send it at [msgPath] via
-     * [sendWatchMessageToConnectedNodes], logging any failure under [logLabel].
+     * submit a task to [NativeAlarmSerialExecutor] to build the wire payload (via
+     * [buildMessagePayload], the one part that actually differs between dismiss and snooze --
+     * dismiss needs only the id, snooze also needs the cached snooze length) and send it at
+     * [msgPath] via [sendWatchMessageToConnectedNodes], logging any failure under [logLabel].
      */
     private fun handleStop(
         context: Context,
@@ -104,7 +96,12 @@ object NativeStopListener {
             return null
         }
 
-        scope.launch {
+        // Submitted through the per-alarm-id serial queue (issue #255 Phase 4B code review),
+        // not a plain scope.launch(Dispatchers.IO) -- the same queue NativeFiredListener's ring
+        // send for this id submits to, so a stop submitted immediately after a fire can never
+        // start (let alone finish) ahead of that fire's own send. See
+        // NativeAlarmSerialExecutor's KDoc for the ordering guarantee this relies on.
+        NativeAlarmSerialExecutor.submit(alarmId) {
             try {
                 val messagePayload = buildMessagePayload(context, alarmId)
                 sendWatchMessageToConnectedNodes(context, msgPath, messagePayload, TAG, logLabel)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/NativeStopListener.kt
@@ -1,0 +1,135 @@
+// In-process listener that stops the watch ringing the instant dismiss/snooze happens on the phone, before Rust boots
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import android.content.Context
+import android.util.Log
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+
+private const val TAG = "NativeStopListener"
+
+// Mirrors alarm-manager's own topic constants for its phone-notification Dismiss/Snooze
+// actions (issue #255 Phase 4A, alarm-manager's own init ContentProvider) -- duplicated
+// rather than shared for the same reason NativeFiredListener's TOPIC_FIRED is duplicated: the
+// two plugins are separate Gradle modules with no shared Kotlin symbol between them.
+internal const val TOPIC_DISMISS_REQUESTED = "alarm-manager:dismiss-requested"
+internal const val TOPIC_SNOOZE_REQUESTED = "alarm-manager:snooze-requested"
+
+// Fallback used only when no cached snooze length is available (see handleSnooze) -- matches
+// AlarmSnoozeRequest.snoozeLengthMinutes's own default in WearSyncPlugin.kt.
+private const val DEFAULT_SNOOZE_LENGTH_MINUTES = 10
+
+/**
+ * Registers with [NativeEventBus] for alarm-manager's `alarm-manager:dismiss-requested` and
+ * `alarm-manager:snooze-requested` topics and sends the corresponding stop message to every
+ * connected watch node directly via Play Services, entirely natively -- no dependency on Rust
+ * or the WebView having booted. This is issue #255 Phase 4B's "phone notification while cold"
+ * half of symmetric stop signals: the counterpart to [NativeFiredListener], but for the
+ * dismiss/snooze-stops-the-watch direction rather than fired-starts-the-watch.
+ * [WearRingInitProvider]'s `onCreate()` registers this listener the same way it registers
+ * [NativeFiredListener], so it is live before `AlarmRingingService`'s own notification
+ * Dismiss/Snooze actions can post through alarm-manager's channel.
+ *
+ * Unlike [NativeFiredListener], this listener claims no tag on [NativeEventBus.publish] and
+ * applies no staleness/dedup gate: per issue #255's design decision 4, a double-delivered
+ * *stop* signal is benign (the watch already safely no-ops a dismiss/snooze for an alarm it
+ * isn't actively ringing), so there is no failure mode here symmetric to the fired path's
+ * "ring the watch twice" that a tag would need to guard against.
+ *
+ * Builds the outgoing message from alarm-manager's `{id}` payload plus, for snooze,
+ * [WearSyncCache]'s cached `snoozeLengthMinutes` (the bus payload itself doesn't carry it), and
+ * sends it with [sendWatchMessageToConnectedNodes] -- the same shared Play Services send-loop
+ * [NativeFiredListener] and [WearSyncPlugin.sendAlarmRing] already use, not a third hand-rolled
+ * copy of the "iterate connected nodes, send message" loop.
+ */
+object NativeStopListener {
+
+    // A dedicated scope, not WearSyncPlugin's -- same reasoning as NativeFiredListener's: this
+    // listener can run (and does run, by design) before any WearSyncPlugin instance exists.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Registers this listener with [NativeEventBus]. Called once from [WearRingInitProvider.onCreate]. */
+    fun register(context: Context) {
+        val appContext = context.applicationContext
+        NativeEventBus.subscribe(TOPIC_DISMISS_REQUESTED) { payload -> handleDismiss(appContext, payload) }
+        NativeEventBus.subscribe(TOPIC_SNOOZE_REQUESTED) { payload -> handleSnooze(appContext, payload) }
+        Log.d(
+            TAG,
+            "Registered native stop listener for topics '$TOPIC_DISMISS_REQUESTED', '$TOPIC_SNOOZE_REQUESTED'",
+        )
+    }
+
+    /**
+     * The [NativeEventBus] listener callback for [TOPIC_DISMISS_REQUESTED]. `internal` (not
+     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle].
+     */
+    internal fun handleDismiss(context: Context, payload: String): String? {
+        val alarmId = parseIdPayload(payload)
+        if (alarmId == null) {
+            Log.w(TAG, "Ignoring malformed '$TOPIC_DISMISS_REQUESTED' payload")
+            return null
+        }
+
+        scope.launch {
+            try {
+                val messagePayload = buildAlarmDismissPayload(alarmId)
+                sendWatchMessageToConnectedNodes(context, MSG_PATH_ALARM_DISMISS, messagePayload, TAG, "alarm dismiss")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send dismiss to watch natively for id=$alarmId", e)
+            }
+        }
+        return null
+    }
+
+    /**
+     * The [NativeEventBus] listener callback for [TOPIC_SNOOZE_REQUESTED]. `internal` (not
+     * `private`) so tests can drive it directly, mirroring [NativeFiredListener.handle].
+     */
+    internal fun handleSnooze(context: Context, payload: String): String? {
+        val alarmId = parseIdPayload(payload)
+        if (alarmId == null) {
+            Log.w(TAG, "Ignoring malformed '$TOPIC_SNOOZE_REQUESTED' payload")
+            return null
+        }
+
+        scope.launch {
+            try {
+                val cached = WearSyncCache.read(context)
+                val snoozeLengthMinutes = cached?.third ?: DEFAULT_SNOOZE_LENGTH_MINUTES
+                val messagePayload = buildAlarmSnoozePayload(alarmId, snoozeLengthMinutes)
+                sendWatchMessageToConnectedNodes(context, MSG_PATH_ALARM_SNOOZE, messagePayload, TAG, "alarm snooze")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send snooze to watch natively for id=$alarmId", e)
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * Parses the `{id}` JSON payload alarm-manager publishes to [NativeEventBus] for both
+ * [TOPIC_DISMISS_REQUESTED] and [TOPIC_SNOOZE_REQUESTED] (see [NativeStopListener]'s KDoc).
+ * Returns `null` for anything malformed or missing a usable positive `id`, mirroring
+ * [parseFiredPayload]'s tolerance -- a corrupt payload is silently skipped (logged by the
+ * caller) rather than crashing [NativeEventBus.publish]'s caller.
+ *
+ * A pure function of the raw payload string so it's unit-testable without any Android
+ * framework class, same as [parseFiredPayload].
+ */
+internal fun parseIdPayload(payload: String): Int? {
+    return try {
+        val json = JSONObject(payload)
+        val id = json.optInt("id", -1)
+        if (id <= 0) null else id
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
@@ -51,6 +51,38 @@ internal const val TOPIC_WEAR_ALARM_DISMISS = "wear:alarm:dismiss"
 internal const val TOPIC_WEAR_ALARM_SNOOZE = "wear:alarm:snooze"
 
 /**
+ * Which [NativeEventBus] topic (if any) a watch-originated message at [path] should publish
+ * onto when Rust's pipeline isn't ready to act on it promptly -- `null` for every path with no
+ * native listener (sync/save/delete). Factored out as a pure function of [path] alone (issue
+ * #255 Phase 4B code review) so [onMessageReceived]'s "plugin loaded but pipeline not ready"
+ * branch, and the offline branch's existing `busTopic` arguments, both derive the mapping from
+ * one place instead of repeating the `PATH_ALARM_DISMISS`/`PATH_ALARM_SNOOZE` -> topic pairing.
+ */
+internal fun nativeStopBusTopic(path: String): String? = when (path) {
+    PATH_ALARM_DISMISS -> TOPIC_WEAR_ALARM_DISMISS
+    PATH_ALARM_SNOOZE -> TOPIC_WEAR_ALARM_SNOOZE
+    else -> null
+}
+
+/**
+ * Publishes [data] onto [NativeEventBus] for a watch-originated message at [path] if
+ * [pipelineReady] is `false` -- the "[WearSyncPlugin] instance already loaded, but Rust's
+ * pipeline isn't marked ready yet" half of the reachability fix (issue #255 Phase 4B code
+ * review), factored out of [WearMessageService.onMessageReceived]'s `plugin != null` branch so
+ * it's unit-testable without a live [WearableListenerService] instance, mirroring
+ * [enqueueOfflineWrite]'s existing precedent for the plugin-not-loaded-at-all case.
+ *
+ * A no-op for [path]s with no native listener ([nativeStopBusTopic] returns `null`) or once
+ * [pipelineReady] is `true` -- the normal, fully-booted case, where the message flows to Rust
+ * promptly through the usual [WearSyncPlugin.onWatchMessage] channel and there's nothing left
+ * for this signal to race.
+ */
+internal fun publishNativeStopBusIfPipelineNotReady(path: String, data: String, pipelineReady: Boolean) {
+    if (pipelineReady) return
+    nativeStopBusTopic(path)?.let { topic -> NativeEventBus.publish(topic, data) }
+}
+
+/**
  * Receives messages from the watch via the Wear Data Layer and routes
  * them to [WearSyncPlugin] for forwarding to the Rust sync pipeline.
  *
@@ -88,10 +120,20 @@ class WearMessageService : WearableListenerService() {
         NativeEventLog.log(
             applicationContext,
             TAG,
-            "Message received path=$path, pluginLoaded=${plugin != null}, channelReady=${plugin?.isChannelReady}",
+            "Message received path=$path, pluginLoaded=${plugin != null}, channelReady=${plugin?.isChannelReady}, pipelineReady=${plugin?.isPipelineReady}",
         )
         if (plugin != null) {
-            // Normal path: plugin is loaded, route through Tauri events
+            // Normal path: plugin is loaded, route through Tauri events. But a loaded plugin
+            // instance doesn't by itself mean Rust is ready to act on the message promptly --
+            // load() sets `instance` well before Rust finishes booting, registers its own watch
+            // listeners, and calls markWatchPipelineReady(). If the pipeline isn't ready yet,
+            // this is the same "Rust can't act on this right now" situation the offline branch
+            // below handles for dismiss/snooze via its own busTopic publish -- publish here too
+            // (issue #255 Phase 4B code review), rather than silently only queueing the command
+            // and leaving the native-bus stop signal (and WatchStopListener, which is registered
+            // independently of plugin/Rust state -- see WearRingInitProvider) unreachable for
+            // this whole startup window.
+            publishNativeStopBusIfPipelineNotReady(path, data, plugin.isPipelineReady)
             when (path) {
                 PATH_SYNC_REQUEST,
                 PATH_SAVE_ALARM,

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
@@ -38,6 +38,15 @@ private const val WATCH_LOG_FILE_NAME = "Threshold-watch.log"
 // (Phase 4A, a sibling worktree) can subscribe using the same vocabulary the rest of this
 // codebase already uses for "a watch dismiss/snooze happened", and stop the phone's local
 // ringing service immediately without waiting for Rust to boot and drain the durable queue.
+//
+// Payload key note (issue #255 Phase 4B code review): the payload published on these two
+// topics is [data] verbatim -- the raw watch-originated message straight off the wire, in the
+// watch's own `WearDataLayerClient.sendDismissAlarm`/`sendSnoozeAlarm` shape, which keys the
+// alarm id as `"alarmId"` (that wire format predates issue #255 and isn't being changed here).
+// This is *not* the same convention as alarm-manager's own `alarm-manager:dismiss-requested`/
+// `snooze-requested` topics (Phase 4A, consumed by NativeStopListener in this same file's
+// sibling), whose new `{id}` payload keys the alarm id as `"id"`. Don't assume the two topic
+// pairs share a payload shape just because they're both native-bus dismiss/snooze signals.
 internal const val TOPIC_WEAR_ALARM_DISMISS = "wear:alarm:dismiss"
 internal const val TOPIC_WEAR_ALARM_SNOOZE = "wear:alarm:snooze"
 
@@ -237,6 +246,10 @@ class WearMessageService : WearableListenerService() {
  * No dedup tag is threaded back from [NativeEventBus.publish]'s return value here, unlike the
  * fired path's `handled_natively` -- per the #255 design's decision 4, a double-delivered
  * *stop* signal is benign, so there's nothing for a tag to gate.
+ *
+ * [data] is republished onto [busTopic] byte-for-byte, unparsed -- see [TOPIC_WEAR_ALARM_DISMISS]'s
+ * KDoc for the resulting payload's `"alarmId"` key, which a subscriber must not confuse with
+ * alarm-manager's own `"id"`-keyed topics.
  */
 internal fun enqueueOfflineWrite(queue: WearSyncEventQueue, path: String, data: String, busTopic: String?) {
     queue.enqueue(path, data)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearMessageService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.Build
 import android.util.Log
 import java.io.File
+import ca.liminalhq.threshold.nativebus.NativeEventBus
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.MessageEvent
 import com.google.android.gms.wearable.PutDataMapRequest
@@ -29,6 +30,16 @@ private const val PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
 private const val PATH_LOG_RESPONSE = "/threshold/log_response"
 private const val DATA_PATH_ALARMS = "/threshold/alarms"
 private const val WATCH_LOG_FILE_NAME = "Threshold-watch.log"
+
+// NativeEventBus topics published alongside the durable-queue enqueue below when a watch
+// dismiss/snooze arrives offline (issue #255 Phase 4B) -- exact names match the Tauri event
+// names `handle_watch_message` (wear-sync's src/lib.rs) already emits for these once Rust *is*
+// booted (`wear:alarm:dismiss`/`wear:alarm:snooze`), so alarm-manager's own native listener
+// (Phase 4A, a sibling worktree) can subscribe using the same vocabulary the rest of this
+// codebase already uses for "a watch dismiss/snooze happened", and stop the phone's local
+// ringing service immediately without waiting for Rust to boot and drain the durable queue.
+internal const val TOPIC_WEAR_ALARM_DISMISS = "wear:alarm:dismiss"
+internal const val TOPIC_WEAR_ALARM_SNOOZE = "wear:alarm:snooze"
 
 /**
  * Receives messages from the watch via the Wear Data Layer and routes
@@ -92,11 +103,16 @@ class WearMessageService : WearableListenerService() {
             PATH_SYNC_REQUEST -> handleOfflineSyncRequest()
             PATH_SAVE_ALARM,
             PATH_DELETE_ALARM -> handleOfflineWrite(path, data)
-            PATH_ALARM_DISMISS,
-            PATH_ALARM_SNOOZE -> {
+            PATH_ALARM_DISMISS -> {
                 // Dismiss/snooze require the Tauri runtime to stop the ringing service.
-                // Boot the app so the coordinator can process the command.
-                handleOfflineWrite(path, data)
+                // Boot the app so the coordinator can process the command. Also publish onto
+                // NativeEventBus (see busTopic's KDoc on handleOfflineWrite) so alarm-manager's
+                // native listener can stop the phone's ringing service immediately, without
+                // waiting for that boot.
+                handleOfflineWrite(path, data, busTopic = TOPIC_WEAR_ALARM_DISMISS)
+            }
+            PATH_ALARM_SNOOZE -> {
+                handleOfflineWrite(path, data, busTopic = TOPIC_WEAR_ALARM_SNOOZE)
             }
             else -> {
                 Log.w(TAG, "Unknown message path (offline): $path")
@@ -165,16 +181,23 @@ class WearMessageService : WearableListenerService() {
 
     /**
      * Start the [WearSyncService] foreground service to boot the Tauri
-     * runtime and process a watch-initiated write (save or delete).
+     * runtime and process a watch-initiated write (save, delete, dismiss, or snooze).
      *
      * The service shows a brief notification, boots Tauri (~1 second),
      * then replays the message through the normal plugin path.
+     *
+     * @param busTopic when non-null (dismiss/snooze only -- see the call sites in
+     *   [onMessageReceived]), additionally published on [NativeEventBus] alongside the durable
+     *   enqueue below, via [enqueueOfflineWrite]. `null` for save/delete, which have no native
+     *   listener today and no reason to grow one -- they still need Rust to actually apply the
+     *   write, unlike dismiss/snooze's "stop the local ringing service" side effect, which a
+     *   native listener elsewhere in the app can act on immediately.
      */
-    private fun handleOfflineWrite(path: String, data: String) {
+    private fun handleOfflineWrite(path: String, data: String, busTopic: String? = null) {
         Log.i(TAG, "Watch write received offline ($path), starting WearSyncService")
         NativeEventLog.log(applicationContext, TAG, "Offline write received path=$path, starting WearSyncService")
         // Must go through the shared singleton, not a fresh instance -- see WearSyncEventQueue.getInstance's KDoc for why a second, independently-constructed instance over the same SharedPreferences file provides no mutual exclusion against WearSyncPlugin's own enqueues.
-        WearSyncEventQueue.getInstance(applicationContext).enqueue(path, data)
+        enqueueOfflineWrite(WearSyncEventQueue.getInstance(applicationContext), path, data, busTopic)
 
         val serviceIntent = Intent(this, WearSyncService::class.java).apply {
             putExtra(WearSyncService.EXTRA_PATH, path)
@@ -192,5 +215,32 @@ class WearMessageService : WearableListenerService() {
         // Data Layer changes are handled by the watch side.
         // On the phone side, we only publish — we don't listen for data changes.
         Log.d(TAG, "Data changed event received (${dataEvents.count} events), ignored on phone side")
+    }
+}
+
+/**
+ * Core "offline watch write" bookkeeping, factored out of [WearMessageService.handleOfflineWrite]
+ * so it's unit-testable without a live [android.content.Context]/[WearableListenerService]
+ * instance -- mirrors [com.plugin.alarmmanager]'s `recordAndPublishFiredEvent` in spirit
+ * ([queue] plays the role its `persist` callback plays there: the caller supplies the real
+ * [WearSyncEventQueue] singleton, a test supplies one built over an in-memory store).
+ *
+ * Always enqueues onto [queue] first, unconditionally -- Rust's eventual DB catch-up still
+ * needs this durable copy regardless of whether a native listener is subscribed to [busTopic]
+ * right now. When [busTopic] is non-null, additionally publishes the same raw [data] on
+ * [NativeEventBus] under that topic (issue #255 Phase 4B) -- the enqueue and the publish are
+ * deliberately independent side effects, not a fallback for each other: the queue exists for
+ * Rust's benefit, the bus publish exists for any native listener's benefit, and either one can
+ * be a no-op (no native listener registered yet, or [busTopic] simply not applicable to this
+ * path) without affecting the other.
+ *
+ * No dedup tag is threaded back from [NativeEventBus.publish]'s return value here, unlike the
+ * fired path's `handled_natively` -- per the #255 design's decision 4, a double-delivered
+ * *stop* signal is benign, so there's nothing for a tag to gate.
+ */
+internal fun enqueueOfflineWrite(queue: WearSyncEventQueue, path: String, data: String, busTopic: String?) {
+    queue.enqueue(path, data)
+    if (busTopic != null) {
+        NativeEventBus.publish(busTopic, data)
     }
 }

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearRingInitProvider.kt
@@ -1,4 +1,4 @@
-// ContentProvider that registers the native fired->watch-ring listener before anything else can run
+// ContentProvider that registers the native fired->watch-ring and stop->watch listeners before anything else can run
 //
 // (c) Copyright 2026 Liminal HQ, Scott Morris
 // SPDX-License-Identifier: Apache-2.0 OR MIT
@@ -14,19 +14,22 @@ import android.util.Log
 private const val TAG = "WearRingInitProvider"
 
 /**
- * Guarantees [NativeFiredListener] is subscribed to [NativeEventBus] before anything else in
- * the app can run, including on a cold multi-plugin process start.
+ * Guarantees [NativeFiredListener] and [NativeStopListener] are subscribed to [NativeEventBus]
+ * before anything else in the app can run, including on a cold multi-plugin process start.
  * `ContentProvider.onCreate()` is documented to always run before any `Activity`/`Service`/
  * `BroadcastReceiver` callback -- this is the same Jetpack/WorkManager/Firebase early-init
  * trick, and the mechanism issue #255's Phase 0 spike
  * (`feat/255-p0-contentprovider-spike`, see its `BusInitProvider.kt`) proved out on a real
  * device ahead of this, the production implementation.
  *
- * Unlike that spike, this provider is not debug-gated: it ships in every build, since this
- * is the actual fix for issue #254 (the watch staying silent for ~20s when an alarm fires
- * cold while the phone is in active use, because the watch ring used to depend on Rust
- * booting first). `android:exported="false"` in the manifest -- this provider has no real
- * data to serve and no external caller.
+ * Unlike that spike, this provider is not debug-gated: it ships in every build. Registering
+ * [NativeFiredListener] is the actual fix for issue #254 (the watch staying silent for ~20s
+ * when an alarm fires cold while the phone is in active use, because the watch ring used to
+ * depend on Rust booting first). Registering [NativeStopListener] (issue #255 Phase 4B) is the
+ * symmetric fix for the phone-notification-cold direction of the same problem: a Dismiss/Snooze
+ * tapped on the phone's own alarm notification while Rust hasn't booted yet must still stop the
+ * watch immediately, not lag ~20s behind. `android:exported="false"` in the manifest -- this
+ * provider has no real data to serve and no external caller.
  */
 class WearRingInitProvider : ContentProvider() {
 
@@ -42,10 +45,13 @@ class WearRingInitProvider : ContentProvider() {
         // Warm the fan-out toggle's in-memory cache *before* registering the listener that
         // reads it -- see NativeFanOutPrefs' class KDoc for why this ordering is what lets
         // NativeFiredListener.handle() honour NativeEventBus's non-blocking threading
-        // contract despite the toggle check needing to be resolved synchronously.
+        // contract despite the toggle check needing to be resolved synchronously. No equivalent
+        // warm-up is needed for NativeStopListener -- it has no toggle to check synchronously,
+        // per its own KDoc.
         NativeFanOutPrefs.warm(ctx)
         NativeFiredListener.register(ctx)
-        Log.d(TAG, "WearRingInitProvider.onCreate() fired, fan-out toggle warmed, listener registered")
+        NativeStopListener.register(ctx)
+        Log.d(TAG, "WearRingInitProvider.onCreate() fired, fan-out toggle warmed, listeners registered")
 
         return true
     }

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncCache.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncCache.kt
@@ -16,6 +16,12 @@ private const val KEY_SNOOZE_LENGTH = "cached_snooze_length_minutes"
 private const val KEY_IS_24_HOUR = "cached_is_24_hour"
 private const val KEY_IS_24_HOUR_KNOWN = "cached_is_24_hour_known"
 
+// The canonical "no snooze length known yet" fallback -- matches AlarmSnoozeRequest's/
+// AlarmRingRequest's own default in WearSyncPlugin.kt and NativeStopListener's fallback (issue
+// #255 Phase 4B code review), all three of which reference this constant rather than
+// hand-copying the literal, so there's exactly one place to change it.
+internal const val DEFAULT_SNOOZE_LENGTH_MINUTES = 10
+
 /**
  * Persistent cache of the last-published alarm sync payload.
  *
@@ -41,7 +47,7 @@ object WearSyncCache {
         context: Context,
         alarmsJson: String,
         revision: Long,
-        snoozeLengthMinutes: Int = 10,
+        snoozeLengthMinutes: Int = DEFAULT_SNOOZE_LENGTH_MINUTES,
         is24Hour: Boolean = false,
         is24HourKnown: Boolean = false,
     ) {
@@ -71,7 +77,7 @@ object WearSyncCache {
             return null
         }
         val revision = prefs.getLong(KEY_REVISION, 0)
-        val snoozeLength = prefs.getInt(KEY_SNOOZE_LENGTH, 10)
+        val snoozeLength = prefs.getInt(KEY_SNOOZE_LENGTH, DEFAULT_SNOOZE_LENGTH_MINUTES)
         val is24Hour = prefs.getBoolean(KEY_IS_24_HOUR, false)
         val is24HourKnown = prefs.getBoolean(KEY_IS_24_HOUR_KNOWN, false)
         return Quintuple(json, revision, snoozeLength, is24Hour, is24HourKnown)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -31,8 +31,10 @@ private const val MSG_PATH_SYNC_REQUEST = "/threshold/sync_request"
 // internal (not private) -- shared with NativeFiredListener, which sends the same
 // alarm_ring message from outside this Activity-bound plugin instance.
 internal const val MSG_PATH_ALARM_RING = "/threshold/alarm_ring"
-private const val MSG_PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
-private const val MSG_PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
+// internal (not private) -- shared with NativeStopListener (issue #255 Phase 4B), which
+// sends the same dismiss/snooze messages from outside this Activity-bound plugin instance.
+internal const val MSG_PATH_ALARM_DISMISS = "/threshold/alarm_dismiss"
+internal const val MSG_PATH_ALARM_SNOOZE = "/threshold/alarm_snooze"
 private const val MSG_PATH_LOG_REQUEST = "/threshold/log_request"
 private const val EXTRA_HEADLESS_BOOT = "wear_sync_headless_boot"
 
@@ -73,32 +75,71 @@ internal fun buildAlarmRingPayload(
 }
 
 /**
- * Sends [payload] to every currently connected watch node at [MSG_PATH_ALARM_RING], logging
- * both to Logcat and [NativeEventLog] under [tag] (the caller's own tag, so diagnostics from
- * the Rust-invoked path and the native path are still distinguishable). Shared by
- * [WearSyncPlugin.sendAlarmRing] and [NativeFiredListener] alongside [buildAlarmRingPayload]
- * so the two callers' "iterate connected nodes, send message" logic can't drift the way it
- * already had (only one of them was logging to [NativeEventLog]).
+ * Sends [payload] to every currently connected watch node at [path], logging both to Logcat
+ * and [NativeEventLog] under [tag] (the caller's own tag, so diagnostics from the Rust-invoked
+ * path and each native path are still distinguishable) and [logLabel] (a short human-readable
+ * description of the message, e.g. `"alarm ring"`/`"alarm dismiss"`/`"alarm snooze"`, used only
+ * in those log lines).
+ *
+ * Originally specific to [MSG_PATH_ALARM_RING] (issue #255 Phase 3B, shared by
+ * [WearSyncPlugin.sendAlarmRing] and [NativeFiredListener] alongside [buildAlarmRingPayload] so
+ * the two callers' "iterate connected nodes, send message" logic couldn't drift the way it
+ * already had once -- only one of them was logging to [NativeEventLog]). Generalised to take an
+ * arbitrary [path] in Phase 4B so [NativeStopListener]'s dismiss/snooze sends reuse this same
+ * loop instead of hand-rolling a third copy of it.
  *
  * Returns the number of nodes the message was actually sent to (`0` if none connected --
  * the existing "no watch paired" gap noted on [WearSyncPlugin.sendAlarmRing], not something
- * either caller treats as an error).
+ * any caller treats as an error).
  */
-internal suspend fun sendAlarmRingToConnectedNodes(context: Context, payload: ByteArray, tag: String): Int {
+internal suspend fun sendWatchMessageToConnectedNodes(
+    context: Context,
+    path: String,
+    payload: ByteArray,
+    tag: String,
+    logLabel: String,
+): Int {
     val nodeClient = Wearable.getNodeClient(context)
     val messageClient = Wearable.getMessageClient(context)
     val nodes = nodeClient.connectedNodes.await()
     if (nodes.isEmpty()) {
-        Log.d(tag, "No connected watch nodes — skipping ring notification")
+        Log.d(tag, "No connected watch nodes — skipping $logLabel notification")
         return 0
     }
 
     for (node in nodes) {
-        messageClient.sendMessage(node.id, MSG_PATH_ALARM_RING, payload).await()
-        Log.d(tag, "Sent alarm ring to watch: ${node.displayName}")
+        messageClient.sendMessage(node.id, path, payload).await()
+        Log.d(tag, "Sent $logLabel to watch: ${node.displayName}")
     }
-    NativeEventLog.log(context, tag, "Sent alarm ring to ${nodes.size} node(s)")
+    NativeEventLog.log(context, tag, "Sent $logLabel to ${nodes.size} node(s)")
     return nodes.size
+}
+
+/**
+ * Builds the JSON alarm-dismiss message payload sent to the watch over `MessageClient` at
+ * [MSG_PATH_ALARM_DISMISS]. Shared by [WearSyncPlugin.sendAlarmDismiss] (the Rust-invoked path)
+ * and [NativeStopListener] (the in-process native path, issue #255 Phase 4B) so the wire format
+ * is defined in exactly one place, mirroring [buildAlarmRingPayload]'s existing precedent.
+ */
+internal fun buildAlarmDismissPayload(alarmId: Int): ByteArray {
+    val json = JSONObject().apply {
+        put("alarmId", alarmId)
+    }
+    return json.toString().toByteArray()
+}
+
+/**
+ * Builds the JSON alarm-snooze message payload sent to the watch over `MessageClient` at
+ * [MSG_PATH_ALARM_SNOOZE]. Shared by [WearSyncPlugin.sendAlarmSnooze] (the Rust-invoked path)
+ * and [NativeStopListener] (the in-process native path, issue #255 Phase 4B) so the wire format
+ * is defined in exactly one place, mirroring [buildAlarmRingPayload]'s existing precedent.
+ */
+internal fun buildAlarmSnoozePayload(alarmId: Int, snoozeLengthMinutes: Int): ByteArray {
+    val json = JSONObject().apply {
+        put("alarmId", alarmId)
+        put("snoozeLengthMinutes", snoozeLengthMinutes)
+    }
+    return json.toString().toByteArray()
 }
 
 @InvokeArg
@@ -271,7 +312,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                     is24Hour = args.is24Hour,
                     is24HourKnown = args.is24HourKnown,
                 )
-                sendAlarmRingToConnectedNodes(activity, payload, TAG)
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_RING, payload, TAG, "alarm ring")
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm ring to watch", e)
@@ -291,22 +332,8 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         val args = invoke.parseArgs(AlarmDismissRequest::class.java)
         scope.launch {
             try {
-                val nodes = nodeClient.connectedNodes.await()
-                if (nodes.isEmpty()) {
-                    Log.d(TAG, "No connected watch nodes — skipping dismiss notification")
-                    invoke.resolve()
-                    return@launch
-                }
-
-                val json = JSONObject().apply {
-                    put("alarmId", args.alarmId)
-                }
-                val payload = json.toString().toByteArray()
-
-                for (node in nodes) {
-                    messageClient.sendMessage(node.id, MSG_PATH_ALARM_DISMISS, payload).await()
-                    Log.d(TAG, "Sent alarm dismiss to watch: ${node.displayName}")
-                }
+                val payload = buildAlarmDismissPayload(args.alarmId)
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_DISMISS, payload, TAG, "alarm dismiss")
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm dismiss to watch", e)
@@ -326,23 +353,8 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         val args = invoke.parseArgs(AlarmSnoozeRequest::class.java)
         scope.launch {
             try {
-                val nodes = nodeClient.connectedNodes.await()
-                if (nodes.isEmpty()) {
-                    Log.d(TAG, "No connected watch nodes — skipping snooze notification")
-                    invoke.resolve()
-                    return@launch
-                }
-
-                val json = JSONObject().apply {
-                    put("alarmId", args.alarmId)
-                    put("snoozeLengthMinutes", args.snoozeLengthMinutes)
-                }
-                val payload = json.toString().toByteArray()
-
-                for (node in nodes) {
-                    messageClient.sendMessage(node.id, MSG_PATH_ALARM_SNOOZE, payload).await()
-                    Log.d(TAG, "Sent alarm snooze to watch: ${node.displayName}")
-                }
+                val payload = buildAlarmSnoozePayload(args.alarmId, args.snoozeLengthMinutes)
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_SNOOZE, payload, TAG, "alarm snooze")
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm snooze to watch", e)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -16,6 +16,8 @@ import app.tauri.plugin.Channel
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.CoroutineScope
@@ -88,6 +90,14 @@ internal fun buildAlarmRingPayload(
  * arbitrary [path] in Phase 4B so [NativeStopListener]'s dismiss/snooze sends reuse this same
  * loop instead of hand-rolling a third copy of it.
  *
+ * [nodeClient]/[messageClient] default to fresh `Wearable.get*Client(context)` instances --
+ * the right choice for [NativeFiredListener]/[NativeStopListener], which run before any
+ * [WearSyncPlugin] instance (and its cached clients) exists. [WearSyncPlugin]'s own callers
+ * pass its `by lazy` cached clients explicitly instead (issue #255 Phase 4B code review):
+ * dismiss/snooze/ring are commands invoked from the WebView on every alarm interaction, a hot
+ * enough path that constructing a fresh `NodeClient`/`MessageClient` per call -- rather than
+ * reusing the ones the plugin already holds for exactly this purpose -- is wasteful.
+ *
  * Returns the number of nodes the message was actually sent to (`0` if none connected --
  * the existing "no watch paired" gap noted on [WearSyncPlugin.sendAlarmRing], not something
  * any caller treats as an error).
@@ -98,9 +108,9 @@ internal suspend fun sendWatchMessageToConnectedNodes(
     payload: ByteArray,
     tag: String,
     logLabel: String,
+    nodeClient: NodeClient = Wearable.getNodeClient(context),
+    messageClient: MessageClient = Wearable.getMessageClient(context),
 ): Int {
-    val nodeClient = Wearable.getNodeClient(context)
-    val messageClient = Wearable.getMessageClient(context)
     val nodes = nodeClient.connectedNodes.await()
     if (nodes.isEmpty()) {
         Log.d(tag, "No connected watch nodes — skipping $logLabel notification")
@@ -165,7 +175,7 @@ class AlarmRingRequest {
     // wear-sync's models.rs).
     var hour: Int? = null
     var minute: Int? = null
-    var snoozeLengthMinutes: Int = 10
+    var snoozeLengthMinutes: Int = DEFAULT_SNOOZE_LENGTH_MINUTES
     var is24Hour: Boolean = false
     var is24HourKnown: Boolean = false
 }
@@ -178,7 +188,7 @@ class AlarmDismissRequest {
 @InvokeArg
 class AlarmSnoozeRequest {
     var alarmId: Int = -1
-    var snoozeLengthMinutes: Int = 10
+    var snoozeLengthMinutes: Int = DEFAULT_SNOOZE_LENGTH_MINUTES
 }
 
 @InvokeArg
@@ -312,7 +322,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
                     is24Hour = args.is24Hour,
                     is24HourKnown = args.is24HourKnown,
                 )
-                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_RING, payload, TAG, "alarm ring")
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_RING, payload, TAG, "alarm ring", nodeClient, messageClient)
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm ring to watch", e)
@@ -333,7 +343,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         scope.launch {
             try {
                 val payload = buildAlarmDismissPayload(args.alarmId)
-                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_DISMISS, payload, TAG, "alarm dismiss")
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_DISMISS, payload, TAG, "alarm dismiss", nodeClient, messageClient)
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm dismiss to watch", e)
@@ -354,7 +364,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
         scope.launch {
             try {
                 val payload = buildAlarmSnoozePayload(args.alarmId, args.snoozeLengthMinutes)
-                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_SNOOZE, payload, TAG, "alarm snooze")
+                sendWatchMessageToConnectedNodes(activity, MSG_PATH_ALARM_SNOOZE, payload, TAG, "alarm snooze", nodeClient, messageClient)
                 invoke.resolve()
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send alarm snooze to watch", e)

--- a/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
+++ b/plugins/wear-sync/android/src/main/java/ca/liminalhq/threshold/wearsync/WearSyncPlugin.kt
@@ -152,6 +152,56 @@ internal fun buildAlarmSnoozePayload(alarmId: Int, snoozeLengthMinutes: Int): By
     return json.toString().toByteArray()
 }
 
+/**
+ * The peek -> deliver-each-via-[deliver] -> commit-only-what-was-delivered sequence
+ * [WearSyncPlugin.drainQueuedMessages] performs, factored out into its own small class (issue
+ * #255 Phase 4B code review, PR #300 finding) so it's unit-testable -- proving two overlapping
+ * [drain] calls don't both observe and redeliver the same uncommitted batch -- without a live
+ * `Activity`/`Channel`/Play Services instance, which [WearSyncPlugin] itself needs to
+ * construct.
+ *
+ * [WearSyncEventQueue.peekAll]/[WearSyncEventQueue.commit] are each individually
+ * `@Synchronized` on their own underlying `DurableEventQueue`, but that only protects each
+ * individual call, not the sequence between them -- the lock is released between peek and
+ * commit. [WearSyncPlugin] calls [drain] from three independent, differently-threaded call
+ * sites ([WearSyncPlugin.onWatchMessage], plus the `setWatchMessageHandler`/
+ * `markWatchPipelineReady` Tauri commands during app boot) with no mutual exclusion between
+ * them otherwise, so two overlapping calls could each peek the same uncommitted batch and
+ * redeliver every message in it to Rust before either commits -- `commit()` itself is
+ * idempotent, so the persisted queue would stay consistent, but Rust would still receive
+ * genuine duplicate deliveries, which can re-anchor a snooze or double-process a dismiss (not
+ * every `AlarmCoordinator` handler is idempotent against a resend).
+ *
+ * `@Synchronized` on [drain] (locking on this [QueueDrainer] instance) closes that gap: a
+ * second overlapping call blocks until the first's peek-deliver-commit sequence has fully
+ * finished. [WearSyncPlugin] holds exactly one [QueueDrainer] per plugin instance (see its
+ * `queueDrainer` field), so every call site synchronizes on the same monitor.
+ *
+ * Deliberately peek-then-commit-after-delivery, not drain-then-deliver: if [deliver] throws
+ * partway through a batch (a stale Channel reference, a JNI failure, whatever), every message
+ * not yet delivered at that point must still be in the queue afterwards so it's retried on the
+ * next drain, not silently lost.
+ */
+internal class QueueDrainer(private val queue: WearSyncEventQueue) {
+
+    @Synchronized
+    fun drain(deliver: (WearSyncEventQueue.QueuedMessage) -> Unit) {
+        val pending = queue.peekAll()
+        if (pending.isEmpty()) return
+
+        Log.i(TAG, "Replaying ${pending.size} queued message(s)")
+        val delivered = mutableSetOf<String>()
+        try {
+            for (message in pending) {
+                deliver(message)
+                delivered.add(message.eventId)
+            }
+        } finally {
+            queue.commit(delivered)
+        }
+    }
+}
+
 @InvokeArg
 class PublishRequest {
     var alarmsJson: String = ""
@@ -210,6 +260,10 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
     private val nodeClient by lazy { Wearable.getNodeClient(activity) }
     // Must go through the process-wide singleton, not a fresh instance -- see WearSyncEventQueue.getInstance's KDoc for why a second, independently-constructed instance over the same SharedPreferences file provides no mutual exclusion against this one, or against WearMessageService's own offline-write enqueues.
     private val watchQueue by lazy { WearSyncEventQueue.getInstance(activity) }
+    // One drainer per plugin instance, reused by every drainQueuedMessages() call site -- see
+    // QueueDrainer's own KDoc for why this is what actually closes the overlapping-drain race
+    // (issue #255 Phase 4B code review, PR #300 finding).
+    private val queueDrainer by lazy { QueueDrainer(watchQueue) }
     private var watchMessageChannel: Channel? = null
     @Volatile
     private var watchPipelineReady: Boolean = false
@@ -492,7 +546,7 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
     /**
      * Peeks every queued message and delivers each one to Rust in turn, committing (removing) only the ones that were actually handed to the [Channel] successfully.
      *
-     * Deliberately peek-then-commit-after-delivery rather than drain-then-deliver: if `channel.send()` throws partway through a batch (a stale Channel reference, a JNI failure, whatever), every message not yet delivered at that point must still be in the queue afterwards so it's retried on the next drain, not silently lost.
+     * Delegates the actual peek-deliver-commit sequence, and the mutual exclusion around it, to [queueDrainer] -- see [QueueDrainer]'s own KDoc for why a bare per-call `peekAll()`/`commit()` pair isn't enough on its own to stop two overlapping calls (this method is invoked from three independent, differently-threaded call sites: [onWatchMessage], and the [setWatchMessageHandler]/[markWatchPipelineReady] Tauri commands during app boot) from both redelivering the same uncommitted batch to Rust.
      */
     private fun drainQueuedMessages() {
         if (!watchPipelineReady) return
@@ -502,31 +556,33 @@ class WearSyncPlugin(private val activity: Activity) : Plugin(activity) {
             return
         }
 
-        val pending = watchQueue.peekAll()
-        if (pending.isEmpty()) return
-
-        Log.i(TAG, "Replaying ${pending.size} queued message(s)")
-        val delivered = mutableSetOf<String>()
-        try {
-            for (message in pending) {
-                val event = JSObject()
-                event.put("path", message.path)
-                event.put("data", message.data)
-                // Stamped in so a same-process dedup pass on the Rust side (issue #255 Phase
-                // 3C) has something to key watch-originated dismiss/snooze messages on, same
-                // as the fired path's eventId -- see WatchMessage::event_id on the Rust side.
-                event.put("eventId", message.eventId)
-                channel.send(event)
-                delivered.add(message.eventId)
-                Log.d(TAG, "Sent watch message to Rust channel: path=${message.path}")
-            }
-        } finally {
-            watchQueue.commit(delivered)
+        queueDrainer.drain { message ->
+            val event = JSObject()
+            event.put("path", message.path)
+            event.put("data", message.data)
+            // Stamped in so a same-process dedup pass on the Rust side (issue #255 Phase
+            // 3C) has something to key watch-originated dismiss/snooze messages on, same
+            // as the fired path's eventId -- see WatchMessage::event_id on the Rust side.
+            event.put("eventId", message.eventId)
+            channel.send(event)
+            Log.d(TAG, "Sent watch message to Rust channel: path=${message.path}")
         }
     }
 
     /** Whether the Kotlin→Rust Channel has been registered and is ready. */
     val isChannelReady: Boolean get() = watchMessageChannel != null
+
+    /**
+     * Whether Rust has finished booting, registered its own watch-event listeners, and called
+     * [markWatchPipelineReady] -- distinct from [isChannelReady], which only reflects that
+     * [setWatchMessageHandler] has registered the Kotlin→Rust [Channel], a step that can (and
+     * normally does) happen first. [WearMessageService] checks this, not just whether `instance`
+     * is non-null, to decide whether a watch-originated dismiss/snooze still needs the
+     * [NativeEventBus] stop signal: [load] sets `instance` well before Rust finishes booting and
+     * calls [markWatchPipelineReady], so gating on instance existence alone left that whole
+     * window unable to reach `WatchStopListener` (issue #255 Phase 4B code review).
+     */
+    val isPipelineReady: Boolean get() = watchPipelineReady
 
     companion object {
         /**

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeAlarmSerialExecutorTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeAlarmSerialExecutorTest.kt
@@ -1,0 +1,97 @@
+// Unit tests for NativeAlarmSerialExecutor's per-alarm-id ordering guarantee
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation, no `kotlinx-coroutines-test`. Covers
+ * [NativeAlarmSerialExecutor], the fix for issue #255 Phase 4B code review's ordering bug:
+ * [NativeFiredListener]'s ring send and [NativeStopListener]'s dismiss/snooze send used to run
+ * on independent `Dispatchers.IO` coroutines with no ordering relationship, so a stop launched
+ * immediately after a fire could race ahead of and complete before the fire's own send. These
+ * tests exercise [NativeAlarmSerialExecutor.submit] directly (the seam both listeners now
+ * submit through), rather than [NativeFiredListener.handle]/[NativeStopListener.handleDismiss]
+ * themselves, which need a real [android.content.Context] and Play Services clients neither
+ * this test source set nor its dependencies can fake -- mirrors [NativeStopListenerTest]'s and
+ * [NativeFiredListenerTest]'s own "test the pure/structural seam, not the Context-requiring
+ * entry point" approach.
+ *
+ * A completion callback (rather than a raw `List` read after the fact) is used to observe
+ * ordering, so each test's final assertion only runs once every submitted task has actually
+ * finished -- `submit` itself returns immediately without waiting for its block to run.
+ */
+class NativeAlarmSerialExecutorTest {
+
+    @Test
+    fun `a task submitted for the same alarm id cannot complete before an earlier, still-running task for that id`() = runBlocking {
+        // Models the exact race from the bug report: a "fired" send is submitted first and is
+        // still in flight (simulated by delay, standing in for a cache read, node discovery, or
+        // the Play Services call itself) when a "stop" send for the same alarm id is submitted
+        // right after it. A naive `Dispatchers.IO.limitedParallelism(1)` dispatcher does *not*
+        // prevent this: it only limits concurrently *running* bodies, not the order suspended
+        // tasks complete in, so "stop" could still finish first during "fired"'s delay. The
+        // actual fix (a single-consumer queue per alarm id) prevents "stop" from even starting
+        // until "fired" has fully finished.
+        val alarmId = 7
+        val order = mutableListOf<String>()
+        val allDone = CompletableDeferred<Unit>()
+        val firedStarted = CompletableDeferred<Unit>()
+
+        NativeAlarmSerialExecutor.submit(alarmId) {
+            firedStarted.complete(Unit)
+            delay(50)
+            order.add("fired")
+        }
+        // Wait for "fired" to have actually begun running before submitting "stop", so this
+        // test reflects the real ordering (fired happens first in wall-clock time; a user can
+        // only dismiss/snooze an alarm that has already fired) rather than relying on
+        // submission-order luck alone.
+        firedStarted.await()
+        NativeAlarmSerialExecutor.submit(alarmId) {
+            order.add("stop")
+            allDone.complete(Unit)
+        }
+
+        allDone.await()
+
+        assertEquals(listOf("fired", "stop"), order)
+    }
+
+    @Test
+    fun `unrelated alarm ids are not serialized against each other`() = runBlocking {
+        // The per-id scoping in NativeAlarmSerialExecutor exists specifically so this stays
+        // true -- a slow send for one alarm must never delay a send for a different, unrelated
+        // alarm.
+        val order = mutableListOf<String>()
+        val fastDone = CompletableDeferred<Unit>()
+        val slowStarted = CompletableDeferred<Unit>()
+        val slowDone = CompletableDeferred<Unit>()
+
+        NativeAlarmSerialExecutor.submit(101) {
+            slowStarted.complete(Unit)
+            delay(50)
+            order.add("alarm-101")
+            slowDone.complete(Unit)
+        }
+        slowStarted.await()
+        NativeAlarmSerialExecutor.submit(102) {
+            order.add("alarm-102")
+            fastDone.complete(Unit)
+        }
+
+        fastDone.await()
+        slowDone.await()
+
+        // The unrelated alarm's task finishes first, despite being submitted second -- it was
+        // never queued behind alarm 101's still-in-flight task.
+        assertEquals(listOf("alarm-102", "alarm-101"), order)
+    }
+}

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeStopListenerTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/NativeStopListenerTest.kt
@@ -1,0 +1,85 @@
+// Unit tests for NativeStopListener's pure payload-parsing/construction helpers
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers the pure functions
+ * [NativeStopListener] (and the shared [buildAlarmDismissPayload]/[buildAlarmSnoozePayload]
+ * helpers it calls) factor out specifically so this parsing/payload-construction logic is
+ * testable independent of [android.content.Context], [ca.liminalhq.threshold.nativebus.NativeEventBus],
+ * and Play Services -- mirrors the style of [NativeFiredListenerTest].
+ *
+ * [NativeStopListener.handleDismiss]/[handleSnooze] themselves aren't exercised here, same as
+ * [NativeFiredListener.handle] isn't in [NativeFiredListenerTest]: both need a real
+ * [android.content.Context] to construct a call, and the actual watch send goes through
+ * [sendWatchMessageToConnectedNodes], which needs live Play Services clients neither this test
+ * source set nor its dependencies (plain JUnit + `org.json`, no mocking framework) can fake.
+ * What *is* verified here -- by inspection of NativeStopListener.kt, not by a runtime
+ * assertion -- is that [NativeStopListener.handleDismiss]/[handleSnooze] call
+ * [sendWatchMessageToConnectedNodes] (the same shared send-loop [NativeFiredListener] and
+ * [WearSyncPlugin.sendAlarmRing] use) rather than iterating `connectedNodes` themselves.
+ */
+class NativeStopListenerTest {
+
+    // ── parseIdPayload ───────────────────────────────────────────────
+
+    @Test
+    fun `parseIdPayload reads a positive id from a well-formed payload`() {
+        val payload = JSONObject().apply { put("id", 42) }.toString()
+
+        assertEquals(42, parseIdPayload(payload))
+    }
+
+    @Test
+    fun `parseIdPayload returns null for malformed JSON`() {
+        assertNull(parseIdPayload("not even json"))
+    }
+
+    @Test
+    fun `parseIdPayload returns null when id is missing`() {
+        assertNull(parseIdPayload(JSONObject().toString()))
+    }
+
+    @Test
+    fun `parseIdPayload returns null when id is zero`() {
+        val payload = JSONObject().apply { put("id", 0) }.toString()
+
+        assertNull(parseIdPayload(payload))
+    }
+
+    @Test
+    fun `parseIdPayload returns null when id is negative`() {
+        val payload = JSONObject().apply { put("id", -5) }.toString()
+
+        assertNull(parseIdPayload(payload))
+    }
+
+    // ── buildAlarmDismissPayload (shared with WearSyncPlugin.sendAlarmDismiss) ──────────
+
+    @Test
+    fun `buildAlarmDismissPayload encodes just the alarm id`() {
+        val json = JSONObject(String(buildAlarmDismissPayload(alarmId = 7)))
+
+        assertEquals(7, json.getInt("alarmId"))
+        assertEquals(1, json.length())
+    }
+
+    // ── buildAlarmSnoozePayload (shared with WearSyncPlugin.sendAlarmSnooze) ────────────
+
+    @Test
+    fun `buildAlarmSnoozePayload encodes the alarm id and snooze length`() {
+        val json = JSONObject(String(buildAlarmSnoozePayload(alarmId = 7, snoozeLengthMinutes = 5)))
+
+        assertEquals(7, json.getInt("alarmId"))
+        assertEquals(5, json.getInt("snoozeLengthMinutes"))
+        assertEquals(2, json.length())
+    }
+}

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/QueueDrainerTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/QueueDrainerTest.kt
@@ -1,0 +1,106 @@
+// Unit tests for QueueDrainer's synchronized peek-deliver-commit sequence
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests -- no Robolectric/instrumentation. Covers [QueueDrainer], factored out of
+ * [WearSyncPlugin.drainQueuedMessages] specifically so it's unit-testable without a live
+ * `Activity`/`Channel`/Play Services instance (PR #300 finding, on top of issue #255 Phase 4B).
+ *
+ * The concurrency test below drives [QueueDrainer.drain] from two real [Thread]s -- not just
+ * asserting single-threaded correctness -- since the bug this fixes is specifically about two
+ * *overlapping* calls, which a single-threaded test can't exercise.
+ */
+class QueueDrainerTest {
+
+    private lateinit var store: InMemoryKeyValueStore
+    private lateinit var queue: WearSyncEventQueue
+    private lateinit var drainer: QueueDrainer
+
+    @Before
+    fun setUp() {
+        store = InMemoryKeyValueStore()
+        queue = WearSyncEventQueue(store)
+        drainer = QueueDrainer(queue)
+    }
+
+    @Test
+    fun `drain delivers every pending message exactly once, oldest first, and commits them`() {
+        queue.enqueue("/threshold/save_alarm", "{\"alarmId\":1}")
+        queue.enqueue("/threshold/save_alarm", "{\"alarmId\":2}")
+
+        val delivered = mutableListOf<String>()
+        drainer.drain { message -> delivered.add(message.data) }
+
+        assertEquals(listOf("{\"alarmId\":1}", "{\"alarmId\":2}"), delivered)
+        assertTrue(queue.peekAll().isEmpty())
+    }
+
+    @Test
+    fun `drain on an empty queue delivers nothing`() {
+        var deliveredAnything = false
+
+        drainer.drain { deliveredAnything = true }
+
+        assertTrue(!deliveredAnything)
+    }
+
+    @Test
+    fun `two overlapping drain calls do not both deliver the same batch`() {
+        // The exact race from the bug report (PR #300 finding): WearSyncPlugin.
+        // drainQueuedMessages() is invoked from three independent, differently-threaded call
+        // sites with no mutual exclusion between peek and commit. Without @Synchronized on
+        // QueueDrainer.drain, a second overlapping call could peekAll() the same
+        // not-yet-committed message this one is still delivering, and redeliver it too.
+        queue.enqueue("/threshold/alarm_dismiss", "{\"alarmId\":7}")
+
+        val deliveredEventIds = CopyOnWriteArrayList<String>()
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+
+        // The first drain call deliberately blocks mid-delivery (standing in for a slow
+        // channel.send()) until explicitly released, holding QueueDrainer's monitor the whole
+        // time -- giving the second call every opportunity to race ahead if the synchronization
+        // weren't actually in effect.
+        val firstThread = Thread {
+            drainer.drain { message ->
+                firstStarted.countDown()
+                releaseFirst.await(2, TimeUnit.SECONDS)
+                deliveredEventIds.add(message.eventId)
+            }
+        }
+        firstThread.start()
+        assertTrue("first drain should have started delivering", firstStarted.await(2, TimeUnit.SECONDS))
+
+        // Started once the first call is already inside its delivery callback but hasn't
+        // committed yet -- exactly the "overlapping" window the bug describes. With the fix in
+        // place this call blocks on QueueDrainer's monitor until the first call's drain()
+        // returns; without it, it would run straight through and redeliver the same message.
+        val secondThread = Thread {
+            drainer.drain { message -> deliveredEventIds.add(message.eventId) }
+        }
+        secondThread.start()
+        // Give the second thread a real chance to attempt (and, if unfixed, complete) its own
+        // drain() call before the first is released.
+        Thread.sleep(200)
+
+        releaseFirst.countDown()
+        firstThread.join(2_000)
+        secondThread.join(2_000)
+
+        // Exactly one delivery for the single queued message -- not two.
+        assertEquals(1, deliveredEventIds.size)
+        assertTrue(queue.peekAll().isEmpty())
+    }
+}

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/WearMessageServiceTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/WearMessageServiceTest.kt
@@ -1,0 +1,114 @@
+// Unit tests for WearMessageService's offline-write bus-publish bookkeeping
+//
+// (c) Copyright 2026 Liminal HQ, Scott Morris
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+package ca.liminalhq.threshold.wearsync
+
+import ca.liminalhq.threshold.nativebus.NativeEventBus
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Plain JUnit 4 tests against [enqueueOfflineWrite] -- the pure bookkeeping
+ * [WearMessageService.handleOfflineWrite] delegates to, factored out specifically so it's
+ * testable without a live [android.content.Context]/`WearableListenerService` instance.
+ * Mirrors [WearSyncEventQueueTest]'s style (in-memory [InMemoryKeyValueStore], no
+ * Robolectric/instrumentation).
+ *
+ * Covers issue #255 Phase 4B's addition: publishing onto [NativeEventBus] alongside the
+ * pre-existing durable-queue enqueue for watch-originated dismiss/snooze messages, without
+ * disturbing that enqueue's own behaviour.
+ */
+class WearMessageServiceTest {
+
+    private lateinit var store: InMemoryKeyValueStore
+    private lateinit var queue: WearSyncEventQueue
+
+    @Before
+    fun setUp() {
+        store = InMemoryKeyValueStore()
+        queue = WearSyncEventQueue(store)
+    }
+
+    @After
+    fun tearDown() {
+        // NativeEventBus is a process-wide singleton -- see NativeEventBusTest's own
+        // tearDown for why this is needed between tests.
+        NativeEventBus.resetForTests()
+    }
+
+    @Test
+    fun `enqueues onto the durable queue exactly as before when busTopic is null`() {
+        enqueueOfflineWrite(queue, "/threshold/save_alarm", "{\"alarmId\":1}", busTopic = null)
+
+        val pending = queue.peekAll()
+
+        assertEquals(1, pending.size)
+        assertEquals("/threshold/save_alarm" to "{\"alarmId\":1}", pending.single().path to pending.single().data)
+    }
+
+    @Test
+    fun `a null busTopic publishes nothing onto NativeEventBus`() {
+        var published = false
+        NativeEventBus.subscribe("wear:alarm:dismiss") { published = true; null }
+
+        enqueueOfflineWrite(queue, "/threshold/save_alarm", "{\"alarmId\":1}", busTopic = null)
+
+        assertTrue(!published)
+    }
+
+    @Test
+    fun `a non-null busTopic still enqueues onto the durable queue`() {
+        enqueueOfflineWrite(queue, "/threshold/alarm_dismiss", "{\"alarmId\":7}", busTopic = TOPIC_WEAR_ALARM_DISMISS)
+
+        val pending = queue.peekAll()
+
+        assertEquals(1, pending.size)
+        assertEquals("/threshold/alarm_dismiss" to "{\"alarmId\":7}", pending.single().path to pending.single().data)
+    }
+
+    @Test
+    fun `a non-null busTopic additionally publishes the raw data onto NativeEventBus`() {
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_DISMISS) { payload -> receivedPayload = payload; null }
+
+        enqueueOfflineWrite(queue, "/threshold/alarm_dismiss", "{\"alarmId\":7}", busTopic = TOPIC_WEAR_ALARM_DISMISS)
+
+        assertEquals("{\"alarmId\":7}", receivedPayload)
+    }
+
+    @Test
+    fun `snooze publishes on the snooze topic, not the dismiss topic`() {
+        var dismissReceived = false
+        var snoozeReceived = false
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_DISMISS) { dismissReceived = true; null }
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_SNOOZE) { snoozeReceived = true; null }
+
+        enqueueOfflineWrite(
+            queue,
+            "/threshold/alarm_snooze",
+            "{\"alarmId\":7,\"snoozeLengthMinutes\":10}",
+            busTopic = TOPIC_WEAR_ALARM_SNOOZE,
+        )
+
+        assertTrue(!dismissReceived)
+        assertTrue(snoozeReceived)
+    }
+
+    @Test
+    fun `publishing onto a topic nobody is subscribed to still leaves the durable enqueue intact`() {
+        // No NativeEventBus.subscribe call here -- alarm-manager's listener (Phase 4A) hasn't
+        // registered yet, mirroring a cold process where wear-sync's provider has run but
+        // alarm-manager's own init ContentProvider hasn't (or vice versa, ordering is
+        // unspecified between separate plugins' providers).
+        enqueueOfflineWrite(queue, "/threshold/alarm_dismiss", "{\"alarmId\":9}", busTopic = TOPIC_WEAR_ALARM_DISMISS)
+
+        val pending = queue.peekAll()
+
+        assertEquals(listOf("/threshold/alarm_dismiss" to "{\"alarmId\":9}"), pending.map { it.path to it.data })
+    }
+}

--- a/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/WearMessageServiceTest.kt
+++ b/plugins/wear-sync/android/src/test/java/ca/liminalhq/threshold/wearsync/WearMessageServiceTest.kt
@@ -111,4 +111,73 @@ class WearMessageServiceTest {
 
         assertEquals(listOf("/threshold/alarm_dismiss" to "{\"alarmId\":9}"), pending.map { it.path to it.data })
     }
+
+    // ── nativeStopBusTopic ───────────────────────────────────────────
+
+    @Test
+    fun `nativeStopBusTopic maps dismiss and snooze paths to their own topics`() {
+        assertEquals(TOPIC_WEAR_ALARM_DISMISS, nativeStopBusTopic("/threshold/alarm_dismiss"))
+        assertEquals(TOPIC_WEAR_ALARM_SNOOZE, nativeStopBusTopic("/threshold/alarm_snooze"))
+    }
+
+    @Test
+    fun `nativeStopBusTopic returns null for paths with no native listener`() {
+        assertEquals(null, nativeStopBusTopic("/threshold/sync_request"))
+        assertEquals(null, nativeStopBusTopic("/threshold/save_alarm"))
+        assertEquals(null, nativeStopBusTopic("/threshold/delete_alarm"))
+        assertEquals(null, nativeStopBusTopic("/threshold/not_a_real_path"))
+    }
+
+    // ── publishNativeStopBusIfPipelineNotReady (reachability fix, issue #255 Phase 4B code
+    // review: a watch dismiss/snooze arriving after WearSyncPlugin.load() has set `instance`
+    // but before markWatchPipelineReady() has run must still reach NativeEventBus) ──────────
+
+    @Test
+    fun `publishes onto NativeEventBus when the pipeline is not ready, even though this models a loaded plugin instance`() {
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_DISMISS) { payload -> receivedPayload = payload; null }
+
+        // pipelineReady = false is exactly the "WearSyncPlugin.instance != null but
+        // markWatchPipelineReady() hasn't run yet" window -- the call site in
+        // WearMessageService.onMessageReceived only reaches this function once `plugin` is
+        // already known non-null, so this parameter alone stands in for that state here.
+        publishNativeStopBusIfPipelineNotReady("/threshold/alarm_dismiss", "{\"alarmId\":7}", pipelineReady = false)
+
+        assertEquals("{\"alarmId\":7}", receivedPayload)
+    }
+
+    @Test
+    fun `publishes the snooze payload onto the snooze topic when the pipeline is not ready`() {
+        var receivedPayload: String? = null
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_SNOOZE) { payload -> receivedPayload = payload; null }
+
+        publishNativeStopBusIfPipelineNotReady(
+            "/threshold/alarm_snooze",
+            "{\"alarmId\":7,\"snoozeLengthMinutes\":10}",
+            pipelineReady = false,
+        )
+
+        assertEquals("{\"alarmId\":7,\"snoozeLengthMinutes\":10}", receivedPayload)
+    }
+
+    @Test
+    fun `does not publish once the pipeline is ready -- the normal, fully-booted case`() {
+        var published = false
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_DISMISS) { published = true; null }
+
+        publishNativeStopBusIfPipelineNotReady("/threshold/alarm_dismiss", "{\"alarmId\":7}", pipelineReady = true)
+
+        assertTrue(!published)
+    }
+
+    @Test
+    fun `does not publish for a path with no native listener regardless of pipeline readiness`() {
+        var published = false
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_DISMISS) { published = true; null }
+        NativeEventBus.subscribe(TOPIC_WEAR_ALARM_SNOOZE) { published = true; null }
+
+        publishNativeStopBusIfPipelineNotReady("/threshold/save_alarm", "{\"alarmId\":7}", pipelineReady = false)
+
+        assertTrue(!published)
+    }
 }


### PR DESCRIPTION
## What this is

Phase 4B of #255's implementation plan — wear-sync's side of "symmetric stop signals." No dedup tags needed (per decision 4: a double-delivered stop is benign, the watch already safely drops a dismiss for a non-ringing alarm).

## What's here

- **Watch→phone**: `WearMessageService`'s existing offline branch now additionally publishes `wear:alarm:dismiss`/`wear:alarm:snooze` onto `NativeEventBus` alongside its unchanged durable-queue enqueue, so alarm-manager's own listener (#301) can stop the phone's ringing service natively without waiting for Rust.
- **Phone→watch**: `WearRingInitProvider` (from #299) additionally subscribes to `alarm-manager:dismiss-requested`/`snooze-requested` and sends the stop to the watch, reusing the shared Play Services send helper rather than a third hand-rolled copy.
- Note: `wear:alarm:dismiss`/`snooze`'s payload uses key `"alarmId"` (matching the watch's own pre-existing wire format), distinct from alarm-manager's `"id"`-keyed topics — documented in code so a future reader doesn't assume one shared convention.

## Testing checklist (automated, no device needed)

- [x] 43 wear-sync Kotlin tests across 4 classes, all passing
- [x] `cargo check -p tauri-plugin-wear-sync` clean
- [x] Full combined-stack verification (with #301): `cargo test --workspace` all green

## Review status

Reviewed via `/code-review high`. The headline finding (no producer wired for the alarm-manager topics) was the expected cross-branch gap, resolved by #301. Real fixes applied: cached Play Services clients reused instead of constructed fresh on a hot path, duplicated dismiss/snooze handler logic consolidated, a fourth copy of the default snooze length consolidated to one constant, and shared listener-registration boilerplate factored out.

Stacked on #301. Part of #255.