### PR TITLE
Make dismiss_alarm safe to call twice for the same dismiss

### DIFF
--- a/apps/threshold/src-tauri/Cargo.toml
+++ b/apps/threshold/src-tauri/Cargo.toml
@@ -56,3 +56,6 @@ tauri-plugin-app-events = "0.2"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ts-rs = "12"
+# "test" feature unlocks tauri::test::mock_app() for coordinator-level tests that need a
+# real AppHandle to call app.emit() through (see alarm/mod.rs's dismiss_alarm tests).
+tauri = { version = "2.10.2", features = ["test"] }

--- a/apps/threshold/src-tauri/src/alarm/database.rs
+++ b/apps/threshold/src-tauri/src/alarm/database.rs
@@ -363,6 +363,26 @@ impl AlarmDatabase {
     }
 }
 
+#[cfg(test)]
+impl AlarmDatabase {
+    /// Creates an in-memory database with migrations applied.
+    ///
+    /// For coordinator-level tests in `alarm::mod` that need a real `AlarmDatabase` (not
+    /// just this module's own `pool`-backed unit tests) without a Tauri app data dir.
+    pub(crate) async fn new_in_memory() -> Result<Self> {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
+
+        for migration in migrations() {
+            sqlx::query(migration.sql).execute(&pool).await?;
+        }
+
+        Ok(Self { pool })
+    }
+}
+
 // Helper struct for deserializing SQL rows
 #[derive(sqlx::FromRow)]
 struct AlarmRow {

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -14,11 +14,37 @@ use events::*;
 pub use models::*;
 
 use database::AlarmDatabase;
+use std::collections::HashMap;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
+
+/// Minimum gap between two `dismiss_alarm` calls for the *same* alarm id before the
+/// second is treated as a genuinely new request rather than a duplicate delivery of the
+/// same underlying user action. Wide enough to absorb async plumbing latency between the
+/// direct TS-invoked command and the native `alarm-manager:dismiss-requested` round trip
+/// that Ringing.tsx's Dismiss button now *also* triggers for the same tap (issue #255
+/// Phase 4A/4C), while being far shorter than any realistic gap between two genuinely
+/// separate dismissals of the same repeating alarm (at minimum a day apart) or between a
+/// legitimate "dismiss upcoming" notification action -- which fires up to roughly ten
+/// minutes *before* the alarm rings, see `AlarmManagerService.dismissNextOccurrence` in
+/// the TS layer -- and the alarm's original due time.
+const DISMISS_DEBOUNCE_WINDOW_MS: i64 = 5_000;
 
 /// Central coordinator for all alarm operations
 pub struct AlarmCoordinator {
     db: AlarmDatabase,
+    /// Per-alarm-id `dismiss_alarm` bookkeeping: last-dismissed wall-clock time (epoch
+    /// ms), used to debounce duplicate near-simultaneous calls for the same underlying
+    /// dismiss action (see `DISMISS_DEBOUNCE_WINDOW_MS` and `dismiss_alarm`'s own doc
+    /// comment). The mutex is held across `dismiss_alarm`'s entire read-decide-write
+    /// critical section, not just this map, so it also serializes concurrent calls
+    /// against each other -- coarse-grained across every alarm id rather than per-id,
+    /// mirroring `ImportLock`'s precedent in `lib.rs`: dismiss isn't a hot path, so
+    /// serializing unrelated alarms' dismisses against each other is an acceptable trade
+    /// for a simple, race-free critical section. In-memory only, like `EventDedup`: this
+    /// covers same-process double-delivery, not crash-and-restart redelivery (see
+    /// `EventDedup`'s own doc comment for why that's a separate, deliberately unclosed
+    /// gap).
+    dismiss_debounce: tokio::sync::Mutex<HashMap<i32, i64>>,
 }
 
 impl AlarmCoordinator {
@@ -26,7 +52,10 @@ impl AlarmCoordinator {
     ///
     /// - `db`: backing alarm database for persistence and revisions.
     pub fn new(db: AlarmDatabase) -> Self {
-        Self { db }
+        Self {
+            db,
+            dismiss_debounce: tokio::sync::Mutex::new(HashMap::new()),
+        }
     }
 
     /// Get the phone's current revision number.
@@ -165,21 +194,44 @@ impl AlarmCoordinator {
     /// Idempotent: `dismiss_alarm` for the same underlying user action can legitimately
     /// arrive here twice in quick succession -- once via the direct TS `AlarmService.dismiss`
     /// command, and once via the native `alarm-manager:dismiss-requested` round trip (see
-    /// `lib.rs`), with no shared `event_id` to dedup on (issue #255 Phase 4C). Only the
-    /// first call may recompute `next_trigger`; see `dismiss_should_advance` for why.
+    /// `lib.rs`), with no shared `event_id` to dedup on (issue #255 Phase 4C). A second
+    /// call for the same alarm within `DISMISS_DEBOUNCE_WINDOW_MS` is treated as a replay
+    /// of the first rather than a new request; see the constant's own doc comment for why
+    /// this is time-based rather than derived from `next_trigger`.
     ///
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
     pub async fn dismiss_alarm<R: Runtime>(&self, app: &AppHandle<R>, id: i32) -> Result<()> {
-        let alarm = self.db.get_by_id(id).await?;
         let now = chrono::Utc::now().timestamp_millis();
 
-        if !dismiss_should_advance(alarm.next_trigger, now) {
-            // Idempotent replay: an earlier dismiss_alarm call already advanced
-            // next_trigger past the occurrence being dismissed (it's in the future).
-            // Recomputing again here would use that *already advanced* value as the new
-            // reference and silently skip a whole scheduled occurrence for a repeating
-            // alarm -- so this call does nothing to the DB and doesn't bump the revision.
+        // Held for this whole method, not just the map lookup below: dismiss_alarm reads
+        // the alarm, decides whether to advance it, then writes -- without a lock spanning
+        // that whole sequence, two genuinely concurrent calls for the same id could both
+        // read pre-dismiss state and both pass the duplicate check before either commits,
+        // reproducing the double-advance bug this exists to prevent. Coarse-grained across
+        // every alarm id rather than per-id -- see the field's own doc comment for why
+        // that's an acceptable simplification here.
+        let mut debounce = self.dismiss_debounce.lock().await;
+
+        let alarm = self.db.get_by_id(id).await?;
+
+        // Note on an earlier, reverted design: a heuristic based on "is next_trigger
+        // already in the future" was tried here instead of a time-based debounce. It
+        // can't distinguish a duplicate replay (an earlier call already advanced
+        // next_trigger past this occurrence) from a legitimate *new* dismiss of a
+        // still-upcoming occurrence -- which is exactly what the "dismiss upcoming
+        // alarm" notification action does: it fires up to roughly ten minutes *before*
+        // the alarm rings, while next_trigger is still in the future (see
+        // `AlarmManagerService.dismissNextOccurrence` in the TS layer). That heuristic
+        // silently no-opped legitimate early dismisses, leaving the alarm to ring
+        // anyway. Time elapsed since this alarm's *last dismissal*, not the shape of its
+        // schedule, is the signal that actually distinguishes "duplicate" from "new".
+        let is_duplicate = is_duplicate_dismiss(debounce.get(&id).copied(), now);
+
+        if is_duplicate {
+            // Deliberately does nothing to the DB or revision -- see
+            // `DISMISS_DEBOUNCE_WINDOW_MS`'s doc comment for why this call is being
+            // treated as a replay of the one that just ran.
             //
             // We still re-emit `alarm:dismissed` so every dismiss source gets the same
             // confirmation (mirrors `alarm:snoozed`'s toast design -- see CLAUDE.md's
@@ -201,6 +253,12 @@ impl AlarmCoordinator {
             app.emit("alarm:dismissed", &event)?;
             return Ok(());
         }
+
+        // Recorded before the rest of the (fallible) work below so a second call that
+        // arrives while this one is still in flight -- e.g. genuinely concurrent, not
+        // just close together -- sees it immediately once it acquires the lock above,
+        // rather than racing to insert its own entry first.
+        debounce.insert(id, now);
 
         let dismissed_at = now;
         let fired_at = dismissed_at; // Approximation if not tracking exact fire time
@@ -599,26 +657,18 @@ impl AlarmCoordinator {
     }
 }
 
-/// Whether `dismiss_alarm` should recompute and advance `next_trigger`, given the
-/// alarm's currently stored value and the current time. Pulled out of `dismiss_alarm`
-/// as a pure function (matching `classify_scheduling_transition` below) so the
-/// idempotency rule is directly unit-testable without a database or `AppHandle`.
+/// Whether a `dismiss_alarm` call for an alarm at `now` should be treated as a duplicate
+/// of an already-processed dismiss, given that alarm's last-recorded dismiss time (if
+/// any). Pulled out of `dismiss_alarm` as a pure function (matching
+/// `classify_scheduling_transition` below) so the debounce rule is directly
+/// unit-testable without a database, lock, or `AppHandle`.
 ///
-/// Recompute only when the stored trigger is due/overdue (`<= now`) or unset -- that's
-/// the case where the alarm genuinely just fired (or was never scheduled) and hasn't
-/// been advanced past this occurrence yet. If it's already in the future, an earlier
-/// `dismiss_alarm` call for this same alarm already advanced it, and recomputing again
-/// from that already-advanced value would skip a whole scheduled occurrence.
-///
-/// Note this can't distinguish "just fired, never dismissed" from "already dismissed
-/// down to no remaining occurrences" when both leave `next_trigger` at `None` -- e.g. a
-/// non-repeating alarm (no active days) that has already been dismissed once. That's
-/// fine: recomputing again in that case reproduces the same `None` output regardless of
-/// how many times it runs, so it stays safe (if not a strict no-op) for that case. See
-/// `dismiss_alarm`'s own doc comment and its tests for the repeating-alarm case this
-/// guards against.
-fn dismiss_should_advance(next_trigger: Option<i64>, now: i64) -> bool {
-    next_trigger.is_none_or(|t| t <= now)
+/// Deliberately time-based rather than derived from `next_trigger`: see
+/// `DISMISS_DEBOUNCE_WINDOW_MS`'s doc comment (and `dismiss_alarm`'s) for why a
+/// next_trigger-shape heuristic can't distinguish a duplicate replay from a legitimate
+/// early dismiss of a still-upcoming occurrence.
+fn is_duplicate_dismiss(last_dismissed_at: Option<i64>, now: i64) -> bool {
+    last_dismissed_at.is_some_and(|last| now.saturating_sub(last) < DISMISS_DEBOUNCE_WINDOW_MS)
 }
 
 /// What, if anything, a mutation should do to an alarm's native schedule. Pulled out of
@@ -792,26 +842,35 @@ mod scheduling_transition_tests {
 mod dismiss_idempotency_tests {
     use super::*;
 
-    // -- Pure `dismiss_should_advance` coverage -----------------------------------------
+    // -- Pure `is_duplicate_dismiss` coverage -------------------------------------------
 
     #[test]
-    fn advances_when_the_stored_trigger_is_overdue() {
-        assert!(dismiss_should_advance(Some(1_000), 2_000));
+    fn not_a_duplicate_when_never_dismissed_before() {
+        assert!(!is_duplicate_dismiss(None, 10_000));
     }
 
     #[test]
-    fn advances_when_the_stored_trigger_is_exactly_now() {
-        assert!(dismiss_should_advance(Some(2_000), 2_000));
+    fn is_a_duplicate_within_the_debounce_window() {
+        assert!(is_duplicate_dismiss(
+            Some(10_000),
+            10_000 + DISMISS_DEBOUNCE_WINDOW_MS - 1
+        ));
     }
 
     #[test]
-    fn advances_when_there_is_no_stored_trigger() {
-        assert!(dismiss_should_advance(None, 2_000));
+    fn is_not_a_duplicate_at_exactly_the_window_boundary() {
+        assert!(!is_duplicate_dismiss(
+            Some(10_000),
+            10_000 + DISMISS_DEBOUNCE_WINDOW_MS
+        ));
     }
 
     #[test]
-    fn does_not_advance_when_the_stored_trigger_is_already_in_the_future() {
-        assert!(!dismiss_should_advance(Some(3_000), 2_000));
+    fn is_not_a_duplicate_well_outside_the_window() {
+        assert!(!is_duplicate_dismiss(
+            Some(10_000),
+            10_000 + DISMISS_DEBOUNCE_WINDOW_MS + 60_000
+        ));
     }
 
     // -- Coordinator-level coverage ---------------------------------------------------
@@ -820,8 +879,9 @@ mod dismiss_idempotency_tests {
     // `AlarmDatabase` (see `AlarmDatabase::new_in_memory`, test-only) and a
     // `tauri::test::mock_app()` `AppHandle` (needed because `dismiss_alarm` emits
     // lifecycle events through it). Being inside `alarm::mod` itself, these tests can
-    // reach `coord.db` directly to set up fixtures no public API exposes (e.g. an alarm
-    // whose `next_trigger` is already overdue, simulating "just fired").
+    // reach `coord.db` and `coord.dismiss_debounce` directly to set up fixtures no
+    // public API exposes (e.g. an alarm whose `next_trigger` is already overdue, or a
+    // synthetic "last dismissed" timestamp from days ago, without actually sleeping).
 
     async fn test_coordinator() -> AlarmCoordinator {
         let db = database::AlarmDatabase::new_in_memory()
@@ -881,8 +941,53 @@ mod dismiss_idempotency_tests {
         assert!(after.revision > rev1);
     }
 
+    /// Regression coverage for the "dismiss upcoming alarm" notification action
+    /// (`AlarmManagerService.dismissNextOccurrence` -> `AlarmService.dismiss`), which
+    /// fires up to roughly ten minutes *before* the alarm rings -- while `next_trigger`
+    /// is still in the future. An earlier, reverted version of this fix treated "trigger
+    /// already in the future" as proof of an already-processed duplicate, which silently
+    /// no-opped this legitimate early dismiss and let the alarm ring anyway. It must
+    /// still advance past the dismissed occurrence like any other dismiss.
     #[tokio::test]
-    async fn double_dismiss_on_a_repeating_alarm_does_not_skip_an_occurrence() {
+    async fn dismissing_an_upcoming_alarm_before_it_rings_still_skips_the_occurrence() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let upcoming_trigger = now + 10 * 60 * 1_000; // rings in 10 minutes -- not due yet
+
+        let input = repeating_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input.clone(), Some(upcoming_trigger), rev1)
+            .await
+            .unwrap();
+
+        let expected_next = scheduler::calculate_next_trigger_after(
+            &AlarmInput {
+                id: Some(alarm.id),
+                ..input
+            },
+            upcoming_trigger + 1_000,
+        )
+        .unwrap();
+
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+
+        let after = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert_eq!(after.next_trigger, expected_next);
+        assert_ne!(
+            after.next_trigger,
+            Some(upcoming_trigger),
+            "the dismissed (still-upcoming) occurrence must not remain scheduled"
+        );
+        assert!(after.revision > rev1);
+    }
+
+    #[tokio::test]
+    async fn near_simultaneous_duplicate_dismiss_calls_do_not_double_advance() {
         let coord = test_coordinator().await;
         let app = tauri::test::mock_app();
         let handle = app.handle();
@@ -898,8 +1003,8 @@ mod dismiss_idempotency_tests {
             .await
             .unwrap();
 
-        // First dismiss: the stored trigger is overdue, so this recomputes and advances
-        // it to the next occurrence -- exactly like a normal dismiss.
+        // First dismiss: nothing recorded yet for this id, so this processes normally
+        // and advances to the next occurrence -- exactly like a normal dismiss.
         coord.dismiss_alarm(handle, alarm.id).await.unwrap();
         let after_first = coord.db.get_by_id(alarm.id).await.unwrap();
         assert!(after_first.next_trigger.unwrap() > now);
@@ -919,15 +1024,95 @@ mod dismiss_idempotency_tests {
             "test fixture sanity check: the skipped-ahead value must differ from the correct one"
         );
 
-        // Second (duplicate) dismiss for the *same* underlying action -- the alarm's
-        // stored trigger is now in the future, so this must be a no-op replay: no further
-        // advance, no redundant revision bump.
+        // Second (duplicate) dismiss for the *same* underlying action, arriving well
+        // within the debounce window (this test runs in a few microseconds) -- must be a
+        // no-op replay: no further advance, no redundant revision bump.
         coord.dismiss_alarm(handle, alarm.id).await.unwrap();
         let after_second = coord.db.get_by_id(alarm.id).await.unwrap();
 
         assert_eq!(after_second.next_trigger, after_first.next_trigger);
         assert_ne!(after_second.next_trigger, would_be_skipped);
         assert_eq!(after_second.revision, after_first.revision);
+    }
+
+    /// Proves the lock (not just the debounce timestamp) actually closes the race: two
+    /// genuinely concurrent calls -- polled together via `tokio::join!`, so their
+    /// `.await` points interleave rather than running strictly one-after-the-other --
+    /// must still result in exactly one advance, with the second seeing the first's
+    /// freshly-recorded debounce entry once it acquires the lock rather than racing it
+    /// to read pre-dismiss state.
+    #[tokio::test]
+    async fn concurrent_dismiss_calls_for_the_same_alarm_do_not_double_advance() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000;
+
+        let input = repeating_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input, Some(past_trigger), rev1)
+            .await
+            .unwrap();
+
+        let (first, second) = tokio::join!(
+            coord.dismiss_alarm(handle, alarm.id),
+            coord.dismiss_alarm(handle, alarm.id),
+        );
+        first.unwrap();
+        second.unwrap();
+
+        let after = coord.db.get_by_id(alarm.id).await.unwrap();
+        // Exactly one of the two calls actually wrote to the DB -- the revision moved
+        // forward by one step, not two.
+        assert_eq!(after.revision, rev1 + 1);
+        assert!(after.next_trigger.unwrap() > now);
+    }
+
+    #[tokio::test]
+    async fn dismissals_of_the_same_alarm_outside_the_debounce_window_are_not_deduped() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000; // fired again, e.g. a week after a prior dismiss
+
+        let input = repeating_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input.clone(), Some(past_trigger), rev1)
+            .await
+            .unwrap();
+
+        // Simulate a genuinely separate, much earlier dismissal of this same alarm --
+        // well outside the debounce window -- without actually sleeping in the test.
+        {
+            let mut debounce = coord.dismiss_debounce.lock().await;
+            debounce.insert(alarm.id, now - DISMISS_DEBOUNCE_WINDOW_MS - 60_000);
+        }
+
+        let expected_next = scheduler::calculate_next_trigger_after(
+            &AlarmInput {
+                id: Some(alarm.id),
+                ..input
+            },
+            past_trigger + 1_000,
+        )
+        .unwrap();
+
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+
+        let after = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert_eq!(
+            after.next_trigger, expected_next,
+            "a dismissal outside the debounce window must process normally, not be treated as a duplicate"
+        );
+        assert!(after.revision > rev1);
     }
 
     #[tokio::test]
@@ -955,7 +1140,8 @@ mod dismiss_idempotency_tests {
         assert_eq!(after_first.next_trigger, None);
         assert!(after_first.enabled);
 
-        // Double-dismiss must not error, re-enable the alarm, or fabricate a schedule.
+        // Double-dismiss (well within the debounce window) must not error, re-enable
+        // the alarm, or fabricate a schedule.
         let result = coord.dismiss_alarm(handle, alarm.id).await;
         assert!(result.is_ok());
 

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -15,6 +15,8 @@ pub use models::*;
 
 use database::AlarmDatabase;
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 /// Minimum gap between two `dismiss_alarm` calls for the *same* alarm id before the
@@ -27,24 +29,40 @@ use tauri::{AppHandle, Emitter, Manager, Runtime};
 /// legitimate "dismiss upcoming" notification action -- which fires up to roughly ten
 /// minutes *before* the alarm rings, see `AlarmManagerService.dismissNextOccurrence` in
 /// the TS layer -- and the alarm's original due time.
-const DISMISS_DEBOUNCE_WINDOW_MS: i64 = 5_000;
+///
+/// A time-window debounce checked against a monotonic clock is a deliberate,
+/// short-term tradeoff, not the final design: the more correct fix is a shared
+/// `event_id` threaded through *every* dismiss delivery path (today only the native
+/// listeners in `lib.rs` carry one, reused via `EventDedup` for exact-match rather than
+/// time-window dedup) -- but that requires changes to `Ringing.tsx` and
+/// `AlarmManagerPlugin.kt`, already implemented in PR #301 before this gap was found, so
+/// reopening that PR's scope wasn't worth it here. Tracked as a follow-up: issue #304.
+const DISMISS_DEBOUNCE_WINDOW: Duration = Duration::from_millis(5_000);
 
 /// Central coordinator for all alarm operations
 pub struct AlarmCoordinator {
     db: AlarmDatabase,
-    /// Per-alarm-id `dismiss_alarm` bookkeeping: last-dismissed wall-clock time (epoch
-    /// ms), used to debounce duplicate near-simultaneous calls for the same underlying
-    /// dismiss action (see `DISMISS_DEBOUNCE_WINDOW_MS` and `dismiss_alarm`'s own doc
-    /// comment). The mutex is held across `dismiss_alarm`'s entire read-decide-write
-    /// critical section, not just this map, so it also serializes concurrent calls
-    /// against each other -- coarse-grained across every alarm id rather than per-id,
-    /// mirroring `ImportLock`'s precedent in `lib.rs`: dismiss isn't a hot path, so
-    /// serializing unrelated alarms' dismisses against each other is an acceptable trade
-    /// for a simple, race-free critical section. In-memory only, like `EventDedup`: this
-    /// covers same-process double-delivery, not crash-and-restart redelivery (see
-    /// `EventDedup`'s own doc comment for why that's a separate, deliberately unclosed
-    /// gap).
-    dismiss_debounce: tokio::sync::Mutex<HashMap<i32, i64>>,
+    /// Per-alarm-id locks used by `dismiss_alarm` to serialize concurrent calls for the
+    /// *same* alarm and to hold that alarm's last-successful-dismiss time (`None` if
+    /// never dismissed this process), used to debounce duplicate near-simultaneous calls
+    /// for the same underlying dismiss action (see `DISMISS_DEBOUNCE_WINDOW` and
+    /// `dismiss_alarm`'s own doc comment).
+    ///
+    /// The outer `std::sync::Mutex` only ever guards a quick, synchronous
+    /// get-or-create-and-sweep on this map (see `dismiss_lock_for`) -- it's never held
+    /// across an `.await`. The real critical section is the *inner* per-id
+    /// `tokio::sync::Mutex`, held for that alarm's entire `dismiss_alarm` call, so
+    /// unrelated alarms' dismisses never block each other (unlike a single lock guarding
+    /// every id) and a concurrent call for the *same* id can't slip past the duplicate
+    /// check before the first one resolves.
+    ///
+    /// In-memory only, like `EventDedup`: this covers same-process double-delivery, not
+    /// crash-and-restart redelivery (see `EventDedup`'s own doc comment for why that's a
+    /// separate, deliberately unclosed gap). Bounded in size the same way: idle entries
+    /// (not currently locked) whose last dismiss has aged out of the debounce window are
+    /// opportunistically swept on every `dismiss_lock_for` call, so this doesn't grow
+    /// forever the way a plain "every id ever dismissed" map would.
+    dismiss_locks: std::sync::Mutex<HashMap<i32, Arc<tokio::sync::Mutex<Option<Instant>>>>>,
 }
 
 impl AlarmCoordinator {
@@ -54,8 +72,43 @@ impl AlarmCoordinator {
     pub fn new(db: AlarmDatabase) -> Self {
         Self {
             db,
-            dismiss_debounce: tokio::sync::Mutex::new(HashMap::new()),
+            dismiss_locks: std::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Gets (creating if needed) the per-alarm-id lock `dismiss_alarm` uses to serialize
+    /// calls for `id` and hold its last-dismissed marker.
+    ///
+    /// While already holding the outer map lock, opportunistically evicts *other* idle
+    /// and expired entries -- `try_lock` fails immediately rather than blocking if an
+    /// entry is currently held by an in-flight `dismiss_alarm` call elsewhere, so a busy
+    /// entry is never evicted out from under it. `id`'s own entry is never evicted here.
+    fn dismiss_lock_for(&self, id: i32) -> Arc<tokio::sync::Mutex<Option<Instant>>> {
+        let mut locks = self
+            .dismiss_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let now = Instant::now();
+        locks.retain(|&other_id, lock| {
+            if other_id == id {
+                return true;
+            }
+            match lock.try_lock() {
+                // Busy elsewhere -- never evict.
+                Err(_) => true,
+                // Idle: keep only if it has a recent-enough marker; a stale or never-set
+                // marker means nothing is relying on this exact lock object anymore.
+                Ok(last_dismissed_at) => last_dismissed_at.is_some_and(|last| {
+                    now.saturating_duration_since(last) < DISMISS_DEBOUNCE_WINDOW
+                }),
+            }
+        });
+
+        locks
+            .entry(id)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
+            .clone()
     }
 
     /// Get the phone's current revision number.
@@ -145,19 +198,7 @@ impl AlarmCoordinator {
         enabled: bool,
     ) -> Result<AlarmRecord> {
         let alarm = self.db.get_by_id(id).await?;
-
-        let input = AlarmInput {
-            id: Some(alarm.id),
-            label: alarm.label,
-            enabled,
-            mode: alarm.mode.clone(),
-            fixed_time: alarm.fixed_time,
-            window_start: alarm.window_start,
-            window_end: alarm.window_end,
-            active_days: alarm.active_days,
-            sound_uri: alarm.sound_uri,
-            sound_title: alarm.sound_title,
-        };
+        let input = AlarmInput::from_record(&alarm, enabled);
 
         self.save_alarm(app, input).await
     }
@@ -195,24 +236,23 @@ impl AlarmCoordinator {
     /// arrive here twice in quick succession -- once via the direct TS `AlarmService.dismiss`
     /// command, and once via the native `alarm-manager:dismiss-requested` round trip (see
     /// `lib.rs`), with no shared `event_id` to dedup on (issue #255 Phase 4C). A second
-    /// call for the same alarm within `DISMISS_DEBOUNCE_WINDOW_MS` is treated as a replay
-    /// of the first rather than a new request; see the constant's own doc comment for why
+    /// call for the same alarm within `DISMISS_DEBOUNCE_WINDOW` is treated as a replay of
+    /// the first rather than a new request; see the constant's own doc comment for why
     /// this is time-based rather than derived from `next_trigger`.
     ///
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
     pub async fn dismiss_alarm<R: Runtime>(&self, app: &AppHandle<R>, id: i32) -> Result<()> {
-        let now = chrono::Utc::now().timestamp_millis();
+        // Held for this whole method: dismiss_alarm reads the alarm, decides whether to
+        // advance it, then writes -- without a lock spanning that whole sequence, two
+        // genuinely concurrent calls for the same id could both read pre-dismiss state
+        // and both pass the duplicate check before either commits, reproducing the
+        // double-advance bug this exists to prevent. Scoped to just this alarm's id (see
+        // `dismiss_lock_for`), so a dismiss of a *different* alarm never blocks on this.
+        let lock = self.dismiss_lock_for(id);
+        let mut last_dismissed_at = lock.lock().await;
 
-        // Held for this whole method, not just the map lookup below: dismiss_alarm reads
-        // the alarm, decides whether to advance it, then writes -- without a lock spanning
-        // that whole sequence, two genuinely concurrent calls for the same id could both
-        // read pre-dismiss state and both pass the duplicate check before either commits,
-        // reproducing the double-advance bug this exists to prevent. Coarse-grained across
-        // every alarm id rather than per-id -- see the field's own doc comment for why
-        // that's an acceptable simplification here.
-        let mut debounce = self.dismiss_debounce.lock().await;
-
+        let now = Instant::now();
         let alarm = self.db.get_by_id(id).await?;
 
         // Note on an earlier, reverted design: a heuristic based on "is next_trigger
@@ -226,11 +266,13 @@ impl AlarmCoordinator {
         // silently no-opped legitimate early dismisses, leaving the alarm to ring
         // anyway. Time elapsed since this alarm's *last dismissal*, not the shape of its
         // schedule, is the signal that actually distinguishes "duplicate" from "new".
-        let is_duplicate = is_duplicate_dismiss(debounce.get(&id).copied(), now);
+        let is_duplicate = is_duplicate_dismiss(*last_dismissed_at, now);
+
+        let wall_clock_now = chrono::Utc::now().timestamp_millis();
 
         if is_duplicate {
-            // Deliberately does nothing to the DB or revision -- see
-            // `DISMISS_DEBOUNCE_WINDOW_MS`'s doc comment for why this call is being
+            // Deliberately does nothing to the DB, the revision, or `last_dismissed_at`
+            // -- see `DISMISS_DEBOUNCE_WINDOW`'s doc comment for why this call is being
             // treated as a replay of the one that just ran.
             //
             // We still re-emit `alarm:dismissed` so every dismiss source gets the same
@@ -245,8 +287,8 @@ impl AlarmCoordinator {
             // alarm-manager's `alarm:scheduled` listener needlessly re-arm the OS alarm.
             let event = AlarmDismissed {
                 id,
-                fired_at: now,
-                dismissed_at: now,
+                fired_at: wall_clock_now,
+                dismissed_at: wall_clock_now,
                 next_trigger: alarm.next_trigger,
                 revision: alarm.revision,
             };
@@ -254,32 +296,15 @@ impl AlarmCoordinator {
             return Ok(());
         }
 
-        // Recorded before the rest of the (fallible) work below so a second call that
-        // arrives while this one is still in flight -- e.g. genuinely concurrent, not
-        // just close together -- sees it immediately once it acquires the lock above,
-        // rather than racing to insert its own entry first.
-        debounce.insert(id, now);
-
-        let dismissed_at = now;
+        let dismissed_at = wall_clock_now;
         let fired_at = dismissed_at; // Approximation if not tracking exact fire time
 
         // Recalculate next occurrence after the current scheduled trigger so
         // dismissing an upcoming alarm skips this occurrence.
-        let input = AlarmInput {
-            id: Some(alarm.id),
-            label: alarm.label.clone(),
-            enabled: alarm.enabled,
-            mode: alarm.mode.clone(),
-            fixed_time: alarm.fixed_time.clone(),
-            window_start: alarm.window_start.clone(),
-            window_end: alarm.window_end.clone(),
-            active_days: alarm.active_days.clone(),
-            sound_uri: alarm.sound_uri.clone(),
-            sound_title: alarm.sound_title.clone(),
-        };
+        let input = AlarmInput::from_record(&alarm, alarm.enabled);
 
         let next_trigger = if input.enabled {
-            let reference_ms = alarm.next_trigger.unwrap_or(now) + 1_000;
+            let reference_ms = alarm.next_trigger.unwrap_or(wall_clock_now) + 1_000;
             scheduler::calculate_next_trigger_after(&input, reference_ms)?
         } else {
             None
@@ -307,6 +332,14 @@ impl AlarmCoordinator {
             revision: new_alarm.revision,
         };
         app.emit("alarm:dismissed", &event)?;
+
+        // Marked only now, right before returning success -- everything above this
+        // point is fallible (`?`-propagated) and returns early on error without ever
+        // reaching this line. That's deliberate: a failed attempt must not poison the
+        // debounce window, or a legitimate retry within it would see a stale-but-present
+        // marker, get silently treated as a duplicate, and return `Ok(())` without ever
+        // actually dismissing anything.
+        *last_dismissed_at = Some(now);
 
         Ok(())
     }
@@ -664,11 +697,21 @@ impl AlarmCoordinator {
 /// unit-testable without a database, lock, or `AppHandle`.
 ///
 /// Deliberately time-based rather than derived from `next_trigger`: see
-/// `DISMISS_DEBOUNCE_WINDOW_MS`'s doc comment (and `dismiss_alarm`'s) for why a
+/// `DISMISS_DEBOUNCE_WINDOW`'s doc comment (and `dismiss_alarm`'s) for why a
 /// next_trigger-shape heuristic can't distinguish a duplicate replay from a legitimate
 /// early dismiss of a still-upcoming occurrence.
-fn is_duplicate_dismiss(last_dismissed_at: Option<i64>, now: i64) -> bool {
-    last_dismissed_at.is_some_and(|last| now.saturating_sub(last) < DISMISS_DEBOUNCE_WINDOW_MS)
+///
+/// Deliberately built on `Instant` (a monotonic clock), not `chrono::Utc::now()`: this
+/// debounce is purely an internal, in-memory, same-process mechanism with no need to
+/// relate to wall-clock time at all, so a monotonic clock sidesteps backward-jump bugs
+/// (NTP corrections, manual clock changes) entirely rather than special-casing them --
+/// `now.saturating_sub(last)` on wall-clock millis would otherwise go negative and look
+/// like a duplicate on *every* call until wall-clock time caught back up.
+/// `Instant::saturating_duration_since` degrades safely even in the (for a monotonic
+/// clock, essentially theoretical) case where `last` is somehow after `now`.
+fn is_duplicate_dismiss(last_dismissed_at: Option<Instant>, now: Instant) -> bool {
+    last_dismissed_at
+        .is_some_and(|last| now.saturating_duration_since(last) < DISMISS_DEBOUNCE_WINDOW)
 }
 
 /// What, if anything, a mutation should do to an alarm's native schedule. Pulled out of
@@ -846,31 +889,42 @@ mod dismiss_idempotency_tests {
 
     #[test]
     fn not_a_duplicate_when_never_dismissed_before() {
-        assert!(!is_duplicate_dismiss(None, 10_000));
+        assert!(!is_duplicate_dismiss(None, Instant::now()));
     }
 
     #[test]
     fn is_a_duplicate_within_the_debounce_window() {
-        assert!(is_duplicate_dismiss(
-            Some(10_000),
-            10_000 + DISMISS_DEBOUNCE_WINDOW_MS - 1
-        ));
+        let last = Instant::now();
+        let now = last + DISMISS_DEBOUNCE_WINDOW - Duration::from_millis(1);
+        assert!(is_duplicate_dismiss(Some(last), now));
     }
 
     #[test]
     fn is_not_a_duplicate_at_exactly_the_window_boundary() {
-        assert!(!is_duplicate_dismiss(
-            Some(10_000),
-            10_000 + DISMISS_DEBOUNCE_WINDOW_MS
-        ));
+        let last = Instant::now();
+        let now = last + DISMISS_DEBOUNCE_WINDOW;
+        assert!(!is_duplicate_dismiss(Some(last), now));
     }
 
     #[test]
     fn is_not_a_duplicate_well_outside_the_window() {
-        assert!(!is_duplicate_dismiss(
-            Some(10_000),
-            10_000 + DISMISS_DEBOUNCE_WINDOW_MS + 60_000
-        ));
+        let last = Instant::now();
+        let now = last + DISMISS_DEBOUNCE_WINDOW + Duration::from_secs(60);
+        assert!(!is_duplicate_dismiss(Some(last), now));
+    }
+
+    /// A backward *wall-clock* jump (NTP correction, manual clock change) can't affect
+    /// this debounce at all now that it's built on `Instant` -- there's no dedicated
+    /// regression test for that scenario because it's structurally moot, not because
+    /// it's unhandled. This test instead covers the one related edge `Instant` doesn't
+    /// rule out by construction: `saturating_duration_since` degrading safely if
+    /// `last_dismissed_at` is somehow after `now` (which "monotonic" makes practically
+    /// unreachable, but the function still shouldn't panic or misbehave if it happened).
+    #[test]
+    fn does_not_panic_if_the_recorded_instant_is_somehow_after_now() {
+        let now = Instant::now();
+        let later = now + Duration::from_secs(1);
+        assert!(is_duplicate_dismiss(Some(later), now));
     }
 
     // -- Coordinator-level coverage ---------------------------------------------------
@@ -879,9 +933,9 @@ mod dismiss_idempotency_tests {
     // `AlarmDatabase` (see `AlarmDatabase::new_in_memory`, test-only) and a
     // `tauri::test::mock_app()` `AppHandle` (needed because `dismiss_alarm` emits
     // lifecycle events through it). Being inside `alarm::mod` itself, these tests can
-    // reach `coord.db` and `coord.dismiss_debounce` directly to set up fixtures no
+    // reach `coord.db` and `coord.dismiss_lock_for` directly to set up fixtures no
     // public API exposes (e.g. an alarm whose `next_trigger` is already overdue, or a
-    // synthetic "last dismissed" timestamp from days ago, without actually sleeping).
+    // synthetic "last dismissed" instant from days ago, without actually sleeping).
 
     async fn test_coordinator() -> AlarmCoordinator {
         let db = database::AlarmDatabase::new_in_memory()
@@ -1092,8 +1146,10 @@ mod dismiss_idempotency_tests {
         // Simulate a genuinely separate, much earlier dismissal of this same alarm --
         // well outside the debounce window -- without actually sleeping in the test.
         {
-            let mut debounce = coord.dismiss_debounce.lock().await;
-            debounce.insert(alarm.id, now - DISMISS_DEBOUNCE_WINDOW_MS - 60_000);
+            let lock = coord.dismiss_lock_for(alarm.id);
+            let mut last_dismissed_at = lock.lock().await;
+            *last_dismissed_at =
+                Some(Instant::now() - DISMISS_DEBOUNCE_WINDOW - Duration::from_secs(60));
         }
 
         let expected_next = scheduler::calculate_next_trigger_after(
@@ -1113,6 +1169,101 @@ mod dismiss_idempotency_tests {
             "a dismissal outside the debounce window must process normally, not be treated as a duplicate"
         );
         assert!(after.revision > rev1);
+    }
+
+    /// Regression coverage for the debounce marker being recorded before (rather than
+    /// after) the fallible work in an earlier version of this fix: if `dismiss_alarm`
+    /// fails partway through, a retry within what would be the debounce window must get
+    /// a fresh attempt, not be silently swallowed as a duplicate no-op that returns
+    /// `Ok(())` without ever actually dismissing anything.
+    #[tokio::test]
+    async fn a_failed_dismiss_does_not_poison_the_debounce_window_for_a_retry() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000;
+
+        // A zero-length window makes `calculate_next_trigger_after` fail every time --
+        // standing in for any transient failure partway through dismiss_alarm's fallible
+        // section (recompute, DB write, event emission, ...).
+        let input = AlarmInput {
+            mode: AlarmMode::Window,
+            fixed_time: None,
+            window_start: Some("07:00".into()),
+            window_end: Some("07:00".into()),
+            ..AlarmInput::default()
+        };
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input, Some(past_trigger), rev1)
+            .await
+            .unwrap();
+
+        let first = coord.dismiss_alarm(handle, alarm.id).await;
+        assert!(
+            first.is_err(),
+            "test fixture sanity check: a zero-length window must fail to compute"
+        );
+
+        // A retry, still well within what would be the debounce window (this test runs
+        // in microseconds), must get a fresh attempt and fail the same way -- not be
+        // silently treated as a duplicate replay of the failed first call.
+        let second = coord.dismiss_alarm(handle, alarm.id).await;
+        assert!(
+            second.is_err(),
+            "a retry after a failed dismiss must not be treated as a duplicate replay"
+        );
+
+        // Neither attempt silently wrote to the DB.
+        let after = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert_eq!(after.revision, rev1);
+    }
+
+    /// Direct coverage of `dismiss_lock_for`'s opportunistic sweep: an idle entry whose
+    /// last dismiss has aged out of the debounce window is evicted, but a recent one and
+    /// a currently-locked ("busy") one are both kept regardless.
+    #[tokio::test]
+    async fn dismiss_lock_for_evicts_idle_expired_entries_but_keeps_recent_and_busy_ones() {
+        let coord = test_coordinator().await;
+
+        let stale_id = 1;
+        {
+            let lock = coord.dismiss_lock_for(stale_id);
+            let mut last_dismissed_at = lock.lock().await;
+            *last_dismissed_at =
+                Some(Instant::now() - DISMISS_DEBOUNCE_WINDOW - Duration::from_secs(60));
+        }
+
+        let recent_id = 2;
+        {
+            let lock = coord.dismiss_lock_for(recent_id);
+            let mut last_dismissed_at = lock.lock().await;
+            *last_dismissed_at = Some(Instant::now());
+        }
+
+        let busy_id = 3;
+        let busy_lock = coord.dismiss_lock_for(busy_id);
+        let _busy_guard = busy_lock.lock().await; // held for the rest of this test
+
+        // Requesting a lock for an unrelated fourth id triggers the sweep.
+        let _ = coord.dismiss_lock_for(4);
+
+        let locks = coord.dismiss_locks.lock().unwrap();
+        assert!(
+            !locks.contains_key(&stale_id),
+            "an idle, expired entry must be evicted"
+        );
+        assert!(
+            locks.contains_key(&recent_id),
+            "an idle, still-within-window entry must be kept"
+        );
+        assert!(
+            locks.contains_key(&busy_id),
+            "a currently-locked entry must never be evicted"
+        );
     }
 
     #[tokio::test]

--- a/apps/threshold/src-tauri/src/alarm/mod.rs
+++ b/apps/threshold/src-tauri/src/alarm/mod.rs
@@ -162,24 +162,47 @@ impl AlarmCoordinator {
 
     /// Dismiss a ringing alarm and calculate the next occurrence.
     ///
+    /// Idempotent: `dismiss_alarm` for the same underlying user action can legitimately
+    /// arrive here twice in quick succession -- once via the direct TS `AlarmService.dismiss`
+    /// command, and once via the native `alarm-manager:dismiss-requested` round trip (see
+    /// `lib.rs`), with no shared `event_id` to dedup on (issue #255 Phase 4C). Only the
+    /// first call may recompute `next_trigger`; see `dismiss_should_advance` for why.
+    ///
     /// - `app`: app handle for event emission.
     /// - `id`: alarm identifier.
     pub async fn dismiss_alarm<R: Runtime>(&self, app: &AppHandle<R>, id: i32) -> Result<()> {
         let alarm = self.db.get_by_id(id).await?;
+        let now = chrono::Utc::now().timestamp_millis();
 
-        // Emit dismissed event
-        // Note: We need a revision for this event.
-        // Technically dismiss changes state (next_trigger), so save_alarm will generate a revision.
-        // But we want to emit 'dismissed' as a lifecycle event.
-        // However, save_alarm will emit 'updated' + 'scheduled'/'cancelled'.
+        if !dismiss_should_advance(alarm.next_trigger, now) {
+            // Idempotent replay: an earlier dismiss_alarm call already advanced
+            // next_trigger past the occurrence being dismissed (it's in the future).
+            // Recomputing again here would use that *already advanced* value as the new
+            // reference and silently skip a whole scheduled occurrence for a repeating
+            // alarm -- so this call does nothing to the DB and doesn't bump the revision.
+            //
+            // We still re-emit `alarm:dismissed` so every dismiss source gets the same
+            // confirmation (mirrors `alarm:snoozed`'s toast design -- see CLAUDE.md's
+            // note on why AlarmManagerService listens for it unconditionally). This is
+            // safe because every current `alarm:dismissed` consumer already tolerates a
+            // duplicate: Ringing.tsx guards `closeRingingWindow` behind `isClosingRef`,
+            // and wear-sync's mirror just re-sends an already-idempotent "stop ringing"
+            // message to the watch. Deliberately NOT re-running
+            // save/emit_alarm_updated/emit_scheduling_events/emit_batch_update here,
+            // though -- nothing changed in the DB, and doing so would make
+            // alarm-manager's `alarm:scheduled` listener needlessly re-arm the OS alarm.
+            let event = AlarmDismissed {
+                id,
+                fired_at: now,
+                dismissed_at: now,
+                next_trigger: alarm.next_trigger,
+                revision: alarm.revision,
+            };
+            app.emit("alarm:dismissed", &event)?;
+            return Ok(());
+        }
 
-        // Let's rely on save_alarm for the state change events.
-        // We can emit 'dismissed' here using the current revision or a new one?
-        // Ideally lifecycle events also have revisions.
-        // Let's grab the current revision for the dismissed event, as it relates to the *act* of dismissing.
-        // Or better, save_alarm will produce a new revision.
-
-        let dismissed_at = chrono::Utc::now().timestamp_millis();
+        let dismissed_at = now;
         let fired_at = dismissed_at; // Approximation if not tracking exact fire time
 
         // Recalculate next occurrence after the current scheduled trigger so
@@ -198,10 +221,7 @@ impl AlarmCoordinator {
         };
 
         let next_trigger = if input.enabled {
-            let reference_ms = alarm
-                .next_trigger
-                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis())
-                + 1_000;
+            let reference_ms = alarm.next_trigger.unwrap_or(now) + 1_000;
             scheduler::calculate_next_trigger_after(&input, reference_ms)?
         } else {
             None
@@ -579,6 +599,28 @@ impl AlarmCoordinator {
     }
 }
 
+/// Whether `dismiss_alarm` should recompute and advance `next_trigger`, given the
+/// alarm's currently stored value and the current time. Pulled out of `dismiss_alarm`
+/// as a pure function (matching `classify_scheduling_transition` below) so the
+/// idempotency rule is directly unit-testable without a database or `AppHandle`.
+///
+/// Recompute only when the stored trigger is due/overdue (`<= now`) or unset -- that's
+/// the case where the alarm genuinely just fired (or was never scheduled) and hasn't
+/// been advanced past this occurrence yet. If it's already in the future, an earlier
+/// `dismiss_alarm` call for this same alarm already advanced it, and recomputing again
+/// from that already-advanced value would skip a whole scheduled occurrence.
+///
+/// Note this can't distinguish "just fired, never dismissed" from "already dismissed
+/// down to no remaining occurrences" when both leave `next_trigger` at `None` -- e.g. a
+/// non-repeating alarm (no active days) that has already been dismissed once. That's
+/// fine: recomputing again in that case reproduces the same `None` output regardless of
+/// how many times it runs, so it stays safe (if not a strict no-op) for that case. See
+/// `dismiss_alarm`'s own doc comment and its tests for the repeating-alarm case this
+/// guards against.
+fn dismiss_should_advance(next_trigger: Option<i64>, now: i64) -> bool {
+    next_trigger.is_none_or(|t| t <= now)
+}
+
 /// What, if anything, a mutation should do to an alarm's native schedule. Pulled out of
 /// `emit_scheduling_events` as a pure function so it's testable without an `AppHandle`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -743,5 +785,182 @@ mod scheduling_transition_tests {
             classify_scheduling_transition(None, &current),
             SchedulingTransition::NoOp
         );
+    }
+}
+
+#[cfg(test)]
+mod dismiss_idempotency_tests {
+    use super::*;
+
+    // -- Pure `dismiss_should_advance` coverage -----------------------------------------
+
+    #[test]
+    fn advances_when_the_stored_trigger_is_overdue() {
+        assert!(dismiss_should_advance(Some(1_000), 2_000));
+    }
+
+    #[test]
+    fn advances_when_the_stored_trigger_is_exactly_now() {
+        assert!(dismiss_should_advance(Some(2_000), 2_000));
+    }
+
+    #[test]
+    fn advances_when_there_is_no_stored_trigger() {
+        assert!(dismiss_should_advance(None, 2_000));
+    }
+
+    #[test]
+    fn does_not_advance_when_the_stored_trigger_is_already_in_the_future() {
+        assert!(!dismiss_should_advance(Some(3_000), 2_000));
+    }
+
+    // -- Coordinator-level coverage ---------------------------------------------------
+    //
+    // These exercise the real `dismiss_alarm` async method against an in-memory
+    // `AlarmDatabase` (see `AlarmDatabase::new_in_memory`, test-only) and a
+    // `tauri::test::mock_app()` `AppHandle` (needed because `dismiss_alarm` emits
+    // lifecycle events through it). Being inside `alarm::mod` itself, these tests can
+    // reach `coord.db` directly to set up fixtures no public API exposes (e.g. an alarm
+    // whose `next_trigger` is already overdue, simulating "just fired").
+
+    async fn test_coordinator() -> AlarmCoordinator {
+        let db = database::AlarmDatabase::new_in_memory()
+            .await
+            .expect("failed to create in-memory alarm database");
+        AlarmCoordinator::new(db)
+    }
+
+    fn repeating_alarm_input() -> AlarmInput {
+        AlarmInput {
+            active_days: vec![0, 1, 2, 3, 4, 5, 6], // every day, so it never runs out
+            ..AlarmInput::default()
+        }
+    }
+
+    fn one_shot_alarm_input() -> AlarmInput {
+        AlarmInput {
+            active_days: vec![], // no active day ever matches -- exhausts after firing once
+            ..AlarmInput::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_normal_single_dismiss_advances_next_trigger_and_bumps_revision() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000; // alarm "just fired" a minute ago
+
+        let input = repeating_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input.clone(), Some(past_trigger), rev1)
+            .await
+            .unwrap();
+
+        let expected_next = scheduler::calculate_next_trigger_after(
+            &AlarmInput {
+                id: Some(alarm.id),
+                ..input
+            },
+            past_trigger + 1_000,
+        )
+        .unwrap();
+        assert!(
+            expected_next.is_some(),
+            "a daily alarm always has a next occurrence"
+        );
+
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+
+        let after = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert_eq!(after.next_trigger, expected_next);
+        assert!(after.revision > rev1);
+    }
+
+    #[tokio::test]
+    async fn double_dismiss_on_a_repeating_alarm_does_not_skip_an_occurrence() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000;
+
+        let input = repeating_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input.clone(), Some(past_trigger), rev1)
+            .await
+            .unwrap();
+
+        // First dismiss: the stored trigger is overdue, so this recomputes and advances
+        // it to the next occurrence -- exactly like a normal dismiss.
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+        let after_first = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert!(after_first.next_trigger.unwrap() > now);
+
+        // What a second, buggy recompute would produce if it (wrongly) chained off the
+        // already-advanced trigger from the first call -- i.e. skipped an occurrence.
+        let would_be_skipped = scheduler::calculate_next_trigger_after(
+            &AlarmInput {
+                id: Some(alarm.id),
+                ..input
+            },
+            after_first.next_trigger.unwrap() + 1_000,
+        )
+        .unwrap();
+        assert_ne!(
+            after_first.next_trigger, would_be_skipped,
+            "test fixture sanity check: the skipped-ahead value must differ from the correct one"
+        );
+
+        // Second (duplicate) dismiss for the *same* underlying action -- the alarm's
+        // stored trigger is now in the future, so this must be a no-op replay: no further
+        // advance, no redundant revision bump.
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+        let after_second = coord.db.get_by_id(alarm.id).await.unwrap();
+
+        assert_eq!(after_second.next_trigger, after_first.next_trigger);
+        assert_ne!(after_second.next_trigger, would_be_skipped);
+        assert_eq!(after_second.revision, after_first.revision);
+    }
+
+    #[tokio::test]
+    async fn double_dismiss_on_a_one_shot_alarm_is_safe() {
+        let coord = test_coordinator().await;
+        let app = tauri::test::mock_app();
+        let handle = app.handle();
+
+        let now = chrono::Utc::now().timestamp_millis();
+        let past_trigger = now - 60_000;
+
+        let input = one_shot_alarm_input();
+        let rev1 = coord.db.next_revision().await.unwrap();
+        let alarm = coord
+            .db
+            .save(input, Some(past_trigger), rev1)
+            .await
+            .unwrap();
+        assert!(alarm.enabled);
+
+        coord.dismiss_alarm(handle, alarm.id).await.unwrap();
+        let after_first = coord.db.get_by_id(alarm.id).await.unwrap();
+        // A non-repeating alarm has no next occurrence -- `dismiss_alarm` never flips
+        // `enabled` itself, so it stays true with a cleared trigger.
+        assert_eq!(after_first.next_trigger, None);
+        assert!(after_first.enabled);
+
+        // Double-dismiss must not error, re-enable the alarm, or fabricate a schedule.
+        let result = coord.dismiss_alarm(handle, alarm.id).await;
+        assert!(result.is_ok());
+
+        let after_second = coord.db.get_by_id(alarm.id).await.unwrap();
+        assert_eq!(after_second.next_trigger, None);
+        assert!(after_second.enabled);
     }
 }

--- a/apps/threshold/src-tauri/src/alarm/models.rs
+++ b/apps/threshold/src-tauri/src/alarm/models.rs
@@ -80,6 +80,28 @@ impl Default for AlarmInput {
     }
 }
 
+impl AlarmInput {
+    /// Builds an `AlarmInput` from an existing `AlarmRecord`, carrying every field over
+    /// unchanged except `enabled`. Shared by `AlarmCoordinator::toggle_alarm` (which
+    /// flips `enabled`) and `dismiss_alarm` (which keeps the record's own value) so a
+    /// future field addition only needs updating in one place instead of being copied
+    /// field-by-field at each call site and silently missed in one of them.
+    pub fn from_record(record: &AlarmRecord, enabled: bool) -> Self {
+        Self {
+            id: Some(record.id),
+            label: record.label.clone(),
+            enabled,
+            mode: record.mode.clone(),
+            fixed_time: record.fixed_time.clone(),
+            window_start: record.window_start.clone(),
+            window_end: record.window_end.clone(),
+            active_days: record.active_days.clone(),
+            sound_uri: record.sound_uri.clone(),
+            sound_title: record.sound_title.clone(),
+        }
+    }
+}
+
 /// Generates `apps/threshold/src/types/alarm.ts` from the types above and
 /// keeps it honest: this test fails if the committed file has drifted from
 /// a fresh generation, so `AlarmRecord`/`AlarmInput` can't silently diverge


### PR DESCRIPTION
## What this is

A follow-up fix, found and fixed during #301's implementation, not a pre-planned phase of #255. Making in-app dismiss publish onto the native bus uniformly (#301) means it now reaches `AlarmCoordinator::dismiss_alarm` twice for the same user action: once via the direct TS `AlarmService.dismiss` command, and once via the native `alarm-manager:dismiss-requested` round trip — with no shared `event_id` between the two paths to dedup on. `dismiss_alarm` was not idempotent: it recomputed `next_trigger` relative to whatever was currently stored, so the second call would silently advance a repeating alarm's next occurrence a second time, skipping a whole day.

## What's here

- A time-based debounce (5s), not a `next_trigger`-shape heuristic — an earlier attempt at this fix used "is `next_trigger` already in the future" as the duplicate signal, but that's indistinguishable from a legitimate case: the "dismiss upcoming alarm" notification action fires ~10 minutes *before* the alarm rings, while `next_trigger` is still in the future. That heuristic silently broke early dismiss. Time elapsed since the alarm's last successful dismissal is the signal that actually distinguishes "duplicate" from "new."
- Per-alarm-id locking (not one global lock) — unrelated alarms' dismisses never block each other; concurrent calls for the *same* alarm fully serialize.
- The debounce marker is only recorded after the operation succeeds, not before — so a transient failure doesn't poison the retry window and silently swallow a legitimate retry.
- Monotonic clock (`std::time::Instant`), not wall-clock, for the debounce comparison — immune to NTP/manual clock adjustments.
- Bounded map growth — idle, expired entries are opportunistically swept, mirroring `EventDedup`'s own capped design.
- Extracted `AlarmInput::from_record` (was duplicated between `dismiss_alarm` and `toggle_alarm`).

## Known, disclosed tradeoff

The time-window debounce is a stopgap for a real plumbing gap (no shared `event_id` across the TS-command and native-round-trip delivery paths). The more correct long-term fix — threading a shared `event_id` through both paths and reusing the existing, exact-match `EventDedup` mechanism — would require touching already-merged files in #301. Documented in code and filed as #304 rather than expanding this fix's scope.

## Testing checklist (automated, no device needed)

- [x] 68 threshold tests, including: normal dismiss unaffected; dismissing a still-upcoming alarm correctly skips the occurrence (the regression case); near-simultaneous duplicates via `tokio::join!` don't double-advance; a failed dismiss doesn't poison the retry window; one-shot double-dismiss stays safe
- [x] `cargo check --workspace` / `cargo test --workspace` clean, no regressions
- [x] `cargo clippy` / `cargo fmt --check` clean

## Review status

Reviewed via `/code-review high`, three rounds given the correctness sensitivity of this path. First pass caught the original `next_trigger`-shape heuristic's regression against early dismiss. Second pass caught: no rollback on failure, a wall-clock backward-jump bug, unnecessary cross-alarm serialization, and unbounded map growth. All fixed; final pass clean.

Stacked on #302. Part of #255 (a fix arising from its implementation, not a pre-planned phase).